### PR TITLE
01Oct2020 (SH)

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,8 +1,20 @@
+01Oct2020 (SH)
+Release R4.2.7
+
+  Reduce number of sensor records for LCLS ATCA shelf,
+  now that we have more experience with the systems
+  New files:
+	Db/fru_atca_fb_lcls.substitutions
+	Db/fru_atca_rtm_lcls.substitutions
+  Changes to:
+	Db/Makefile
+	Db/shelf_atca_7slot_lcls.substitutions
+
 13Jan2020 (SH)
 Release R4.2.6
 
   Db/system_common.db: For power on/off sequences, replace seq
-    records with series of linked records. Sometimes seq
+records with series of linked records. Sometimes seq
     records are found with PACT=TRUE and so record does not process.
     Cause of that is not understood. This is a workaround.
 

--- a/Db/Makefile
+++ b/Db/Makefile
@@ -38,8 +38,10 @@ DB += server_pc.db
 
 # Templates specific to LCLS
 DB += shelf_microtca_12slot_lcls.db
-DB += shelf_atca_7slot_lcls.db
 DB += server_pc_lcls.db
+DB += fru_atca_fb_lcls.db
+DB += fru_atca_rtm_lcls.db
+DB += shelf_atca_7slot_lcls.db
 
 #----------------------------------------------------
 # Create and install (or just install) into <top>/db

--- a/Db/fru_atca_fb_lcls.substitutions
+++ b/Db/fru_atca_fb_lcls.substitutions
@@ -1,0 +1,65 @@
+#==============================================================================
+# Abs:  ATCA Front Board (FB) FRU PV subset
+#
+# Name:  fru_atca_fb_lcls.substitutions
+#
+# Macros in:
+#	dev      Shelf name, for example CRAT:LI28:RF01
+#	prefix   String in PV name that identifies the FRU sensor is associated with (if there is one)
+#		 PV name syntax: $(dev):$(prefix)$(attr)$(sensinst)
+#		 For atca systems, prefix is "<frutype><instance>_", for example FB1_ for the first FB
+#		 or CU2_ for the second cooling unit
+#		 For supermicro, the sensors are not associated with a FRU, so prefix is an empty string
+#	aliasprefix Temporary string to keep PV names backward-compatible via alias
+#	id       String identifier, for example 'CU' for cooling unit
+#       unit     Instance of this type of module, for example 2 for the second MCH in a carrier
+#       attr	 Used in PV attribute, for example FAN1SPEED or TEMP2
+#       sensinst Instance of this type of sensor on this module
+#       type     Sensor type code, defined in IPMI spec (and src/ipmiDef.h)
+#       fruid    FRU ID according to MicroTCA spec
+#	dev      Shelf name, for example CRAT:LI28:RF01
+#	cod      String identifier, for example 'CU' for cooling unit
+#       inst     Instance of this type of module, for example 2 for the second MCH in a carrier
+#       attr	 Used in PV attribute, for example FAN1SPEED or TEMP2
+#       sensinst Instance of this type of sensor on this module
+#       type     Sensor type code, defined in IPMI spec (and src/ipmiDef.h)
+#       fruid    FRU ID according to MicroTCA spec
+#
+#==============================================================================
+#
+
+file fru_common.db
+{
+   pattern { dev	, id		, unit		, fruid		}
+           { $(dev)	, $(id)		, $(unit)  	, $(fruid)	}
+}
+
+file sensor_ai.db
+{
+   pattern { dev	, prefix	, aliasprefix	,  attr		, sensinst	, type	, fruid }
+           { $(dev)	, $(id)$(unit):	, $(id)$(unit)_	,  TEMP		, 1		, 1	, $(fruid)	}
+           { $(dev)	, $(id)$(unit):	, $(id)$(unit)_	,  TEMP		, 2		, 1	, $(fruid)	}
+           { $(dev)	, $(id)$(unit):	, $(id)$(unit)_	,  TEMP		, 3		, 1	, $(fruid)	}
+           { $(dev)	, $(id)$(unit):	, $(id)$(unit)_	,  TEMP		, 4		, 1	, $(fruid)	}
+           { $(dev)	, $(id)$(unit):	, $(id)$(unit)_	,  TEMP		, 5		, 1	, $(fruid)	}
+           { $(dev)	, $(id)$(unit):	, $(id)$(unit)_	,  TEMP		, 6		, 1	, $(fruid)	}
+           { $(dev)	, $(id)$(unit):	, $(id)$(unit)_	,  TEMP		, 7		, 1	, $(fruid)	}
+           { $(dev)	, $(id)$(unit):	, $(id)$(unit)_	,  TEMP		, 8		, 1	, $(fruid)	}
+           { $(dev)	, $(id)$(unit):	, $(id)$(unit)_	,  TEMP		, 9		, 1	, $(fruid)	}
+           { $(dev)	, $(id)$(unit):	, $(id)$(unit)_	,  TEMP		, 10	, 1	, $(fruid)	}
+           { $(dev)	, $(id)$(unit):	, $(id)$(unit)_	,  V		, 1		, 2	, $(fruid)	}
+           { $(dev)	, $(id)$(unit):	, $(id)$(unit)_	,  V		, 2		, 2	, $(fruid)	}
+           { $(dev)	, $(id)$(unit):	, $(id)$(unit)_	,  V		, 3		, 2	, $(fruid)	}
+           { $(dev)	, $(id)$(unit):	, $(id)$(unit)_	,  V		, 4		, 2	, $(fruid)	}
+           { $(dev)	, $(id)$(unit):	, $(id)$(unit)_	,  V		, 5		, 2	, $(fruid)	}
+           { $(dev)	, $(id)$(unit):	, $(id)$(unit)_	,  V		, 6		, 2	, $(fruid)	}
+           { $(dev)	, $(id)$(unit):	, $(id)$(unit)_	,  V		, 7		, 2	, $(fruid)	}
+           { $(dev)	, $(id)$(unit):	, $(id)$(unit)_	,  V		, 8		, 2	, $(fruid)	}
+           { $(dev)	, $(id)$(unit):	, $(id)$(unit)_	,  V		, 9		, 2	, $(fruid)	}
+           { $(dev)	, $(id)$(unit):	, $(id)$(unit)_	,  V		, 10	, 2	, $(fruid)	}
+           { $(dev)	, $(id)$(unit):	, $(id)$(unit)_	,  I		, 1		, 3	, $(fruid)	}
+           { $(dev)	, $(id)$(unit):	, $(id)$(unit)_	,  I		, 2		, 3	, $(fruid)	}
+           { $(dev)	, $(id)$(unit):	, $(id)$(unit)_	,  I		, 3		, 3	, $(fruid)	}
+           { $(dev)	, $(id)$(unit):	, $(id)$(unit)_	,  I		, 4		, 3	, $(fruid)	}
+           { $(dev)	, $(id)$(unit):	, $(id)$(unit)_	,  I		, 5		, 3	, $(fruid)	}
+}	   		  			

--- a/Db/fru_atca_rtm_lcls.substitutions
+++ b/Db/fru_atca_rtm_lcls.substitutions
@@ -1,0 +1,46 @@
+#==============================================================================
+# Abs:  ATCA RTM FRU PV subset
+#
+# Name:  fru_atca_rtm_lcls.substitutions
+#
+# Macros in:
+#	dev      Shelf name, for example CRAT:LI28:RF01
+#	prefix   String in PV name that identifies the FRU sensor is associated with (if there is one)
+#		 PV name syntax: $(dev):$(prefix)$(attr)$(sensinst)
+#		 For atca systems, prefix is "<frutype><instance>_", for example FB1_ for the first FB
+#		 or CU2_ for the second cooling unit
+#		 For supermicro, the sensors are not associated with a FRU, so prefix is an empty string
+#	aliasprefix Temporary string to keep PV names backward-compatible via alias
+#	id       String identifier, for example 'CU' for cooling unit
+#       unit     Instance of this type of module, for example 2 for the second MCH in a carrier
+#       attr	 Used in PV attribute, for example FAN1SPEED or TEMP2
+#       sensinst Instance of this type of sensor on this module
+#       type     Sensor type code, defined in IPMI spec (and src/ipmiDef.h)
+#       fruid    FRU ID according to MicroTCA spec
+#	dev      Shelf name, for example CRAT:LI28:RF01
+#	cod      String identifier, for example 'CU' for cooling unit
+#       inst     Instance of this type of module, for example 2 for the second MCH in a carrier
+#       attr	 Used in PV attribute, for example FAN1SPEED or TEMP2
+#       sensinst Instance of this type of sensor on this module
+#       type     Sensor type code, defined in IPMI spec (and src/ipmiDef.h)
+#       fruid    FRU ID according to MicroTCA spec
+#
+#==============================================================================
+#
+
+file fru_common.db
+{
+   pattern { dev	, id		, unit		, fruid		}
+           { $(dev)	, $(id)		, $(unit)  	, $(fruid)	}
+}
+
+file sensor_ai.db
+{
+   pattern { dev	, prefix	, aliasprefix	,  attr		, sensinst	, type	, fruid }
+           { $(dev)	, $(id)$(unit):	, $(id)$(unit)_	,  TEMP		, 1		, 1	, $(fruid)	}
+           { $(dev)	, $(id)$(unit):	, $(id)$(unit)_	,  TEMP		, 2		, 1	, $(fruid)	}
+           { $(dev)	, $(id)$(unit):	, $(id)$(unit)_	,  V		, 1		, 2	, $(fruid)	}
+           { $(dev)	, $(id)$(unit):	, $(id)$(unit)_	,  V		, 2		, 2	, $(fruid)	}
+           { $(dev)	, $(id)$(unit):	, $(id)$(unit)_	,  I		, 1		, 3	, $(fruid)	}
+           { $(dev)	, $(id)$(unit):	, $(id)$(unit)_	,  I		, 2		, 3	, $(fruid)	}
+}	   		  			

--- a/Db/shelf_atca_7slot_lcls.substitutions
+++ b/Db/shelf_atca_7slot_lcls.substitutions
@@ -22,15 +22,89 @@
 #==============================================================================
 #
 
-file shelf_atca_7slot.db
+file system_common_lcls.db
 {
    pattern { dev	, link		, location	}
 	   { $(dev)	, $(link)	, $(location)	}	
 }
 
-file system_common_lcls.db
+file system_common.db
 {
    pattern { dev	, link		, location	}
 	   { $(dev)	, $(link)	, $(location)	}	
+}
+
+file system_chassis_status.db
+{
+   pattern { dev	}
+	   { $(dev)	}	
+}
+
+file fru_common.db
+{
+   pattern { dev	, id	, unit	, fruid		}
+           { $(dev)	, SHM	, 1  	, 254		}
+           { $(dev)	, SHM	, 2  	, 253		}
+}
+
+file sensor_ai.db
+{
+   pattern { dev	, prefix	, aliasprefix	,  attr		, sensinst	, type	, fru 	}
+           { $(dev)	, SHM1:		, SHM1_			,  TEMP		, 1			, 1		, 254	}
+           { $(dev)	, SHM1:		, SHM1_			,  TEMP		, 2			, 1		, 254	}
+           { $(dev)	, SHM1:		, SHM1_			,  V		, 1			, 2		, 254	}
+           { $(dev)	, SHM1:		, SHM1_			,  V		, 2			, 2		, 254	}
+           { $(dev)	, SHM1:		, SHM1_			,  I		, 1			, 3		, 254	}
+           { $(dev)	, SHM1:		, SHM1_			,  I		, 2			, 3		, 254	}
+           { $(dev)	, SHM2:		, SHM2_			,  TEMP		, 1			, 1		, 253	}
+           { $(dev)	, SHM2:		, SHM2_			,  TEMP		, 2			, 1		, 253	}
+           { $(dev)	, SHM2:		, SHM2_			,  V		, 1			, 2		, 253	}
+           { $(dev)	, SHM2:		, SHM2_			,  V		, 2			, 2		, 253	}
+           { $(dev)	, SHM2:		, SHM2_			,  I		, 1			, 3		, 253	}
+           { $(dev)	, SHM2:		, SHM2_			,  I		, 2			, 3		, 253	}
+}			
+
+file fru_atca_fb_lcls.db
+{
+   pattern { dev	, id	, unit	, fruid	}
+           { $(dev)	, FB	, 1  	, 5		}
+           { $(dev)	, FB	, 2  	, 6		}
+           { $(dev)	, FB	, 3  	, 7		}
+           { $(dev)	, FB	, 4  	, 8		}
+           { $(dev)	, FB	, 5  	, 9		}
+           { $(dev)	, FB	, 6  	, 10	}
+           { $(dev)	, FB	, 7  	, 11	}
+}
+
+file fru_atca_rtm_lcls.db
+{
+   pattern { dev	, id	, unit	, fruid	}
+           { $(dev)	, RTM	, 1  	, 90	}
+           { $(dev)	, RTM	, 2  	, 91	}
+           { $(dev)	, RTM	, 3  	, 92	}
+           { $(dev)	, RTM	, 4  	, 93	}
+           { $(dev)	, RTM	, 5  	, 94	}
+           { $(dev)	, RTM	, 6  	, 95	}
+           { $(dev)	, RTM	, 7  	, 96	}
+}
+
+file fru_cu.db
+{
+   pattern { dev	, id	, unit	, fruid	}
+           { $(dev)	, CU	, 1  	, 40	}
+           { $(dev)	, CU	, 2  	, 41	}
+           { $(dev)	, CU	, 3  	, 42	}
+           { $(dev)	, CU	, 4  	, 43	}
+}
+
+file fru_common.db
+{
+   pattern { dev	, id	, unit	, fruid }
+           { $(dev)	, PM	, 1    	, 50	}
+           { $(dev)	, PM	, 2  	, 51	}
+           { $(dev)	, PM	, 3  	, 52	}
+           { $(dev)	, PM	, 4  	, 53	}
+           { $(dev)	, SH	, 1  	, 1		}
+           { $(dev)	, SH	, 2  	, 2		}
 }
 

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,3 +1,7 @@
+R4.2.7: 01-Oct-2020 S. Hoobler
+  		Reduce number of sensor records for LCLS ATCA shelf,
+  		now that we have more experience with the systems
+
 R4.2.6: 13-Jan-2020 S. Hoobler
           Change how power on/off sequences are executed to hopefully
             avoid problem causing that sequence to stall.


### PR DESCRIPTION
Release R4.2.7

  Reduce number of sensor records for LCLS ATCA shelf,
  now that we have more experience with the systems
  New files:
        Db/fru_atca_fb_lcls.substitutions
        Db/fru_atca_rtm_lcls.substitutions
  Changes to:
        Db/Makefile
        Db/shelf_atca_7slot_lcls.substitutions