### PR TITLE
set PVs to N/A or Not Available when FRU info can't be read

### DIFF
--- a/Db/fru_common.db
+++ b/Db/fru_common.db
@@ -35,6 +35,8 @@ record(mbbi, "$(dev):$(id)$(unit):MSTATE") {
   field(SVST, "Deactivation In Progress")
   field(EIVL, "0x80")
   field(EIST, "Communication Lost")
+  field(NIVL, "0x100")
+  field(NIST, "Not Available")
   alias("$(dev):$(id)$(unit)_MSTATE")
 }
 

--- a/src/devMch.c
+++ b/src/devMch.c
@@ -1029,8 +1029,6 @@ int      s = 0, inst;
 	inst    = mchSess->instance;
 	task    = recPvt->task;
 
-	pmbbi->rval = 0x100; /* default state */
-
 	/* Read initialized status */
        	if ( !(strcmp( task, "init" )) )
        		pmbbi->rval = mchStat[inst] & MCH_MASK_INIT;
@@ -1063,6 +1061,7 @@ int      s = 0, inst;
 		else if ( !(strcmp( task, "hs")) && checkMchOnlnSess( mchSess ) ) {
 
 			if ( -1 == (sindex = sensLkup( mchSys, pmbbi->inp.value.camacio )) ) {
+				pmbbi->rval = 0x100; /* default state */
 				/* return 0 here rather than ERROR so we can provide "Not Available" */
 				return 0;
 			}
@@ -1585,13 +1584,17 @@ uint8_t  l = 0, *d = 0; /* FRU data length and raw */
 
 	/* index check may be sufficient; may no longer need to check recType */
 
-	strncpy(pstringin->val, "N/A", sizeof(pstringin->val));
 
 	if ( checkMchInitDone( mchSess ) ) {
 
 		if ( !(strcmp( task, "bmf" )) ) {
-			d = fru->board.manuf.data;
-			l = fru->board.manuf.length;
+			if (fru->board.manuf.length == 0) {
+				d = "N/A";
+				l = 4;
+			} else {
+				d = fru->board.manuf.data;
+				l = fru->board.manuf.length;
+			}
 		}
 		else if ( !(strcmp( task, "bp" )) ) {
 			d = fru->board.prod.data;

--- a/src/devMch.c
+++ b/src/devMch.c
@@ -1584,7 +1584,6 @@ uint8_t  l = 0, *d = 0; /* FRU data length and raw */
 
 	/* index check may be sufficient; may no longer need to check recType */
 
-
 	if ( checkMchInitDone( mchSess ) ) {
 
 		if ( !(strcmp( task, "bmf" )) ) {
@@ -1597,33 +1596,68 @@ uint8_t  l = 0, *d = 0; /* FRU data length and raw */
 			}
 		}
 		else if ( !(strcmp( task, "bp" )) ) {
-			d = fru->board.prod.data;
-			l = fru->board.prod.length;
+			if (fru->board.manuf.length == 0) {
+				d = "N/A";
+				l = 4;
+			} else {
+				d = fru->board.prod.data;
+				l = fru->board.prod.length;
+			}
 		}
 		else if ( !(strcmp( task, "pmf" )) ) {
-			d = fru->prod.manuf.data;
-			l = fru->prod.manuf.length;
+			if (fru->board.manuf.length == 0) {
+				d = "N/A";
+				l = 4;
+			} else {
+				d = fru->prod.manuf.data;
+				l = fru->prod.manuf.length;
+			}
 		}
 		else if ( !(strcmp( task, "pp" )) ) {
-			d = fru->prod.prod.data;
-			l = fru->prod.prod.length;
+			if (fru->board.manuf.length == 0) {
+				d = "N/A";
+				l = 4;
+			} else {
+				d = fru->prod.prod.data;
+				l = fru->prod.prod.length;
+			}
 		}
 		else if ( !(strcmp( task, "bpn" )) ) {
-			d = fru->board.part.data;
-			l = fru->board.part.length;
+			if (fru->board.manuf.length == 0) {
+				d = "N/A";
+				l = 4;
+			} else {
+				d = fru->board.part.data;
+				l = fru->board.part.length;
+			}
 		}
 		else if ( !(strcmp( task, "ppn" )) ) {
-			d = fru->prod.part.data;
-			l = fru->prod.part.length;
+			if (fru->board.manuf.length == 0) {
+				d = "N/A";
+				l = 4;
+			} else {
+				d = fru->prod.part.data;
+				l = fru->prod.part.length;
+			}
 		}
 		else if ( !(strcmp( task, "bsn" )) ) {
-			d = fru->board.sn.data;
-			l = fru->board.sn.length;
+			if (fru->board.manuf.length == 0) {
+				d = "N/A";
+				l = 4;
+			} else {
+				d = fru->board.sn.data;
+				l = fru->board.sn.length;
+			}
 		} 
 
 		else if ( !(strcmp( task, "psn" )) ) {
-			d = fru->prod.sn.data;
-			l = fru->prod.sn.length;
+			if (fru->board.manuf.length == 0) {
+				d = "N/A";
+				l = 4;
+			} else {
+				d = fru->prod.sn.data;
+				l = fru->prod.sn.length;
+			}
 		}
 
 		if ( d ) {

--- a/src/devMch.c
+++ b/src/devMch.c
@@ -1029,6 +1029,8 @@ int      s = 0, inst;
 	inst    = mchSess->instance;
 	task    = recPvt->task;
 
+	pmbbi->rval = 0x100; /* default state */
+
 	/* Read initialized status */
        	if ( !(strcmp( task, "init" )) )
        		pmbbi->rval = mchStat[inst] & MCH_MASK_INIT;
@@ -1061,7 +1063,8 @@ int      s = 0, inst;
 		else if ( !(strcmp( task, "hs")) && checkMchOnlnSess( mchSess ) ) {
 
 			if ( -1 == (sindex = sensLkup( mchSys, pmbbi->inp.value.camacio )) ) {
-				return ERROR;
+				/* return 0 here rather than ERROR so we can provide "Not Available" */
+				return 0;
 			}
 
 			sens = &mchSys->sens[sindex];
@@ -1581,6 +1584,8 @@ uint8_t  l = 0, *d = 0; /* FRU data length and raw */
 	fru = &mchSys->fru[index];
 
 	/* index check may be sufficient; may no longer need to check recType */
+
+	strncpy(pstringin->val, "N/A", sizeof(pstringin->val));
 
 	if ( checkMchInitDone( mchSess ) ) {
 

--- a/src/devMch.c
+++ b/src/devMch.c
@@ -1596,7 +1596,7 @@ uint8_t  l = 0, *d = 0; /* FRU data length and raw */
 			}
 		}
 		else if ( !(strcmp( task, "bp" )) ) {
-			if (fru->board.manuf.length == 0) {
+			if (fru->board.prod.length == 0) {
 				d = "N/A";
 				l = 4;
 			} else {
@@ -1605,7 +1605,7 @@ uint8_t  l = 0, *d = 0; /* FRU data length and raw */
 			}
 		}
 		else if ( !(strcmp( task, "pmf" )) ) {
-			if (fru->board.manuf.length == 0) {
+			if (fru->prod.manuf.length == 0) {
 				d = "N/A";
 				l = 4;
 			} else {
@@ -1614,7 +1614,7 @@ uint8_t  l = 0, *d = 0; /* FRU data length and raw */
 			}
 		}
 		else if ( !(strcmp( task, "pp" )) ) {
-			if (fru->board.manuf.length == 0) {
+			if (fru->prod.prod.length == 0) {
 				d = "N/A";
 				l = 4;
 			} else {
@@ -1623,7 +1623,7 @@ uint8_t  l = 0, *d = 0; /* FRU data length and raw */
 			}
 		}
 		else if ( !(strcmp( task, "bpn" )) ) {
-			if (fru->board.manuf.length == 0) {
+			if (fru->board.part.length == 0) {
 				d = "N/A";
 				l = 4;
 			} else {
@@ -1632,7 +1632,7 @@ uint8_t  l = 0, *d = 0; /* FRU data length and raw */
 			}
 		}
 		else if ( !(strcmp( task, "ppn" )) ) {
-			if (fru->board.manuf.length == 0) {
+			if (fru->prod.part.length == 0) {
 				d = "N/A";
 				l = 4;
 			} else {
@@ -1641,7 +1641,7 @@ uint8_t  l = 0, *d = 0; /* FRU data length and raw */
 			}
 		}
 		else if ( !(strcmp( task, "bsn" )) ) {
-			if (fru->board.manuf.length == 0) {
+			if (fru->board.sn.length == 0) {
 				d = "N/A";
 				l = 4;
 			} else {
@@ -1651,7 +1651,7 @@ uint8_t  l = 0, *d = 0; /* FRU data length and raw */
 		} 
 
 		else if ( !(strcmp( task, "psn" )) ) {
-			if (fru->board.manuf.length == 0) {
+			if (fru->prod.sn.length == 0) {
 				d = "N/A";
 				l = 4;
 			} else {


### PR DESCRIPTION
CATER 146591. The Fan Tray FRU EEPROM for some crates does not have the EEPROM programmed. Trying to access the FRU info fails. Vendor has confirmed they intentionally do not program the EEPROM.

The solution we came up with is to populate the PV with N/A or Not Available. This way, the GUI can show that the underlying software tried to read the FRU info but was unsuccessful.

We also found an issue where we can't use 0 for an mbbi field option. For some reason, the value of 0 is known but is not translated to a string. So we use 0x100, which is not ideal because other mbbi fields don't have that option. Meaning, if the FRU info for other mbbi fields is not able to be read, the value will be set to 0x100. I am open to a better solution if one can be thought of.