### PR TITLE
have Fan Tray FRU elements show N/A or Not Available

### DIFF
--- a/Db/fru_common.db
+++ b/Db/fru_common.db
@@ -35,6 +35,8 @@ record(mbbi, "$(dev):$(id)$(unit):MSTATE") {
   field(SVST, "Deactivation In Progress")
   field(EIVL, "0x80")
   field(EIST, "Communication Lost")
+  field(NIVL, "0x0")
+  field(NIST, "Not Available")
   alias("$(dev):$(id)$(unit)_MSTATE")
 }
 

--- a/src/devMch.c
+++ b/src/devMch.c
@@ -1029,6 +1029,8 @@ int      s = 0, inst;
 	inst    = mchSess->instance;
 	task    = recPvt->task;
 
+	pmbbi->rval = 0; /* default state */
+
 	/* Read initialized status */
        	if ( !(strcmp( task, "init" )) )
        		pmbbi->rval = mchStat[inst] & MCH_MASK_INIT;
@@ -1061,7 +1063,8 @@ int      s = 0, inst;
 		else if ( !(strcmp( task, "hs")) && checkMchOnlnSess( mchSess ) ) {
 
 			if ( -1 == (sindex = sensLkup( mchSys, pmbbi->inp.value.camacio )) ) {
-				return ERROR;
+				/* return 0 here rather than ERROR so we can provide "Not Available" */
+				return 0;
 			}
 
 			sens = &mchSys->sens[sindex];
@@ -1581,6 +1584,8 @@ uint8_t  l = 0, *d = 0; /* FRU data length and raw */
 	fru = &mchSys->fru[index];
 
 	/* index check may be sufficient; may no longer need to check recType */
+
+	strncpy(pstringin->val, "N/A", sizeof(pstringin->val));
 
 	if ( checkMchInitDone( mchSess ) ) {
 

--- a/src/drvMch.c
+++ b/src/drvMch.c
@@ -1199,12 +1199,13 @@ mchSdrSensDuplicate(MchSys mchSys, uint8_t *raw)
 int i;
 SdrFullRec tmp;
 SensorRec  sens;
+sdr_fru_marshall_t *sdr_fru = (sdr_fru_marshall_t *) raw;
 
-	tmp.owner      = raw[SDR_OWNER_OFFSET];
-	tmp.lun        = raw[SDR_LUN_OFFSET];
-	tmp.number     = raw[SDR_NUMBER_OFFSET];
-	tmp.entityId   = raw[SDR_ENTITY_ID_OFFSET];
-	tmp.entityInst = raw[SDR_ENTITY_INST_OFFSET];
+	tmp.owner      = sdr_fru->owner;
+	tmp.lun        = sdr_fru->lun;
+	tmp.number     = sdr_fru->number;
+	tmp.entityId   = sdr_fru->entityId;
+	tmp.entityInst = sdr_fru->entityInst;
 
 	for ( i = 0; i < mchSys->sensCount; i++ ) {
 
@@ -1261,22 +1262,23 @@ int m = 0, b = 0;
 
 	/* Full Sensor fields */
 	if ( type == SDR_TYPE_FULL_SENSOR ) {
+		sdr_fru_marshall_t *sdr_fru = (sdr_fru_marshall_t *) raw;
 
-		sdr->units1     = raw[SDR_UNITS1_OFFSET];      
-		sdr->units2     = raw[SDR_UNITS2_OFFSET];    
-		sdr->units3     = raw[SDR_UNITS3_OFFSET];    
-		sdr->linear     = raw[SDR_LINEAR_OFFSET];   
-		sdr->M          = raw[SDR_M_OFFSET];   
-		sdr->MTol       = raw[SDR_M_TOL_OFFSET];   
-		sdr->B          = raw[SDR_B_OFFSET];   
-		sdr->BAcc       = raw[SDR_B_ACC_OFFSET];
-		sdr->acc        = raw[SDR_ACC_OFFSET];   
-		sdr->RexpBexp   = raw[SDR_EXP_OFFSET];   
-		sdr->anlgChar   = raw[SDR_ANLG_CHAR_OFFSET];   
-		sdr->nominal    = raw[SDR_NOMINAL_OFFSET];   
-		sdr->normMax    = raw[SDR_NORM_MAX_OFFSET];   
-		sdr->normMin    = raw[SDR_NORM_MIN_OFFSET];   
-		sdr->strLength  = raw[SDR_STR_LENGTH_OFFSET];    
+		sdr->units1     = sdr_fru->units1;
+		sdr->units2     = sdr_fru->units2;
+		sdr->units3     = sdr_fru->units3;
+		sdr->linear     = sdr_fru->linear;
+		sdr->M          = sdr_fru->M;
+		sdr->MTol       = sdr_fru->MTol;
+		sdr->B          = sdr_fru->B;
+		sdr->BAcc       = sdr_fru->BAcc;
+		sdr->acc        = sdr_fru->acc;
+		sdr->RexpBexp   = sdr_fru->RexpBexp;
+		sdr->anlgChar   = sdr_fru->anlgChar;
+		sdr->nominal    = sdr_fru->nominal;
+		sdr->normMax    = sdr_fru->normMax;
+		sdr->normMin    = sdr_fru->normMin;
+		sdr->strLength  = sdr_fru->strLength;
 
 		m = SENSOR_CONV_M_B( sdr->M, sdr->MTol );
 		b = SENSOR_CONV_M_B( sdr->B, sdr->BAcc );
@@ -1290,7 +1292,7 @@ int m = 0, b = 0;
 		l = IPMI_DATA_LENGTH( sdr->strLength );
 		for ( i = 0; i < l; i++ )
 			sdr->str[i] = raw[SDR_STR_OFFSET + i];
-		sdr->str[i+1] = '\0';
+			sdr->str[i+1] = '\0';
        	}     
 
 #ifdef DEBUG

--- a/src/ipmiDef.h
+++ b/src/ipmiDef.h
@@ -629,6 +629,39 @@ extern size_t IPMI_MSG1_LENGTH;
 #define SDR_REC_TYPE_OFFSET    3
 #define SDR_LENGTH_OFFSET      4
 
+typedef struct __attribute__ ((packed)) {
+	uint8_t unknown1[5];
+	uint8_t owner;
+	uint8_t lun;
+	uint8_t number;
+	uint8_t entityId;
+	uint8_t entityInst;
+	uint8_t init;
+	uint8_t capOffset;
+	uint8_t sensType;
+	uint8_t readType;
+	uint16_t assertMask;
+	uint16_t deassertMaxK;
+	uint16_t readMask;
+	uint8_t units1;
+	uint8_t units2;
+	uint8_t units3;
+	uint8_t linear;
+	uint8_t M;
+	uint8_t MTol;
+	uint8_t B;
+	uint8_t BAcc;
+	uint8_t acc;
+	uint8_t RexpBexp;
+	uint8_t anlgChar;
+	uint8_t nominal;
+	uint8_t normMax;
+	uint8_t normMin;
+	uint8_t strLength;
+	uint8_t str;
+} sdr_fru_marshall_t;
+
+
 /* SDR Full Sensor contents */
 #define SDR_OWNER_OFFSET        5  /* SDR Key Fields */
 #define SDR_LUN_OFFSET          6


### PR DESCRIPTION
CATER 146591.  The Fan Tray FRU EEPROM for some crates does not have the EEPROM programmed.  Trying to access the FRU info fails.  Vendor has confirmed they intentionally do not program the EEPROM.

The solution we came up with is to populate the PV with N/A or Not Available.  This way, the GUI can show that the underlying software tried to read the FRU info but was unsuccessful.

We also found an issue where we can't use 0 for an mbbi field option.  For some reason, the value of 0 is known but is not translated to a string.  So we use 0x100, which is not ideal because other mbbi fields don't have that option.  Meaning, if the FRU info for other mbbi fields is not able to be read, the value will be set to 0x100.  I am open to a better solution if one can be thought of.