### PR TITLE
Refactor identation and code style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,21 @@
+---
+BasedOnStyle:  Microsoft
+AlignConsecutiveMacros: true
+AlignConsecutiveAssignments:
+  Enabled: true
+  AcrossComments: true
+AlignConsecutiveBitFields: true
+AlignConsecutiveDeclarations: true
+AlignTrailingComments: true
+BraceWrapping:
+  AfterControlStatement: Never
+  AfterFunction:   false
+  AfterStruct:     false
+  BeforeElse:      false
+IndentCaseLabels: true
+IndentCaseBlocks: true
+InsertBraces: true
+PointerAlignment: Left
+SortIncludes:    false
+...
+

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -76,3 +76,12 @@ jobs:
       env:
         EPICS_SITE_TOP: ${{ github.workspace }}
         EPICS_MODULES: ${{ github.workspace }}/modules
+
+  pre-commit:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v6
+    - name: Install packages
+      run: sudo apt update -y && sudo apt install -y pre-commit clang-format
+    - name: Check pre-commit hooks
+      run: pre-commit run --show-diff-on-failure --color=always --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+- repo: https://github.com/pre-commit/mirrors-clang-format
+  rev: v22.1.5
+  hooks:
+  - id: clang-format

--- a/README.md
+++ b/README.md
@@ -100,3 +100,20 @@ those that you know are in use.
  initialized" if not. During the discovery process, it is set to "Initializing...".
 
 -There is a EPICS PV `$(crat):CONNECT` for each system. It must be set to "Connect".
+
+## Pre-Commit Hooks
+
+We use the `pre-commit` tool to register pre-commit hooks; these hooks are also
+run as part of our CI setup. To use our configured hooks, the following
+packages need to be installed:
+
+- `pre-commit`
+- `clang-format`
+
+And the command below should be run in the repository (the additional flag is
+useful if working with older branches which are missing a configuration file):
+
+
+```
+$ pre-commit install --allow-missing-config
+```

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,3 +1,9 @@
+pre-release:
+    15-Jun-2026 G. Reis
+    - Define clang-format and apply it
+    - Set pre-commit rule to check the defined clang-format
+    - Configure CI job to run pre-commit
+
 R4.6.1: 9-Oct-2024 J. Lorelli
     - Fix exp2, exp10, cube and cuberoot sensor conversions
     - Handle IPMI_COMP_CODE_DESTINATION_UNAVAIL completion code

--- a/iocs/ipmicomm-test-IOC/ipmicomm-test-IOCApp/src/ipmicomm-test-IOCMain.cpp
+++ b/iocs/ipmicomm-test-IOC/ipmicomm-test-IOCApp/src/ipmicomm-test-IOCMain.cpp
@@ -11,13 +11,12 @@
 #include "epicsThread.h"
 #include "iocsh.h"
 
-int main(int argc,char *argv[])
-{
-    if(argc>=2) {    
+int main(int argc, char* argv[]) {
+    if (argc >= 2) {
         iocsh(argv[1]);
         epicsThreadSleep(.2);
     }
     iocsh(NULL);
     epicsExit(0);
-    return(0);
+    return (0);
 }

--- a/src/devMch.c
+++ b/src/devMch.c
@@ -1,163 +1,139 @@
 //////////////////////////////////////////////////////////////////////////////
 // This file is part of 'ipmiComm'.
-// It is subject to the license terms in the LICENSE.txt file found in the 
-// top-level directory of this distribution and at: 
-//    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
-// No part of 'ipmiComm', including this file, 
-// may be copied, modified, propagated, or distributed except according to 
+// It is subject to the license terms in the LICENSE.txt file found in the
+// top-level directory of this distribution and at:
+//    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+// No part of 'ipmiComm', including this file,
+// may be copied, modified, propagated, or distributed except according to
 // the terms contained in the LICENSE.txt file.
 //////////////////////////////////////////////////////////////////////////////
 /*
 =============================================================
 
-  Abs:  EPICS Device Support for MicroTCA MCH/shelf 
+    Abs:  EPICS Device Support for MicroTCA MCH/shelf
 
-  Name: devMch.c
+    Name: devMch.c
 
-         Utilities:
-         -------------------------------------------------------
-	 *   devMchRegister           - Register device
-	 *   devMchFind               - Find registered device
-         *   sensorConversion         - Convert sensor raw reading, according to sensor SDR info
+    Utilities:
+    -------------------------------------------------------
+    *   devMchRegister           - Register device
+    *   devMchFind               - Find registered device
+    *   sensorConversion         - Convert sensor raw reading, according to sensor SDR info
 
-         Analog Input Device Support:
-         -------------------------------------------------------
+    Analog Input Device Support:
+    -------------------------------------------------------
 
-	 devAiMch
-         --------
-         *   init_ai_record           - Record initialization
-         *   read_ai                  - Read analog input
-		 *   ai_ioint_info            - Add to i/o scan list          
-		 *
-	   Supported operations:
+    devAiMch
+    --------
+    *   init_ai_record           - Record initialization
+    *   read_ai                  - Read analog input
+        *   ai_ioint_info            - Add to i/o scan list
+        *
+    Supported operations:
+        * "sens": read sensor
 
-             * "sens": read sensor
-	   
-	 devAiFru
-         --------
-         *   init_fru_ai                  - Record initialization
-         *   fru_ai_ioint_info            - Add to i/o scan list  
-         *   init_fru_ai_record           - Record initialization
-         *   read_fru_ai                  - Read analog input
-
-	   Supported operations:
-
-             * "fan"     : Get fan level
-             * "pwr"     : Get FRU power levels (steady state and early, 
+     devAiFru
+     --------
+     *   init_fru_ai                  - Record initialization
+     *   fru_ai_ioint_info            - Add to i/o scan list
+     *   init_fru_ai_record           - Record initialization
+     *   read_fru_ai                  - Read analog input
+     Supported operations:
+        * "fan"     : Get fan level
+        * "pwr"     : Get FRU power levels (steady state and early,
                                                  desired and actual)
 
-         Binary Output Device Support:
-         -------------------------------------------------------
+    Binary Output Device Support:
+    -------------------------------------------------------
 
-	 devBoMch
-         --------
+    devBoMch
+    --------
+    *   init_bo_record           - Record initialization
+    *   write_bo                 - Write binary output
+    Supported operations:
+        * "reset": perform IPMI cold reset
+        * "sess":  close/open session with MCH
+        * "init":  override 'MCH communication initialized' bit
 
-         *   init_bo_record           - Record initialization
-         *   write_bo                 - Write binary output
+    Binary Input Device Support:
+    -------------------------------------------------------
 
-	   Supported operations:
+    devBiMch
+    ----------
+    *   init_bi                   - bi initialization
+        *   bi_ioint_info             - Add to i/o scan list
+        *   init_bi_record            - Record initialization
+        *   read_bi                   - Read binary input
+    Supported operations:
 
-             * "reset": perform IPMI cold reset
-             * "sess":  close/open session with MCH
-             * "init":  override 'MCH communication initialized' bit
+        * "stat": read crate online/offline status
+        * "spres": sensor presence
+        * "fpres": FRU presence
 
-         Binary Input Device Support:
-         -------------------------------------------------------
+    Multibit-Binary Input Device Support:
+    -------------------------------------------------------
 
-	 devBiMch
-         ----------
+    devMbbiMch
+    ----------
+    *   init_mbbi                 - mbbi initialization
+        *   mbbi_ioint_info           - Add to i/o scan list
+        *   init_mbbi_record          - Record initialization
+        *   read_mbbi                 - Read multi-bit binary input
+    Supported operations:
+        * "init": communication with crate initialized
+        * "fan":  read fan auto-adjustment
+        * "hs":   read FRU hot-swap sensor
+        * "mch":  MCH vendor
 
-	 *   init_bi                   - bi initialization     
-         *   bi_ioint_info             - Add to i/o scan list   
-         *   init_bi_record            - Record initialization
-         *   read_bi                   - Read binary input
+    Multibit-Binary Output Device Support:
+    -------------------------------------------------------
 
-	   Supported operations:
+    devMbboMch
+    ----------
+    *   init_mbbo_record          - Record initialization
+    *   write_mbbo                - Write multi-bit binary output
+    Supported operations:
+        * "chas": chassis control on/off/reset
+        * "fru":  FRU on/off
+        * "dbg":  control debug messages for one MCH
+        * "scan": sensor scan period control, one per system
 
-             * "stat": read crate online/offline status
-             * "spres": sensor presence
-             * "fpres": FRU presence
+    Long Integer Input Device Support:
+    -------------------------------------------------------
 
-         Multibit-Binary Input Device Support:
-         -------------------------------------------------------
+    devLonginMch
+    -------------
+    *   init_longin_record       - Record initialization
+    *   write_longin             - Read long integer input
+    Supported operations:
+        * "chas": read chassis status
 
-	 devMbbiMch
-         ----------
+    String Input Device Support:
+    -------------------------------------------------------
 
-	 *   init_mbbi                 - mbbi initialization     
-         *   mbbi_ioint_info           - Add to i/o scan list   
-         *   init_mbbi_record          - Record initialization
-         *   read_mbbi                 - Read multi-bit binary input
+    devStringinFru
+    --------------
+    *   init_fru_stringin            - stringin initialization
+    *   fru_stringin_ioint_info      - Add to i/o scan list
+    *   init_fru_stringin_record     - Record initialization
+    *   read_fru_stringin            - Read string input
+    Supported operations:
+        * "bmf":  FRU board manufacturer
+        * "bp":   FRU board product name
+        * "bpn":  FRU board part number
+        * "pmf":  FRU product manufacturer
+        * "pp":   FRU product product name
+        * "ppn":  FRU product part number
 
-	   Supported operations:
+    Long Integer Output Device Support:
+    -------------------------------------------------------
 
-             * "init": communication with crate initialized
-             * "fan":  read fan auto-adjustment
-             * "hs":   read FRU hot-swap sensor 
-	     * "mch":  MCH vendor
-
-
-         Multibit-Binary Output Device Support:
-         -------------------------------------------------------
-
-	 devMbboMch
-         ----------
-
-         *   init_mbbo_record          - Record initialization
-         *   write_mbbo                - Write multi-bit binary output
-
-	   Supported operations:
-
-             * "chas": chassis control on/off/reset
-             * "fru":  FRU on/off
-             * "dbg":  control debug messages for one MCH
-             * "scan": sensor scan period control, one per system
-
-         Long Integer Input Device Support:
-         -------------------------------------------------------
-
-	 devLonginMch
-         -------------
-
-         *   init_longin_record       - Record initialization
-         *   write_longin             - Read long integer input
-
-	   Supported operations:
-
-	     * "chas": read chassis status
-
-         String Input Device Support:
-         -------------------------------------------------------
-
-	 devStringinFru
-         --------------
-
-         *   init_fru_stringin            - stringin initialization
-         *   fru_stringin_ioint_info      - Add to i/o scan list
-         *   init_fru_stringin_record     - Record initialization
-         *   read_fru_stringin            - Read string input
-
-	   Supported operations:
-
-             * "bmf":  FRU board manufacturer
-             * "bp":   FRU board product name
-             * "bpn":  FRU board part number
-             * "pmf":  FRU product manufacturer
-             * "pp":   FRU product product name
-             * "ppn":  FRU product part number
-
-         Long Integer Output Device Support:
-         -------------------------------------------------------
-
-	 devLongoutFru
-         -------------
-
-         *   init_fru_longout_record      - Record initialization
-         *   write_longout                - Write long integer output
-
-	   Supported operations:
-
-             * "fan":  fan level control
+    devLongoutFru
+    -------------
+    *   init_fru_longout_record      - Record initialization
+    *   write_longout                - Write long integer output
+    Supported operations:
+        * "fan":  fan level control
 
 =============================================================
 */
@@ -201,72 +177,74 @@
 
 extern uint32_t mchStat[MAX_MCH];
 
-/* Sensor scan period options (in seconds). Must match 
- * SENSOR_SCAN_PERIOD record definition in system_common.db 
+/* Sensor scan period options (in seconds). Must match
+ * SENSOR_SCAN_PERIOD record definition in system_common.db
  */
-uint8_t SENSOR_SCAN_PERIODS[5] = { 5, 10, 20, 30, 60 }; 
+uint8_t SENSOR_SCAN_PERIODS[5] = {5, 10, 20, 30, 60};
 
 IOSCANPVT drvMchStatScan;
 IOSCANPVT drvMchInitScan;
 IOSCANPVT drvMchFruScan;
 
 #define MAX_STRING_LENGTH 39
-#define MAX_EGU_LENGTH 16
+#define MAX_EGU_LENGTH    16
 
 /* Device support return values */
-static long SUCCESS    =  0;
-static long NO_CONVERT =  2; /* Used by ai, success and indicate that devsup handles the conversion (record support does not need to) */
-static long ERROR      = -1;
+static long SUCCESS = 0;
+static long NO_CONVERT =
+    2; /* Used by ai, success and indicate that devsup handles the conversion (record support does not need to) */
+static long ERROR = -1;
 
 /* Device support prototypes */
-static long init_ai_record(struct aiRecord *pai);
-static long read_ai(struct aiRecord *pai);
-static long ai_ioint_info(int cmd, struct aiRecord *pai, IOSCANPVT *iopvt);
+static long init_ai_record(struct aiRecord* pai);
+static long read_ai(struct aiRecord* pai);
+static long ai_ioint_info(int cmd, struct aiRecord* pai, IOSCANPVT* iopvt);
 
-static long init_bo_record(struct  boRecord *pbo);
-static long write_bo(struct boRecord *pbo);
+static long init_bo_record(struct boRecord* pbo);
+static long write_bo(struct boRecord* pbo);
 
-static long init_bi(struct biRecord *pbi);
-static long init_bi_record(struct biRecord *pbi);
-static long read_bi(struct biRecord *pbi);
-static long bi_ioint_info(int cmd, struct biRecord *pbi, IOSCANPVT *iopvt);
+static long init_bi(struct biRecord* pbi);
+static long init_bi_record(struct biRecord* pbi);
+static long read_bi(struct biRecord* pbi);
+static long bi_ioint_info(int cmd, struct biRecord* pbi, IOSCANPVT* iopvt);
 
-static long init_mbbi(struct mbbiRecord *pmbbi);
-static long init_mbbi_record(struct mbbiRecord *pmbbi);
-static long read_mbbi(struct mbbiRecord *pmbbi);
-static long mbbi_ioint_info(int cmd, struct mbbiRecord *mbpbi, IOSCANPVT *iopvt);
+static long init_mbbi(struct mbbiRecord* pmbbi);
+static long init_mbbi_record(struct mbbiRecord* pmbbi);
+static long read_mbbi(struct mbbiRecord* pmbbi);
+static long mbbi_ioint_info(int cmd, struct mbbiRecord* mbpbi, IOSCANPVT* iopvt);
 
-static long init_mbbo_record(struct mbboRecord *pmbbo);
-static long write_mbbo(struct mbboRecord *pmbbo);
+static long init_mbbo_record(struct mbboRecord* pmbbo);
+static long write_mbbo(struct mbboRecord* pmbbo);
 
-static long init_longin_record(struct longinRecord *plongin);
-static long read_longin(struct longinRecord *plongin);
+static long init_longin_record(struct longinRecord* plongin);
+static long read_longin(struct longinRecord* plongin);
 
-static long init_fru_ai(struct aiRecord *pai);
-static long init_fru_ai_record(struct aiRecord *pai);
-static long read_fru_ai(struct aiRecord *pai);
-static long ai_fru_ioint_info(int cmd, struct aiRecord *pai, IOSCANPVT *iopvt);
+static long init_fru_ai(struct aiRecord* pai);
+static long init_fru_ai_record(struct aiRecord* pai);
+static long read_fru_ai(struct aiRecord* pai);
+static long ai_fru_ioint_info(int cmd, struct aiRecord* pai, IOSCANPVT* iopvt);
 
-static long init_fru_longout_record(struct longoutRecord *plongout);
-static long write_fru_longout(struct longoutRecord *plongout);
+static long init_fru_longout_record(struct longoutRecord* plongout);
+static long write_fru_longout(struct longoutRecord* plongout);
 
-static long init_fru_stringin(struct stringinRecord *pstringin);
-static long init_fru_stringin_record(struct stringinRecord *pstringin);
-static long read_fru_stringin(struct stringinRecord *pstringin);
-static long stringin_fru_ioint_info(int cmd, struct stringinRecord *pstringin, IOSCANPVT *iopvt);
+static long init_fru_stringin(struct stringinRecord* pstringin);
+static long init_fru_stringin_record(struct stringinRecord* pstringin);
+static long read_fru_stringin(struct stringinRecord* pstringin);
+static long stringin_fru_ioint_info(int cmd, struct stringinRecord* pstringin, IOSCANPVT* iopvt);
 
 /* global struct for devSup */
 typedef struct {
-        long            number;
-        DEVSUPFUN       report;
-        DEVSUPFUN       init;
-        DEVSUPFUN       init_record;
-        DEVSUPFUN       get_ioint_info;
-        DEVSUPFUN       read_write;
-        DEVSUPFUN       special_linconv;
+    long      number;
+    DEVSUPFUN report;
+    DEVSUPFUN init;
+    DEVSUPFUN init_record;
+    DEVSUPFUN get_ioint_info;
+    DEVSUPFUN read_write;
+    DEVSUPFUN special_linconv;
 } MCH_DEV_SUP_SET;
 
 /* Add reporting */
+// clang-format off
 MCH_DEV_SUP_SET devAiMch         = {6, NULL, NULL,                         (DEVSUPFUN)init_ai_record,           (DEVSUPFUN)ai_ioint_info,           (DEVSUPFUN)read_ai,           NULL};
 MCH_DEV_SUP_SET devBoMch         = {6, NULL, NULL,                         (DEVSUPFUN)init_bo_record,           NULL,                               (DEVSUPFUN)write_bo,          NULL};
 MCH_DEV_SUP_SET devMbboMch       = {6, NULL, NULL,                         (DEVSUPFUN)init_mbbo_record,         NULL,                               (DEVSUPFUN)write_mbbo,        NULL};
@@ -276,6 +254,7 @@ MCH_DEV_SUP_SET devLonginMch     = {6, NULL, NULL,                         (DEVS
 MCH_DEV_SUP_SET devAiFru         = {6, NULL, (DEVSUPFUN)init_fru_ai,       (DEVSUPFUN)init_fru_ai_record,       (DEVSUPFUN)ai_fru_ioint_info,       (DEVSUPFUN)read_fru_ai,       NULL};
 MCH_DEV_SUP_SET devLongoutFru    = {6, NULL, NULL,                         (DEVSUPFUN)init_fru_longout_record,  NULL,                               (DEVSUPFUN)write_fru_longout, NULL};
 MCH_DEV_SUP_SET devStringinFru   = {6, NULL, (DEVSUPFUN)init_fru_stringin, (DEVSUPFUN)init_fru_stringin_record, (DEVSUPFUN)stringin_fru_ioint_info, (DEVSUPFUN)read_fru_stringin, NULL};
+// clang-format on
 
 epicsExportAddress(dset, devAiMch);
 epicsExportAddress(dset, devBoMch);
@@ -287,374 +266,355 @@ epicsExportAddress(dset, devAiFru);
 epicsExportAddress(dset, devLongoutFru);
 epicsExportAddress(dset, devStringinFru);
 
-
 /*--- Register functions stolen from devBusMapped ---*/
 
 /* just any unique address */
-static void     *registryId = (void*)&registryId;
-static void     *ioRegistryId = (void*)&ioRegistryId;
-static void     *ioscanRegistryId = (void*)&ioscanRegistryId;
+static void* registryId       = (void*)&registryId;
+static void* ioRegistryId     = (void*)&ioRegistryId;
+static void* ioscanRegistryId = (void*)&ioscanRegistryId;
 
 /* Register a device's base address and return a pointer to a
  * freshly allocated 'MchDev' struct or NULL on failure.
  */
-MchDev
-devMchRegister(const char *name)
-{
-MchDev rval = 0, d;
+MchDev devMchRegister(const char* name) {
+    MchDev rval = 0, d;
 
-        if ( (d = malloc(sizeof(*rval) + strlen(name))) ) {
+    if ((d = malloc(sizeof(*rval) + strlen(name)))) {
 
-                strcpy((char*)d->name, name);
-                if ( (d->mutex = epicsMutexCreate()) ) {
-                        /* NOTE: the registry keeps a pointer to the name and
-                         *       does not copy the string, therefore we keep one.
-                         *       (_must_ pass d->name, not 'name'!!)
-                         */
-                        if ( registryAdd( registryId, d->name, d ) ) {
-                                /* success */
-                                rval = d;
-                                d = 0;
-                        }
-                }
+        strcpy((char*)d->name, name);
+        if ((d->mutex = epicsMutexCreate())) {
+            /* NOTE: the registry keeps a pointer to the name and
+             *       does not copy the string, therefore we keep one.
+             *       (_must_ pass d->name, not 'name'!!)
+             */
+            if (registryAdd(registryId, d->name, d)) {
+                /* success */
+                rval = d;
+                d    = 0;
+            }
         }
+    }
 
-        if (d) {
-                /* an error happened and we need to clean up */
-                if (d->mutex)
-                        epicsMutexDestroy(d->mutex);
-                free(d);
+    if (d) {
+        /* an error happened and we need to clean up */
+        if (d->mutex) {
+            epicsMutexDestroy(d->mutex);
         }
+        free(d);
+    }
 
-        /* return address of MchDev struct for success, 0 for error */
-        return rval;
+    /* return address of MchDev struct for success, 0 for error */
+    return rval;
 }
 
 /* Find the 'MchDev' of a registered device by name */
-MchDev
-devMchFind(const char *name)
-{
-	return (MchDev)registryFind(registryId, name);
+MchDev devMchFind(const char* name) {
+    return (MchDev)registryFind(registryId, name);
 }
 
 /*--- end stolen ---*/
 
-static epicsFloat64
-sensorConversion(SdrFull sdr, uint8_t raw, char *name)
-{
-int l, units, format, m, b, rexp, bexp;
-epicsFloat64 value;
+static epicsFloat64 sensorConversion(SdrFull sdr, uint8_t raw, char* name) {
+    int          l, units, format, m, b, rexp, bexp;
+    epicsFloat64 value;
 
-	l = SENSOR_LINEAR( sdr->linear );
+    l = SENSOR_LINEAR(sdr->linear);
 
-	m     = sdr->m;
-	b     = sdr->b;
-	rexp  = sdr->rexp;
-	bexp  = sdr->bexp;
-	units = sdr->units2;    
+    m     = sdr->m;
+    b     = sdr->b;
+    rexp  = sdr->rexp;
+    bexp  = sdr->bexp;
+    units = sdr->units2;
 
-	format = SENSOR_NUMERIC_FORMAT( sdr->units1 );
+    format = SENSOR_NUMERIC_FORMAT(sdr->units1);
 
-	switch ( format ) {
+    switch (format) {
 
-		default:
-			printf("sensorConversion %s: Unknown analog data format\n", name);
-			return raw;
+        default:
+            printf("sensorConversion %s: Unknown analog data format\n", name);
+            return raw;
 
-		case SENSOR_NUMERIC_FORMAT_UNSIGNED:
-			value = raw;
-			break;
+        case SENSOR_NUMERIC_FORMAT_UNSIGNED:
+            value = raw;
+            break;
 
-		case SENSOR_NUMERIC_FORMAT_ONES_COMP:
-			value = ONES_COMP_SIGNED_NBIT( raw, 8 );
-			break;
+        case SENSOR_NUMERIC_FORMAT_ONES_COMP:
+            value = ONES_COMP_SIGNED_NBIT(raw, 8);
+            break;
 
-		case SENSOR_NUMERIC_FORMAT_TWOS_COMP:
-			value = TWOS_COMP_SIGNED_NBIT( raw, 8 );
-			break;
+        case SENSOR_NUMERIC_FORMAT_TWOS_COMP:
+            value = TWOS_COMP_SIGNED_NBIT(raw, 8);
+            break;
 
-		case SENSOR_NUMERIC_FORMAT_NONNUMERIC:
-			printf("sensorConversion %s: Non-numeric data format\n", name);
-			return raw;
-	}
+        case SENSOR_NUMERIC_FORMAT_NONNUMERIC:
+            printf("sensorConversion %s: Non-numeric data format\n", name);
+            return raw;
+    }
 
-       	value = ((m*value) + (b*pow(10,bexp)))*pow(10,rexp);
+    value = ((m * value) + (b * pow(10, bexp))) * pow(10, rexp);
 
-	if ( l == SENSOR_CONV_LINEAR )
-		value = value;
-	else if ( l == SENSOR_CONV_LN )
-		value = log( value );
-	else if ( l == SENSOR_CONV_LOG10 )
-		value = log10( value );
-	else if ( l == SENSOR_CONV_LOG2 )
-		value = log( value )/log( 2 );
-	else if ( l == SENSOR_CONV_E )
-		value = exp( value );
-	else if ( l == SENSOR_CONV_EXP10 )
-		value = exp10( value );
-	else if ( l == SENSOR_CONV_EXP2 )
-		value = exp2( value );
-	else if ( l == SENSOR_CONV_1_X )
-		value = 1/value;
-	else if ( l == SENSOR_CONV_SQR )
-		value = pow( value, 2);
-	else if ( l == SENSOR_CONV_CUBE )
-		value = pow( value, 3.0 );
-	else if ( l == SENSOR_CONV_SQRT )
-		value = sqrt( value );
-	else if ( l == SENSOR_CONV_CUBE_NEG1 )
-		value = cbrt( value );
-	else
-		printf("sensorConversion %s: unknown sensor conversion algorithm\n", name);
+    if (l == SENSOR_CONV_LINEAR) {
+        value = value;
+    } else if (l == SENSOR_CONV_LN) {
+        value = log(value);
+    } else if (l == SENSOR_CONV_LOG10) {
+        value = log10(value);
+    } else if (l == SENSOR_CONV_LOG2) {
+        value = log(value) / log(2);
+    } else if (l == SENSOR_CONV_E) {
+        value = exp(value);
+    } else if (l == SENSOR_CONV_EXP10) {
+        value = exp10(value);
+    } else if (l == SENSOR_CONV_EXP2) {
+        value = exp2(value);
+    } else if (l == SENSOR_CONV_1_X) {
+        value = 1 / value;
+    } else if (l == SENSOR_CONV_SQR) {
+        value = pow(value, 2);
+    } else if (l == SENSOR_CONV_CUBE) {
+        value = pow(value, 3.0);
+    } else if (l == SENSOR_CONV_SQRT) {
+        value = sqrt(value);
+    } else if (l == SENSOR_CONV_CUBE_NEG1) {
+        value = cbrt(value);
+    } else {
+        printf("sensorConversion %s: unknown sensor conversion algorithm\n", name);
+    }
 
-	return value;
+    return value;
 }
 
-static short
-fruLkup(MchSys mchSys, struct camacio link) {
+static short fruLkup(MchSys mchSys, struct camacio link) {
 
-	return mchSys->fruLkup[link.b];
+    return mchSys->fruLkup[link.b];
 }
 
-static short
-sensLkup(MchSys mchSys, struct camacio link) {
+static short sensLkup(MchSys mchSys, struct camacio link) {
 
-int fruindex = fruLkup( mchSys, link );
+    int fruindex = fruLkup(mchSys, link);
 
-	if ( -1 == fruindex )
-		return -1;
+    if (-1 == fruindex) {
+        return -1;
+    }
 
-	return mchSys->sensLkup[fruindex][link.c][link.n];
+    return mchSys->sensLkup[fruindex][link.c][link.n];
 }
 
-static int
-checkMchOnlnSessInitDone(MchSess mchSess) {
+static int checkMchOnlnSessInitDone(MchSess mchSess) {
 
-	return (MCH_ONLN( mchStat[mchSess->instance] ) && mchSess->session && MCH_INIT_DONE( mchStat[mchSess->instance] ));
+    return (MCH_ONLN(mchStat[mchSess->instance]) && mchSess->session && MCH_INIT_DONE(mchStat[mchSess->instance]));
 }
 
-static int
-checkMchOnlnSess(MchSess mchSess) {
+static int checkMchOnlnSess(MchSess mchSess) {
 
-	return (MCH_ONLN( mchStat[mchSess->instance] ) && mchSess->session);
+    return (MCH_ONLN(mchStat[mchSess->instance]) && mchSess->session);
 }
 
-static int
-checkMchInitDone(MchSess mchSess) {
-	return MCH_INIT_DONE( mchStat[mchSess->instance] );
+static int checkMchInitDone(MchSess mchSess) {
+    return MCH_INIT_DONE(mchStat[mchSess->instance]);
 }
 
-static int
-checkMchOnln(MchSess mchSess) {
-	return MCH_ONLN( mchStat[mchSess->instance] );
-}	
+static int checkMchOnln(MchSess mchSess) {
+    return MCH_ONLN(mchStat[mchSess->instance]);
+}
 
-static void
-sensEgu(char *egu, unsigned units) {
+static void sensEgu(char* egu, unsigned units) {
 
-	switch ( units ) {
+    switch (units) {
 
-		default:
-			strcpy( egu, "" );
+        default:
+            strcpy(egu, "");
 
-		/* If unspecified, copy empty string to .EGU */
-		case SENSOR_UNITS_UNSPEC:
-			strcpy( egu, "");
-			break;
+        /* If unspecified, copy empty string to .EGU */
+        case SENSOR_UNITS_UNSPEC:
+            strcpy(egu, "");
+            break;
 
-		case SENSOR_UNITS_DEGC:   
-			strcpy( egu, "DegC");
-			break;
+        case SENSOR_UNITS_DEGC:
+            strcpy(egu, "DegC");
+            break;
 
-		case SENSOR_UNITS_DEGF:   
-			strcpy( egu, "DegF");
-			break;
+        case SENSOR_UNITS_DEGF:
+            strcpy(egu, "DegF");
+            break;
 
-		case SENSOR_UNITS_DEGK:   
-			strcpy( egu, "DegK");
-			break;
+        case SENSOR_UNITS_DEGK:
+            strcpy(egu, "DegK");
+            break;
 
-		case SENSOR_UNITS_VOLTS:  
-			strcpy( egu, "V");
-			break;
+        case SENSOR_UNITS_VOLTS:
+            strcpy(egu, "V");
+            break;
 
-		case SENSOR_UNITS_AMPS:   
-			strcpy( egu, "A");
-			break;
+        case SENSOR_UNITS_AMPS:
+            strcpy(egu, "A");
+            break;
 
-		case SENSOR_UNITS_WATTS:  
-			strcpy( egu, "W");
-			break;
+        case SENSOR_UNITS_WATTS:
+            strcpy(egu, "W");
+            break;
 
-		case SENSOR_UNITS_JOULES: 
-			strcpy( egu, "J");
-			break;
+        case SENSOR_UNITS_JOULES:
+            strcpy(egu, "J");
+            break;
 
-		case SENSOR_UNITS_COULOMBS:
-			strcpy( egu, "C");
-			break;
+        case SENSOR_UNITS_COULOMBS:
+            strcpy(egu, "C");
+            break;
 
-		case SENSOR_UNITS_RPM:
-			strcpy( egu, "RPM");
-			break;
-	}
-}		
+        case SENSOR_UNITS_RPM:
+            strcpy(egu, "RPM");
+            break;
+    }
+}
 
-static void
-sensThresh(SdrFull sdr, Sensor sens, epicsFloat64 *lolo, epicsEnum16 *llsv, epicsFloat64 *low, epicsEnum16 *lsv, epicsFloat64 *high, epicsEnum16 *hsv, epicsFloat64 *hihi, epicsEnum16 *hhsv, char *name) 
-{
+static void sensThresh(SdrFull sdr, Sensor sens, epicsFloat64* lolo, epicsEnum16* llsv, epicsFloat64* low,
+                       epicsEnum16* lsv, epicsFloat64* high, epicsEnum16* hsv, epicsFloat64* hihi, epicsEnum16* hhsv,
+                       char* name) {
 
-	if ( IPMI_SENSOR_THRESH_LC_READABLE(sens->tmask) ) {
-		*lolo = sensorConversion( sdr, sens->tlc, name );
-		*llsv = MAJOR_ALARM;
-	}
-	else {
-		*lolo = 0;
-		*llsv = NO_ALARM;
-	}
-	if ( IPMI_SENSOR_THRESH_LNC_READABLE(sens->tmask) ) {
-		*low  = sensorConversion( sdr, sens->tlnc, name  );
-		*lsv  = MINOR_ALARM;
-	}
-	else {
-		*low  = 0;
-		*lsv  = NO_ALARM;
-	}
-	if ( IPMI_SENSOR_THRESH_UNC_READABLE(sens->tmask) ) {
-		*high = sensorConversion( sdr, sens->tunc, name  );
-		*hsv  = MINOR_ALARM;
-	}
-	else {
-		*high = 0;
-		*hsv  = NO_ALARM;
-	}
-	if ( IPMI_SENSOR_THRESH_UC_READABLE(sens->tmask) ) {
-		*hihi = sensorConversion( sdr, sens->tuc, name  );
-		*hhsv = MAJOR_ALARM;
-	}
-	else {
-		*hihi = 0;
-		*hhsv = NO_ALARM;
-	}
+    if (IPMI_SENSOR_THRESH_LC_READABLE(sens->tmask)) {
+        *lolo = sensorConversion(sdr, sens->tlc, name);
+        *llsv = MAJOR_ALARM;
+    } else {
+        *lolo = 0;
+        *llsv = NO_ALARM;
+    }
+    if (IPMI_SENSOR_THRESH_LNC_READABLE(sens->tmask)) {
+        *low = sensorConversion(sdr, sens->tlnc, name);
+        *lsv = MINOR_ALARM;
+    } else {
+        *low = 0;
+        *lsv = NO_ALARM;
+    }
+    if (IPMI_SENSOR_THRESH_UNC_READABLE(sens->tmask)) {
+        *high = sensorConversion(sdr, sens->tunc, name);
+        *hsv  = MINOR_ALARM;
+    } else {
+        *high = 0;
+        *hsv  = NO_ALARM;
+    }
+    if (IPMI_SENSOR_THRESH_UC_READABLE(sens->tmask)) {
+        *hihi = sensorConversion(sdr, sens->tuc, name);
+        *hhsv = MAJOR_ALARM;
+    } else {
+        *hihi = 0;
+        *hhsv = NO_ALARM;
+    }
 }
 
 /* Perform some common dev sup checks */
-static MchRec
-init_record_chk(DBLINK *plink, long *status, char *str) {
-short  f, t, s;
-MchRec rval = 0;
+static MchRec init_record_chk(DBLINK* plink, long* status, char* str) {
+    short  f, t, s;
+    MchRec rval = 0;
 
-        if ( CAMAC_IO != plink->type ) {
-		*status = S_dev_badBus;
-		return rval;
-	}
+    if (CAMAC_IO != plink->type) {
+        *status = S_dev_badBus;
+        return rval;
+    }
 
-        f = plink->value.camacio.b;
-        t = plink->value.camacio.c;
-        s = plink->value.camacio.n;
+    f = plink->value.camacio.b;
+    t = plink->value.camacio.c;
+    s = plink->value.camacio.n;
 
-        if ( f < 0 ) {
-	       	sprintf( str, "FRU id (Branch) is %i; must >= 0", f);
-		*status = S_dev_badSignal;
-		return rval;
-	}
+    if (f < 0) {
+        sprintf(str, "FRU id (Branch) is %i; must >= 0", f);
+        *status = S_dev_badSignal;
+        return rval;
+    }
 
-        if ( t < 0 ) {
-	       	sprintf( str, "Sensor type (Crate) is %i; must >= 0", t);
-		*status = S_dev_badSignal;
-	        return rval;
-	}
+    if (t < 0) {
+        sprintf(str, "Sensor type (Crate) is %i; must >= 0", t);
+        *status = S_dev_badSignal;
+        return rval;
+    }
 
-        if ( s < 0 ) {
-	       	sprintf( str, "Sensor instance (Station) is %i; must >= 0", s);
-		*status = S_dev_badSignal;
-		return rval;
-	}
+    if (s < 0) {
+        sprintf(str, "Sensor instance (Station) is %i; must >= 0", s);
+        *status = S_dev_badSignal;
+        return rval;
+    }
 
-	if ( ! (rval = calloc( 1, sizeof( *rval ) )) ) {
-		sprintf( str, "No memory for recPvt structure");
-		*status = S_rec_outMem;
-		return rval;
-	}
+    if (!(rval = calloc(1, sizeof(*rval)))) {
+        sprintf(str, "No memory for recPvt structure");
+        *status = S_rec_outMem;
+        return rval;
+    }
 
-	return rval;
+    return rval;
 }
 
 /* Find data structure in registry by MCH name */
-static long
-init_record_find(MchDev mch, MchRec recPvt, char *node, char *task, long *status, char *str) {
+static long init_record_find(MchDev mch, MchRec recPvt, char* node, char* task, long* status, char* str) {
 
-	if ( (mch = devMchFind( node )) ) {
-		recPvt->mch  = mch;
-                strcpy( recPvt->task, task );
-		return 0;
-	}
-	else {
-		sprintf( str, "Failed to locate data structure" );
-		*status = S_dev_noDeviceFound;
-		return -1;
-	}
+    if ((mch = devMchFind(node))) {
+        recPvt->mch = mch;
+        strcpy(recPvt->task, task);
+        return 0;
+    } else {
+        sprintf(str, "Failed to locate data structure");
+        *status = S_dev_noDeviceFound;
+        return -1;
+    }
 }
 
 /*
 ** Add this record to our IOSCANPVT list.
 */
-static long
-ai_ioint_info(int cmd, struct aiRecord *pai, IOSCANPVT *iopvt)
-{
-MchRec   recPvt  = pai->dpvt; /* Info stored with record */
-MchDev   mch;
-MchData  mchData;
-int      inst;
-long     status  = SUCCESS;
+static long ai_ioint_info(int cmd, struct aiRecord* pai, IOSCANPVT* iopvt) {
+    MchRec  recPvt = pai->dpvt; /* Info stored with record */
+    MchDev  mch;
+    MchData mchData;
+    int     inst;
+    long    status = SUCCESS;
 
-	if ( !recPvt )
-		return NO_CONVERT;
+    if (!recPvt) {
+        return NO_CONVERT;
+    }
 
-	mch = recPvt->mch;  
-	mchData = mch->udata;
-	inst = mchData->mchSess->instance;
+    mch     = recPvt->mch;
+    mchData = mch->udata;
+    inst    = mchData->mchSess->instance;
 
-	*iopvt = drvSensorScan[inst];
-	return status;
+    *iopvt = drvSensorScan[inst];
+    return status;
 }
 
-static long 
-init_ai_record(struct aiRecord *pai)
-{
-MchRec   recPvt  = 0; /* Info stored with record */
-MchDev   mch     = 0; /* MCH device data structures */
-char    *node    = 0; /* Network node name, stored in parm */
-char    *task    = 0; /* Optional additional parameter appended to parm */
-char    *p;
-long     status  = SUCCESS;
-char     str[40];
+static long init_ai_record(struct aiRecord* pai) {
+    MchRec recPvt = 0; /* Info stored with record */
+    MchDev mch    = 0; /* MCH device data structures */
+    char*  node   = 0; /* Network node name, stored in parm */
+    char*  task   = 0; /* Optional additional parameter appended to parm */
+    char*  p;
+    long   status = SUCCESS;
+    char   str[40];
 
-	if ( ! ( recPvt = init_record_chk( &pai->inp, &status, str )) )
-		goto bail;
+    if (!(recPvt = init_record_chk(&pai->inp, &status, str))) {
+        goto bail;
+    }
 
-	/* Break parm into node name and optional parameter */
-	node = strtok( pai->inp.value.camacio.parm, "+" );
-	if ( (p = strtok( NULL, "+" )) ) {
-		task = p;
-		if ( strcmp( task, "sens" ) ) { 
-			sprintf( str, "Unknown task parameter %s", task);
-			status = S_dev_badSignal;
-		}
-	}
+    /* Break parm into node name and optional parameter */
+    node = strtok(pai->inp.value.camacio.parm, "+");
+    if ((p = strtok(NULL, "+"))) {
+        task = p;
+        if (strcmp(task, "sens")) {
+            sprintf(str, "Unknown task parameter %s", task);
+            status = S_dev_badSignal;
+        }
+    }
 
-	if ( init_record_find( mch, recPvt, node, task, &status, str ) )
-		goto bail;
-	else
-		pai->dpvt = recPvt;
+    if (init_record_find(mch, recPvt, node, task, &status, str)) {
+        goto bail;
+    } else {
+        pai->dpvt = recPvt;
+    }
 
 bail:
-	if ( status ) {
-	       recGblRecordError( status, (void *)pai, (const char *)str );
-	       pai->pact=TRUE;
-	}
+    if (status) {
+        recGblRecordError(status, (void*)pai, (const char*)str);
+        pai->pact = TRUE;
+    }
 
-        return status;
+    return status;
 }
 
 /* Take advantage of regular read_ai calls
@@ -662,889 +622,882 @@ bail:
  * the live configuration. Thus read_ai does not check
  * that MCH_INIT_DONE is true, but other read routines do
  */
-static long 
-read_ai(struct aiRecord *pai)
-{
-MchRec   recPvt  = pai->dpvt;
-MchDev   mch;
-MchData  mchData;
-MchSess  mchSess;
-MchSys   mchSys;
-Sensor   sens;
-SdrFull  sdr;
-char     egu[16];
-uint8_t  data[MSG_MAX_LENGTH] = { 0 };
-uint8_t  raw = 0;
-short    index; /* Sensor index */
-int      s = 0, inst;
+static long read_ai(struct aiRecord* pai) {
+    MchRec  recPvt = pai->dpvt;
+    MchDev  mch;
+    MchData mchData;
+    MchSess mchSess;
+    MchSys  mchSys;
+    Sensor  sens;
+    SdrFull sdr;
+    char    egu[16];
+    uint8_t data[MSG_MAX_LENGTH] = {0};
+    uint8_t raw                  = 0;
+    short   index; /* Sensor index */
+    int     s = 0, inst;
 
-	if ( !recPvt )
-		return NO_CONVERT;
+    if (!recPvt) {
+        return NO_CONVERT;
+    }
 
-	mch     = recPvt->mch;
-	mchData = mch->udata;
-	mchSess = mchData->mchSess;
-	mchSys  = mchData->mchSys;
-	inst    = mchSess->instance;
+    mch     = recPvt->mch;
+    mchData = mch->udata;
+    mchSess = mchData->mchSess;
+    mchSys  = mchData->mchSys;
+    inst    = mchSess->instance;
 
-	if ( checkMchOnlnSess( mchSess ) ) {    
+    if (checkMchOnlnSess(mchSess)) {
 
-		epicsMutexLock( mch->mutex );
+        epicsMutexLock(mch->mutex);
 
-		/* If flag is set, check MCH configuration */
-		if ( MCH_CNFG_CHK( mchStat[inst] ) ) {
-			if ( mchCnfgChk( mchData ) ) {
-				epicsMutexUnlock( mch->mutex );
-				return ERROR;
-			}
-		}
-
-		if ( MCH_INIT_NOT_DONE( mchStat[inst] ) ) {
-			epicsMutexUnlock( mch->mutex );
-			return ERROR;
-		}
-
-		/* Check if sensor exists */
-		if ( -1 == (index = sensLkup( mchSys, pai->inp.value.camacio )) ) {
-       			epicsMutexUnlock( mch->mutex );
-			pai->udf = FALSE;
-			return NO_CONVERT;
-		}
-
-		sens = &mchSys->sens[index];
-
-		if ( mchGetSensorReadingStat( mchData, data, sens ) )
-			s = ERROR;
-		else
-			sens->val = raw = data[IPMI_RPLY_IMSG2_SENSOR_READING_OFFSET];
-	
-		epicsMutexUnlock( mch->mutex );
-
-		sdr = &sens->sdr;
-
-		/* Need to reconsider how to handle alarms if sensor scanning disabled */
-
-		if ( !sens->cnfg ) {
-			sensEgu( egu, sdr->units2 );
-			strcpy( pai->egu,  egu );
-			if ( sdr->str )
-				strcpy( pai->desc, sdr->str );
-
-			if ( sdr->recType == SDR_TYPE_FULL_SENSOR )
-				sensThresh( sdr, sens, &pai->lolo, &pai->llsv, &pai->low, &pai->lsv, 
-					    &pai->high, &pai->hsv, &pai->hihi, &pai->hhsv, pai->name );
-			sens->cnfg = 1;
-		}
-
-		if ( s ) {
-			if ( MCH_DBG( mchStat[inst] ) )
-				printf("%s writeread error sensor owner 0x%02x number %02x index %i\n", pai->name, sdr->owner, sdr->number, index);
-			goto bail;
-		}
-
-		/* All of our conversions are for Full Sensor SDRs */
-		if ( sdr->recType != SDR_TYPE_FULL_SENSOR )
-			pai->val = raw;
-		else
-			pai->val = sensorConversion( sdr, raw, pai->name );
-
-		if ( MCH_DBG( mchStat[inst] ) >= MCH_DBG_MED )
-			printf("%s read_ai: sensor index is %i, sensor number is %i, value is %.0f, rval is %i, raw is 0x%02x\n",
-			pai->name, index, sdr->number, pai->val, pai->rval, raw);
-
-		pai->udf = FALSE;
-		return NO_CONVERT;
-	}
-bail:
-	recGblSetSevr( pai, READ_ALARM, INVALID_ALARM );
-	return ERROR;
-}
-
-static long 
-init_bo_record(struct boRecord *pbo)
-{
-MchRec  recPvt  = 0; /* Info stored with record */
-MchDev  mch     = 0; /* MCH device data structures */
-char    *node;       /* Network node name, stored in parm */
-char    *task   = 0; /* Optional additional parameter appended to parm */
-char    *p;
-long    status  = SUCCESS;
-char    str[40];
-
-	if ( ! ( recPvt = init_record_chk( &pbo->out, &status, str )) )
-		goto bail;
-
-        /* Break parm into node name and optional parameter */
-        node = strtok( pbo->out.value.camacio.parm, "+" );
-        if ( (p = strtok( NULL, "+")) ) {
-                task = p;
-                if ( strcmp( task, "reset") && strcmp( task, "sess") && strcmp( task, "init") ) {
-			sprintf( str, "Unknown task parameter %s", task);
-			status = S_dev_badSignal;
-		}
+        /* If flag is set, check MCH configuration */
+        if (MCH_CNFG_CHK(mchStat[inst])) {
+            if (mchCnfgChk(mchData)) {
+                epicsMutexUnlock(mch->mutex);
+                return ERROR;
+            }
         }
 
-	if ( init_record_find( mch, recPvt, node, task, &status, str ) )
-		goto bail;
-	else
-		pbo->dpvt = recPvt;
+        if (MCH_INIT_NOT_DONE(mchStat[inst])) {
+            epicsMutexUnlock(mch->mutex);
+            return ERROR;
+        }
+
+        /* Check if sensor exists */
+        if (-1 == (index = sensLkup(mchSys, pai->inp.value.camacio))) {
+            epicsMutexUnlock(mch->mutex);
+            pai->udf = FALSE;
+            return NO_CONVERT;
+        }
+
+        sens = &mchSys->sens[index];
+
+        if (mchGetSensorReadingStat(mchData, data, sens)) {
+            s = ERROR;
+        } else {
+            sens->val = raw = data[IPMI_RPLY_IMSG2_SENSOR_READING_OFFSET];
+        }
+
+        epicsMutexUnlock(mch->mutex);
+
+        sdr = &sens->sdr;
+
+        /* Need to reconsider how to handle alarms if sensor scanning disabled */
+
+        if (!sens->cnfg) {
+            sensEgu(egu, sdr->units2);
+            strcpy(pai->egu, egu);
+            if (sdr->str) {
+                strcpy(pai->desc, sdr->str);
+            }
+
+            if (sdr->recType == SDR_TYPE_FULL_SENSOR) {
+                sensThresh(sdr, sens, &pai->lolo, &pai->llsv, &pai->low, &pai->lsv, &pai->high, &pai->hsv, &pai->hihi,
+                           &pai->hhsv, pai->name);
+            }
+            sens->cnfg = 1;
+        }
+
+        if (s) {
+            if (MCH_DBG(mchStat[inst])) {
+                printf("%s writeread error sensor owner 0x%02x number %02x index %i\n", pai->name, sdr->owner,
+                       sdr->number, index);
+            }
+            goto bail;
+        }
+
+        /* All of our conversions are for Full Sensor SDRs */
+        if (sdr->recType != SDR_TYPE_FULL_SENSOR) {
+            pai->val = raw;
+        } else {
+            pai->val = sensorConversion(sdr, raw, pai->name);
+        }
+
+        if (MCH_DBG(mchStat[inst]) >= MCH_DBG_MED) {
+            printf("%s read_ai: sensor index is %i, sensor number is %i, value is %.0f, rval is %i, raw is 0x%02x\n",
+                   pai->name, index, sdr->number, pai->val, pai->rval, raw);
+        }
+
+        pai->udf = FALSE;
+        return NO_CONVERT;
+    }
+bail:
+    recGblSetSevr(pai, READ_ALARM, INVALID_ALARM);
+    return ERROR;
+}
+
+static long init_bo_record(struct boRecord* pbo) {
+    MchRec recPvt = 0; /* Info stored with record */
+    MchDev mch    = 0; /* MCH device data structures */
+    char*  node;       /* Network node name, stored in parm */
+    char*  task = 0;   /* Optional additional parameter appended to parm */
+    char*  p;
+    long   status = SUCCESS;
+    char   str[40];
+
+    if (!(recPvt = init_record_chk(&pbo->out, &status, str))) {
+        goto bail;
+    }
+
+    /* Break parm into node name and optional parameter */
+    node = strtok(pbo->out.value.camacio.parm, "+");
+    if ((p = strtok(NULL, "+"))) {
+        task = p;
+        if (strcmp(task, "reset") && strcmp(task, "sess") && strcmp(task, "init")) {
+            sprintf(str, "Unknown task parameter %s", task);
+            status = S_dev_badSignal;
+        }
+    }
+
+    if (init_record_find(mch, recPvt, node, task, &status, str)) {
+        goto bail;
+    } else {
+        pbo->dpvt = recPvt;
+    }
 
 bail:
-	if ( status ) {
-	       recGblRecordError( status, (void *)pbo , (const char *)str );
-	       pbo->pact=TRUE;
-	}
+    if (status) {
+        recGblRecordError(status, (void*)pbo, (const char*)str);
+        pbo->pact = TRUE;
+    }
 
+    return status;
+}
+
+static long write_bo(struct boRecord* pbo) {
+    uint8_t data[MSG_MAX_LENGTH] = {0};
+    MchRec  recPvt               = pbo->dpvt;
+    MchDev  mch;
+    MchData mchData;
+    MchSess mchSess;
+    MchSys  mchSys;
+    char*   task;
+
+    if (!recPvt) {
+        return SUCCESS;
+    }
+
+    mch     = recPvt->mch;
+    mchData = mch->udata;
+    mchSess = mchData->mchSess;
+    mchSys  = mchData->mchSys;
+
+    task = recPvt->task;
+
+    if (checkMchOnln(mchSess)) {
+
+        if (!(strcmp(task, "sess"))) {
+
+            epicsMutexLock(mch->mutex);
+
+            if (pbo->val) {           /* could change this to be purely soft; session should time out */
+                mchSess->session = 1; /* Re-enable session */
+            } else {
+                mchSess->session = 0;
+                mchMsgCloseSess(mchSess, mchData->ipmiSess, data);
+            }
+
+            epicsMutexUnlock(mch->mutex);
+        }
+
+        else if (!(strcmp(task, "reset")) && mchSess->session) {
+
+            epicsMutexLock(mch->mutex);
+            ipmiMsgColdReset(mchSess, mchData->ipmiSess, data);
+            epicsMutexUnlock(mch->mutex);
+        }
+
+        else if (!(strcmp(task, "init")) && mchSess->session) {
+            mchStatSet(mchSess->instance, MCH_MASK_INIT, (pbo->val) ? MCH_MASK_INIT_DONE : MCH_MASK_INIT_NOT_DONE);
+        }
+
+        pbo->udf = FALSE;
+        return SUCCESS;
+    }
+    recGblSetSevr(pbo, WRITE_ALARM, INVALID_ALARM);
+    return ERROR;
+}
+
+static long init_bi(struct biRecord* pbi) {
+    scanIoInit(&drvMchStatScan);
+    return 0;
+}
+
+/*
+** Add this record to our IOSCANPVT list.
+*/
+static long bi_ioint_info(int cmd, struct biRecord* pbi, IOSCANPVT* iopvt) {
+    *iopvt = drvMchStatScan;
+    return 0;
+}
+
+static long init_bi_record(struct biRecord* pbi) {
+    MchRec recPvt = 0; /* Info stored with record */
+    MchDev mch    = 0; /* MCH device data structures */
+    char*  node;       /* Network node name, stored in parm */
+    char*  task = 0;   /* Optional additional parameter appended to parm */
+    char*  p;
+    long   status = SUCCESS;
+    char   str[40];
+
+    if (!(recPvt = init_record_chk(&pbi->inp, &status, str))) {
+        goto bail;
+    }
+
+    /* Break parm into node name and optional parameter */
+    node = strtok(pbi->inp.value.camacio.parm, "+");
+    if ((p = strtok(NULL, "+"))) {
+        task = p;
+        if (strcmp(task, "stat") && strcmp(task, "spres") && strcmp(task, "fpres")) {
+            sprintf(str, "Unknown task parameter %s", task);
+            status = S_dev_badSignal;
+        }
+    }
+
+    if (init_record_find(mch, recPvt, node, task, &status, str)) {
+        goto bail;
+    } else {
+        pbi->dpvt = recPvt;
+    }
+
+bail:
+    if (status) {
+        recGblRecordError(status, (void*)pbi, (const char*)str);
+        pbi->pact = TRUE;
+    }
+
+    return status;
+}
+
+static long read_bi(struct biRecord* pbi) {
+    MchRec  recPvt = pbi->dpvt;
+    MchDev  mch;
+    MchData mchData;
+    MchSess mchSess;
+    MchSys  mchSys;
+    char*   task;
+    long    status = SUCCESS;
+    short   index;
+
+    if (!recPvt) {
         return status;
+    }
+
+    mch     = recPvt->mch;
+    mchData = mch->udata;
+    mchSess = mchData->mchSess;
+    mchSys  = mchData->mchSys;
+
+    task = recPvt->task;
+
+    if (!(strcmp(task, "stat"))) {
+
+        pbi->rval = checkMchOnln(mchSess);
+    }
+
+    else if (checkMchInitDone(mchSess)) {
+
+        if (!(strcmp(task, "spres"))) {
+
+            index     = sensLkup(mchSys, pbi->inp.value.camacio);
+            pbi->rval = (-1 == index) ? 0 : 1;
+        }
+
+        else if (!(strcmp(task, "fpres"))) {
+
+            index     = fruLkup(mchSys, pbi->inp.value.camacio);
+            pbi->rval = (-1 == index) ? 0 : 1;
+        }
+    }
+    return status;
 }
 
-static long 
-write_bo(struct boRecord *pbo)
-{
-uint8_t  data[MSG_MAX_LENGTH] = { 0 };
-MchRec   recPvt = pbo->dpvt;
-MchDev   mch;
-MchData  mchData;
-MchSess  mchSess;
-MchSys   mchSys;
-char    *task;
-
-	if ( !recPvt )
-		return SUCCESS;
-
-	mch     = recPvt->mch;
-	mchData = mch->udata;
-	mchSess = mchData->mchSess;
-	mchSys  = mchData->mchSys;
-
-	task    = recPvt->task;
-
-	if (  checkMchOnln( mchSess ) ) {
-
-		if ( !(strcmp( task, "sess" )) ) {
-
-			epicsMutexLock( mch->mutex );
-
-			if ( pbo->val ) /* could change this to be purely soft; session should time out */
-				mchSess->session = 1; /* Re-enable session */
-			else {
-				mchSess->session = 0;
-				mchMsgCloseSess( mchSess, mchData->ipmiSess, data );
-			}
-			
-			epicsMutexUnlock( mch->mutex );
-		}
-
-		else if ( !(strcmp( task, "reset" )) && mchSess->session ) {
-
-			epicsMutexLock( mch->mutex );
-		       	ipmiMsgColdReset( mchSess, mchData->ipmiSess, data );
-			epicsMutexUnlock( mch->mutex );
-		}
-
-		else if ( !(strcmp( task, "init" )) && mchSess->session )
-			mchStatSet( mchSess->instance, MCH_MASK_INIT, (pbo->val) ? MCH_MASK_INIT_DONE : MCH_MASK_INIT_NOT_DONE );
-
-		pbo->udf = FALSE;
-		return SUCCESS;
-	}
-	recGblSetSevr( pbo, WRITE_ALARM, INVALID_ALARM );
-	return ERROR;
-}
-
-static long
-init_bi(struct biRecord *pbi)
-{
-	scanIoInit( &drvMchStatScan );
-	return 0;
+static long init_mbbi(struct mbbiRecord* pmbbi) {
+    scanIoInit(&drvMchInitScan);
+    return 0;
 }
 
 /*
 ** Add this record to our IOSCANPVT list.
 */
-static long 
-bi_ioint_info(int cmd, struct biRecord *pbi, IOSCANPVT *iopvt)
-{
-       *iopvt = drvMchStatScan;
-       return 0;
-} 
+static long mbbi_ioint_info(int cmd, struct mbbiRecord* pmbbi, IOSCANPVT* iopvt) {
+    *iopvt = drvMchInitScan;
+    return 0;
+}
 
-static long 
-init_bi_record(struct biRecord *pbi)
-{
-MchRec  recPvt  = 0; /* Info stored with record */
-MchDev  mch     = 0; /* MCH device data structures */
-char    *node;       /* Network node name, stored in parm */
-char    *task   = 0; /* Optional additional parameter appended to parm */
-char    *p;
-long     status = SUCCESS;
-char     str[40];
+static long init_mbbi_record(struct mbbiRecord* pmbbi) {
+    MchRec  recPvt = 0; /* Info stored with record */
+    MchDev  mch    = 0; /* MCH device data structures */
+    char*   node;       /* Network node name, stored in parm */
+    char*   task = 0;   /* Optional additional parameter appended to parm */
+    char*   p;
+    long    status = SUCCESS;
+    char    str[40];
+    DBLINK* plink = &pmbbi->inp;
 
-	if ( ! ( recPvt = init_record_chk( &pbi->inp, &status, str )) )
-		goto bail;
+    if (!(recPvt = init_record_chk(plink, &status, str))) {
+        goto bail;
+    }
 
-        /* Break parm into node name and optional parameter */
-        node = strtok( pbi->inp.value.camacio.parm, "+" );
-        if ( (p = strtok( NULL, "+")) ) {
-                task = p;
-                if ( strcmp( task, "stat" ) && strcmp( task, "spres") && strcmp( task, "fpres") ) {
-			sprintf( str, "Unknown task parameter %s", task);
-			status = S_dev_badSignal;
-		}
+    /* Break parm into node name and optional parameter */
+    node = strtok(pmbbi->inp.value.camacio.parm, "+");
+    if ((p = strtok(NULL, "+"))) {
+        task = p;
+        if (strcmp(task, "hs") && strcmp(task, "fan") && strcmp(task, "init") && strcmp(task, "pwr") &&
+            strcmp(task, "mch")) {
+            sprintf(str, "Unknown task parameter %s", task);
+            status = S_dev_badSignal;
+        }
+    }
+
+    if (init_record_find(mch, recPvt, node, task, &status, str)) {
+        goto bail;
+    } else {
+        pmbbi->dpvt = recPvt;
+    }
+bail:
+    if (status) {
+        recGblRecordError(status, (void*)pmbbi, (const char*)str);
+        pmbbi->pact = TRUE;
+    }
+
+    return status;
+}
+
+static long read_mbbi(struct mbbiRecord* pmbbi) {
+    uint8_t data[MSG_MAX_LENGTH] = {0};
+    MchRec  recPvt               = pmbbi->dpvt;
+    MchDev  mch;
+    MchData mchData;
+    MchSess mchSess;
+    MchSys  mchSys;
+    char*   task;
+    Fru     fru;
+    Sensor  sens;
+    uint8_t value = 0;
+    short   findex, sindex; /* FRU and Sensor index */
+    long    status = SUCCESS;
+    int     s      = 0, inst;
+
+    if (!recPvt) {
+        return status;
+    }
+
+    mch     = recPvt->mch;
+    mchData = mch->udata;
+    mchSess = mchData->mchSess;
+    mchSys  = mchData->mchSys;
+    inst    = mchSess->instance;
+    task    = recPvt->task;
+
+    /* Read initialized status */
+    if (!(strcmp(task, "init"))) {
+        pmbbi->rval = mchStat[inst] & MCH_MASK_INIT;
+    }
+
+    else if (task && checkMchInitDone(mchSess)) {
+
+        if (!(strcmp(task, "fan"))) {
+
+            if (-1 == (findex = fruLkup(mchSys, pmbbi->inp.value.camacio))) {
+                return ERROR;
+            }
+            fru = &mchSys->fru[findex];
+
+            pmbbi->rval = (fru->fanProp & (1 << 7)) ? 1 : 0;
         }
 
-	if ( init_record_find( mch, recPvt, node, task, &status, str ) )
-		goto bail;
-	else
-		pbi->dpvt = recPvt;
+        else if (!(strcmp(task, "pwr"))) {
 
-bail:
-	if ( status ) {
-	       recGblRecordError( status, (void *)pbi , (const char *)str );
-	       pbi->pact=TRUE;
-	}
+            if (-1 == (findex = fruLkup(mchSys, pmbbi->inp.value.camacio))) {
+                return ERROR;
+            }
+            fru = &mchSys->fru[findex];
 
-	return status;
-}
-
-static long 
-read_bi(struct biRecord *pbi)
-{
-MchRec   recPvt = pbi->dpvt;
-MchDev   mch;
-MchData  mchData;
-MchSess  mchSess;
-MchSys   mchSys;
-char    *task;
-long     status = SUCCESS;
-short    index;
-
-	if ( !recPvt )
-		return status;
-
-	mch     = recPvt->mch;
-	mchData = mch->udata;
-	mchSess = mchData->mchSess;
-	mchSys  = mchData->mchSys;
-
-	task    = recPvt->task;
-
-       	if ( !(strcmp( task, "stat" )) )
-
-       		pbi->rval = checkMchOnln( mchSess );
-
-	else if ( checkMchInitDone( mchSess ) ) {
-
-		if ( !(strcmp( task, "spres")) ) {
-
-			index     = sensLkup( mchSys, pbi->inp.value.camacio );
-			pbi->rval = ( -1 == index ) ? 0 : 1;
-		}
-
-		else if ( !(strcmp( task, "fpres")) ) {
-
-			index     = fruLkup( mchSys, pbi->inp.value.camacio );
-			pbi->rval = ( -1 == index ) ? 0 : 1;
-		}
-	}
-	return status;
-}
-
-static long
-init_mbbi(struct mbbiRecord *pmbbi)
-{
-	scanIoInit( &drvMchInitScan );
-	return 0;
-}
-
-/*
-** Add this record to our IOSCANPVT list.
-*/
-static long 
-mbbi_ioint_info(int cmd, struct mbbiRecord *pmbbi, IOSCANPVT *iopvt)
-{
-       *iopvt = drvMchInitScan;
-       return 0;
-} 
-
-static long 
-init_mbbi_record(struct mbbiRecord *pmbbi)
-{
-MchRec  recPvt  = 0; /* Info stored with record */
-MchDev  mch     = 0; /* MCH device data structures */
-char    *node;       /* Network node name, stored in parm */
-char    *task   = 0; /* Optional additional parameter appended to parm */
-char    *p;
-long     status = SUCCESS;
-char     str[40];
-DBLINK  *plink  = &pmbbi->inp;
-
-	if ( ! ( recPvt = init_record_chk( plink, &status, str )) )
-		goto bail;
-
-        /* Break parm into node name and optional parameter */
-        node = strtok( pmbbi->inp.value.camacio.parm, "+" );
-        if ( (p = strtok( NULL, "+")) ) {
-                task = p;
-                if ( strcmp( task, "hs") && strcmp( task, "fan") && strcmp( task, "init" ) 
-		    && strcmp( task, "pwr") && strcmp( task, "mch" ) ) {
-			sprintf( str, "Unknown task parameter %s", task);
-			status = S_dev_badSignal;
-		}
+            pmbbi->rval = fru->pwrDyn;
         }
 
-	if ( init_record_find( mch, recPvt, node, task, &status, str ) )
-		goto bail;
-	else
-		pmbbi->dpvt = recPvt;
-bail:
-	if ( status ) {
-	       recGblRecordError( status, (void *)pmbbi , (const char *)str );
-	       pmbbi->pact=TRUE;
-	}
+        else if (!(strcmp(task, "mch"))) {
 
-	return status;
-}
+            pmbbi->rval = mchSess->type;
+        }
 
-static long 
-read_mbbi(struct mbbiRecord *pmbbi)
-{
-uint8_t  data[MSG_MAX_LENGTH] = { 0 };
-MchRec   recPvt = pmbbi->dpvt;
-MchDev   mch;
-MchData  mchData;
-MchSess  mchSess;
-MchSys   mchSys;
-char    *task;
-Fru      fru;
-Sensor   sens;
-uint8_t  value  = 0;
-short    findex, sindex; /* FRU and Sensor index */
-long     status = SUCCESS;
-int      s = 0, inst;
+        else if (!(strcmp(task, "hs")) && checkMchOnlnSess(mchSess)) {
 
-	if ( !recPvt )
-		return status;
+            if (-1 == (sindex = sensLkup(mchSys, pmbbi->inp.value.camacio))) {
+                pmbbi->rval = 0x100; /* default state */
+                /* return 0 here rather than ERROR so we can provide "Not Available" */
+                return 0;
+            }
 
-	mch     = recPvt->mch;
-	mchData = mch->udata;
-	mchSess = mchData->mchSess;
-	mchSys  = mchData->mchSys;
-	inst    = mchSess->instance;
-	task    = recPvt->task;
+            sens = &mchSys->sens[sindex];
+            /* possibly add this later
+            int readoffset;
+                        if ( SENSOR_NUMERIC_FORMAT( mchSys->sens[sindex].sdr.units1) == SENSOR_NUMERIC_FORMAT_NONNUMERIC
+            ) readoffset = IPMI_RPLY_DISCRETE_SENSOR_READING_OFFSET;
+            */
+            epicsMutexLock(mch->mutex);
 
-	/* Read initialized status */
-       	if ( !(strcmp( task, "init" )) )
-       		pmbbi->rval = mchStat[inst] & MCH_MASK_INIT;
+            if (mchGetSensorReadingStat(mchData, data, sens)) {
+                s = ERROR;
+            } else {
+                sens->val = value = data[IPMI_RPLY_IMSG2_DISCRETE_SENSOR_READING_OFFSET];
 
-	else if ( task && checkMchInitDone( mchSess ) ) {
+                if (MCH_DBG(mchStat[inst]) >= MCH_DBG_MED) {
+                    printf("%s read_mbbi: value %02x, sensor %i, owner %i, lun %i, index %i, value %i\n", pmbbi->name,
+                           value, mchSys->sens[sindex].sdr.number, mchSys->sens[sindex].sdr.owner,
+                           mchSys->sens[sindex].sdr.lun, sindex, value);
+                }
+            }
 
-		if ( !(strcmp( task, "fan" )) ) {
+            epicsMutexUnlock(mch->mutex);
 
-			if ( -1 == (findex = fruLkup( mchSys, pmbbi->inp.value.camacio )) )
-				return ERROR;
-			fru = &mchSys->fru[findex];
+            if (s) {
+                recGblSetSevr(pmbbi, READ_ALARM, INVALID_ALARM);
+                return ERROR;
+            }
 
-			pmbbi->rval = ( fru->fanProp & (1<<7) ) ? 1 : 0;
-		}
+            pmbbi->rval = value;
+        }
+    }
 
-		else if ( !(strcmp( task, "pwr" )) ) {
-
-			if ( -1 == (findex = fruLkup( mchSys, pmbbi->inp.value.camacio )) )
-				return ERROR;
-			fru = &mchSys->fru[findex];
-
-			pmbbi->rval = fru->pwrDyn;
-		}
-
-		else if ( !(strcmp( task, "mch" )) ) {
-
-			pmbbi->rval = mchSess->type;
-		}
-
-		else if ( !(strcmp( task, "hs")) && checkMchOnlnSess( mchSess ) ) {
-
-			if ( -1 == (sindex = sensLkup( mchSys, pmbbi->inp.value.camacio )) ) {
-				pmbbi->rval = 0x100; /* default state */
-				/* return 0 here rather than ERROR so we can provide "Not Available" */
-				return 0;
-			}
-
-			sens = &mchSys->sens[sindex];
-/* possibly add this later
-int readoffset;
-			if ( SENSOR_NUMERIC_FORMAT( mchSys->sens[sindex].sdr.units1) == SENSOR_NUMERIC_FORMAT_NONNUMERIC )
-				readoffset = IPMI_RPLY_DISCRETE_SENSOR_READING_OFFSET;
-*/
-			epicsMutexLock( mch->mutex );
-
-			if ( mchGetSensorReadingStat( mchData, data, sens ) )
-				s = ERROR;
-			else {
-				sens->val = value = data[IPMI_RPLY_IMSG2_DISCRETE_SENSOR_READING_OFFSET];
-
-				if ( MCH_DBG( mchStat[inst] ) >= MCH_DBG_MED )
-					printf("%s read_mbbi: value %02x, sensor %i, owner %i, lun %i, index %i, value %i\n",
-						pmbbi->name, value, mchSys->sens[sindex].sdr.number, mchSys->sens[sindex].sdr.owner, mchSys->sens[sindex].sdr.lun, sindex, value);
-			}
-
-			epicsMutexUnlock( mch->mutex );
-
-			if ( s ) {
-				recGblSetSevr( pmbbi, READ_ALARM, INVALID_ALARM );
-				return ERROR;
-			}
-
-			pmbbi->rval = value;
-		}	
-	}
-
-	pmbbi->udf = FALSE;
-	return status;
+    pmbbi->udf = FALSE;
+    return status;
 }
 
 /* Create the dset for mbbo support */
 
-static long 
-init_mbbo_record(struct mbboRecord *pmbbo)
-{
-MchRec  recPvt  = 0; /* Info stored with record */
-MchDev  mch     = 0; /* MCH device data structures */
-char    *node;       /* Network node name, stored in parm */
-char    *task   = 0; /* Optional additional parameter appended to parm */
-char    *p;
-long     status = SUCCESS;
-char     str[40];
+static long init_mbbo_record(struct mbboRecord* pmbbo) {
+    MchRec recPvt = 0; /* Info stored with record */
+    MchDev mch    = 0; /* MCH device data structures */
+    char*  node;       /* Network node name, stored in parm */
+    char*  task = 0;   /* Optional additional parameter appended to parm */
+    char*  p;
+    long   status = SUCCESS;
+    char   str[40];
 
-	if ( ! ( recPvt = init_record_chk( &pmbbo->out, &status, str )) )
-		goto bail;
+    if (!(recPvt = init_record_chk(&pmbbo->out, &status, str))) {
+        goto bail;
+    }
 
-        /* Break parm into node name and optional parameter */
-        node = strtok( pmbbo->out.value.camacio.parm, "+" );
-        if ( (p = strtok( NULL, "+")) ) {
-                task = p;
-                if ( strcmp( task, "chas" ) && strcmp( task, "fru") && strcmp( task, "dbg") && strcmp( task, "scan" ) ) { 
-			sprintf( str, "Unknown task parameter %s", task);
-			status = S_dev_badSignal;
-		}
+    /* Break parm into node name and optional parameter */
+    node = strtok(pmbbo->out.value.camacio.parm, "+");
+    if ((p = strtok(NULL, "+"))) {
+        task = p;
+        if (strcmp(task, "chas") && strcmp(task, "fru") && strcmp(task, "dbg") && strcmp(task, "scan")) {
+            sprintf(str, "Unknown task parameter %s", task);
+            status = S_dev_badSignal;
+        }
+    }
+
+    if (init_record_find(mch, recPvt, node, task, &status, str)) {
+        goto bail;
+    } else {
+        pmbbo->dpvt = recPvt;
+    }
+bail:
+    if (status) {
+        recGblRecordError(status, (void*)pmbbo, (const char*)str);
+        pmbbo->pact = TRUE;
+    }
+
+    return status;
+}
+
+static long write_mbbo(struct mbboRecord* pmbbo) {
+    uint8_t data[MSG_MAX_LENGTH] = {0};
+    MchRec  recPvt               = pmbbo->dpvt;
+    MchDev  mch;
+    MchData mchData;
+    MchSess mchSess;
+    MchSys  mchSys;
+    char*   task;
+    Fru     fru;
+    long    status = SUCCESS;
+    int     cmd;
+    short   index;
+    int     inst;
+
+    if (!recPvt) {
+        return status;
+    }
+
+    mch     = recPvt->mch;
+    mchData = mch->udata;
+    mchSess = mchData->mchSess;
+    mchSys  = mchData->mchSys;
+    inst    = mchSess->instance;
+
+    task = recPvt->task;
+
+    if (!(strcmp(task, "dbg"))) {
+        mchStatSet(inst, MCH_MASK_DBG, MCH_DBG_SET(pmbbo->val));
+        printf("%s Setting debug message verbosity to %i\n", mchSess->name, pmbbo->val);
+        pmbbo->udf = FALSE;
+        return status;
+    } else if (!(strcmp(task, "scan"))) {
+        mchSensorScanPeriod = SENSOR_SCAN_PERIODS[pmbbo->val];
+        printf("%s Setting sensor scan period to %i seconds\n", mchSess->name, SENSOR_SCAN_PERIODS[pmbbo->val]);
+        pmbbo->udf = FALSE;
+        return status;
+    } else if (checkMchOnlnSess(mchSess)) {
+
+        if (!(strcmp(task, "chas"))) {
+
+            if (MCH_DBG(mchStat[inst]) >= MCH_DBG_MED) {
+                printf("write_mbbo: call mchMsgChassisControl with value %i\n", pmbbo->val);
+            }
+
+            epicsMutexLock(mch->mutex);
+            status = mchMsgChassisControl(mchData, data, pmbbo->val);
+            epicsMutexUnlock(mch->mutex);
+        } else if (!(strcmp(task, "fru"))) {
+
+            if (-1 == (index = fruLkup(mchSys, pmbbo->out.value.camacio))) {
+                return ERROR;
+            }
+
+            fru = &mchSys->fru[index];
+
+            if (pmbbo->val > 1) { /* reset not supported yet */
+                recGblSetSevr(pmbbo, STATE_ALARM, MAJOR_ALARM);
+                return ERROR;
+            }
+
+            cmd = (pmbbo->val == 2) ? 0 : pmbbo->val;
+
+            epicsMutexLock(mch->mutex);
+            if (mchData->mchSys->mchcb->set_fru_act) {
+                status = mchData->mchSys->mchcb->set_fru_act(mchData, data, index, cmd);
+            } else {
+                status = -1;
+            }
+            epicsMutexUnlock(mch->mutex);
         }
 
-	if ( init_record_find( mch, recPvt, node, task, &status, str ) )
-		goto bail;
-	else
-		pmbbo->dpvt = recPvt;
-bail:
-	if ( status ) {
-	       recGblRecordError( status, (void *)pmbbo , (const char *)str );
-	       pmbbo->pact=TRUE;
-	}
+        if (status) {
+            recGblSetSevr(pmbbo, WRITE_ALARM, INVALID_ALARM);
+            return ERROR;
+        }
 
-	return status;
-}
-
-static long 
-write_mbbo(struct mbboRecord *pmbbo)
-{
-uint8_t  data[MSG_MAX_LENGTH] = { 0 };
-MchRec   recPvt = pmbbo->dpvt;
-MchDev   mch;
-MchData  mchData;
-MchSess  mchSess;
-MchSys   mchSys;
-char    *task;
-Fru      fru;
-long     status = SUCCESS;
-int      cmd;
-short    index; 
-int      inst;
-
-	if ( !recPvt )
-		return status;
-
-	mch     = recPvt->mch;
-	mchData = mch->udata;
-	mchSess = mchData->mchSess;
-	mchSys  = mchData->mchSys;
-	inst    = mchSess->instance;
-
-	task    = recPvt->task;
-
-	if ( !(strcmp( task, "dbg" )) ) {
-       		mchStatSet( inst, MCH_MASK_DBG, MCH_DBG_SET(pmbbo->val) );
-       		printf("%s Setting debug message verbosity to %i\n", mchSess->name, pmbbo->val);
-		pmbbo->udf = FALSE;
-		return status;
-	}
-	else if ( !(strcmp( task, "scan" )) ) {
-		mchSensorScanPeriod = SENSOR_SCAN_PERIODS[pmbbo->val];
-       		printf("%s Setting sensor scan period to %i seconds\n", mchSess->name, SENSOR_SCAN_PERIODS[pmbbo->val] );
-		pmbbo->udf = FALSE;
-		return status;
-	}
-	else if ( checkMchOnlnSess( mchSess ) ) {
-
-		if ( !(strcmp( task, "chas" )) ) {
-
-			if ( MCH_DBG( mchStat[inst] ) >= MCH_DBG_MED )
-				printf("write_mbbo: call mchMsgChassisControl with value %i\n", pmbbo->val); 
-
-			epicsMutexLock( mch->mutex );
-			status = mchMsgChassisControl( mchData, data, pmbbo->val );
-			epicsMutexUnlock( mch->mutex );
-		}
-		else if ( !(strcmp( task, "fru" )) ) {
-
-			if ( -1 == (index = fruLkup( mchSys, pmbbo->out.value.camacio )) )
-				return ERROR;
-
-			fru = &mchSys->fru[index];
-
-			if ( pmbbo->val > 1 ) { /* reset not supported yet */
-				recGblSetSevr( pmbbo, STATE_ALARM, MAJOR_ALARM );
-				return ERROR;
-			}
-
-			cmd = ( pmbbo->val == 2 ) ? 0 : pmbbo->val; 
-
-			epicsMutexLock( mch->mutex );
-			if ( mchData->mchSys->mchcb->set_fru_act )        
-				status = mchData->mchSys->mchcb->set_fru_act( mchData, data, index, cmd );
-			else
-				status = -1;
-			epicsMutexUnlock( mch->mutex );
-		}
-
-
-		if ( status ) {
-			recGblSetSevr( pmbbo, WRITE_ALARM, INVALID_ALARM );
-			return ERROR;
-		}
-
-		pmbbo->udf = FALSE;
-
-		return status;
-
-	}
-	else {
-		recGblSetSevr( pmbbo, WRITE_ALARM, INVALID_ALARM );
-		return ERROR;
-	}
-}
-
-static long 
-init_longin_record(struct longinRecord *plongin)
-{
-MchRec   recPvt  = 0; /* Info stored with record */
-MchDev   mch     = 0; /* MCH device data structures */
-char    *node    = 0; /* Network node name, stored in parm */
-char    *task    = 0; /* Optional additional parameter appended to parm */
-char    *p;
-long     status  = SUCCESS;
-char     str[40];
-
-	if ( ! ( recPvt = init_record_chk( &plongin->inp, &status, str )) )
-		goto bail;
-
-	/* Break parm into node name and optional parameter */
-	node = strtok( plongin->inp.value.camacio.parm, "+" );
-	if ( (p = strtok( NULL, "+" )) ) {
-		task = p;
-		if ( strcmp( task, "chas" ) ) { 
-			sprintf( str, "Unknown task parameter %s", task);
-			status = S_dev_badSignal;
-		}
-	}
-
-	if ( init_record_find( mch, recPvt, node, task, &status, str ) )
-		goto bail;
-	else
-		plongin->dpvt = recPvt;
-
-bail:
-	if ( status ) {
-	       recGblRecordError( status, (void *)plongin, (const char *)str );
-	       plongin->pact=TRUE;
-	}
+        pmbbo->udf = FALSE;
 
         return status;
+    } else {
+        recGblSetSevr(pmbbo, WRITE_ALARM, INVALID_ALARM);
+        return ERROR;
+    }
 }
 
-static long 
-read_longin(struct longinRecord *plongin)
-{
-MchRec   recPvt  = plongin->dpvt;
-MchDev   mch;
-MchData  mchData;
-MchSess  mchSess;
-uint8_t  data[MSG_MAX_LENGTH] = { 0 };
-int      inst;
+static long init_longin_record(struct longinRecord* plongin) {
+    MchRec recPvt = 0; /* Info stored with record */
+    MchDev mch    = 0; /* MCH device data structures */
+    char*  node   = 0; /* Network node name, stored in parm */
+    char*  task   = 0; /* Optional additional parameter appended to parm */
+    char*  p;
+    long   status = SUCCESS;
+    char   str[40];
 
-	if ( !recPvt )
-		return SUCCESS;
+    if (!(recPvt = init_record_chk(&plongin->inp, &status, str))) {
+        goto bail;
+    }
 
-	mch     = recPvt->mch;
-	mchData = mch->udata;
-	mchSess = mchData->mchSess;
-	inst    = mchSess->instance;
+    /* Break parm into node name and optional parameter */
+    node = strtok(plongin->inp.value.camacio.parm, "+");
+    if ((p = strtok(NULL, "+"))) {
+        task = p;
+        if (strcmp(task, "chas")) {
+            sprintf(str, "Unknown task parameter %s", task);
+            status = S_dev_badSignal;
+        }
+    }
 
-	if ( checkMchOnlnSessInitDone( mchSess ) ) {
-
-		epicsMutexLock( mch->mutex );
-
-		if ( mchData->mchSys->mchcb->get_chassis_status ) {
-
-			if ( mchData->mchSys->mchcb->get_chassis_status( mchData, data ) ) {
-				epicsMutexUnlock( mch->mutex );
-				goto bail;
-			}
-			else {
-				plongin->val = IPMI_GET_CHAS_POWER_STATE( data[IPMI_RPLY_IMSG2_GET_CHAS_POWER_STATE_OFFSET] ) | 
-					(IPMI_GET_CHAS_LAST_EVENT( data[IPMI_RPLY_IMSG2_GET_CHAS_LAST_EVENT_OFFSET]) << 8) | 
-					(IPMI_GET_CHAS_MISC_STATE( data[IPMI_RPLY_IMSG2_GET_CHAS_MISC_STATE_OFFSET]) << 16);
-					/* Or 'last event' and 'misc' bits into power state word */
-
-				if ( MCH_DBG( mchStat[inst] ) >= MCH_DBG_MED )
-					printf("%s read_longin: val %i, power state %i last event %i misc state %i\n", plongin->name, plongin->val, 
-					IPMI_GET_CHAS_POWER_STATE( data[IPMI_RPLY_IMSG2_GET_CHAS_POWER_STATE_OFFSET] ), 
-					IPMI_GET_CHAS_LAST_EVENT( data[IPMI_RPLY_IMSG2_GET_CHAS_LAST_EVENT_OFFSET] ), 
-					IPMI_GET_CHAS_MISC_STATE( data[IPMI_RPLY_IMSG2_GET_CHAS_MISC_STATE_OFFSET] ));
-
-				epicsMutexUnlock( mch->mutex );
-				plongin->udf = FALSE;
-				return SUCCESS;
-			}
-		}
-		else
-			goto bail;
-	}
+    if (init_record_find(mch, recPvt, node, task, &status, str)) {
+        goto bail;
+    } else {
+        plongin->dpvt = recPvt;
+    }
 
 bail:
-	recGblSetSevr( plongin, READ_ALARM, INVALID_ALARM );
-	return ERROR;
+    if (status) {
+        recGblRecordError(status, (void*)plongin, (const char*)str);
+        plongin->pact = TRUE;
+    }
+
+    return status;
 }
 
-/* 
+static long read_longin(struct longinRecord* plongin) {
+    MchRec  recPvt = plongin->dpvt;
+    MchDev  mch;
+    MchData mchData;
+    MchSess mchSess;
+    uint8_t data[MSG_MAX_LENGTH] = {0};
+    int     inst;
+
+    if (!recPvt) {
+        return SUCCESS;
+    }
+
+    mch     = recPvt->mch;
+    mchData = mch->udata;
+    mchSess = mchData->mchSess;
+    inst    = mchSess->instance;
+
+    if (checkMchOnlnSessInitDone(mchSess)) {
+
+        epicsMutexLock(mch->mutex);
+
+        if (mchData->mchSys->mchcb->get_chassis_status) {
+
+            if (mchData->mchSys->mchcb->get_chassis_status(mchData, data)) {
+                epicsMutexUnlock(mch->mutex);
+                goto bail;
+            } else {
+                plongin->val = IPMI_GET_CHAS_POWER_STATE(data[IPMI_RPLY_IMSG2_GET_CHAS_POWER_STATE_OFFSET]) |
+                               (IPMI_GET_CHAS_LAST_EVENT(data[IPMI_RPLY_IMSG2_GET_CHAS_LAST_EVENT_OFFSET]) << 8) |
+                               (IPMI_GET_CHAS_MISC_STATE(data[IPMI_RPLY_IMSG2_GET_CHAS_MISC_STATE_OFFSET]) << 16);
+                /* Or 'last event' and 'misc' bits into power state word */
+
+                if (MCH_DBG(mchStat[inst]) >= MCH_DBG_MED) {
+                    printf("%s read_longin: val %i, power state %i last event %i misc state %i\n", plongin->name,
+                           plongin->val, IPMI_GET_CHAS_POWER_STATE(data[IPMI_RPLY_IMSG2_GET_CHAS_POWER_STATE_OFFSET]),
+                           IPMI_GET_CHAS_LAST_EVENT(data[IPMI_RPLY_IMSG2_GET_CHAS_LAST_EVENT_OFFSET]),
+                           IPMI_GET_CHAS_MISC_STATE(data[IPMI_RPLY_IMSG2_GET_CHAS_MISC_STATE_OFFSET]));
+                }
+
+                epicsMutexUnlock(mch->mutex);
+                plongin->udf = FALSE;
+                return SUCCESS;
+            }
+        } else {
+            goto bail;
+        }
+    }
+
+bail:
+    recGblSetSevr(plongin, READ_ALARM, INVALID_ALARM);
+    return ERROR;
+}
+
+/*
  * Device support to read FRU data
  */
-static long
-init_fru_ai(struct aiRecord *pai)
-{
-	scanIoInit( &drvMchFruScan );
-	return 0;
+static long init_fru_ai(struct aiRecord* pai) {
+    scanIoInit(&drvMchFruScan);
+    return 0;
 }
 
 /*
 ** Add this record to our IOSCANPVT list
- */
-static long 
-ai_fru_ioint_info(int cmd, struct aiRecord *pai, IOSCANPVT *iopvt)
-{
-       *iopvt = drvMchFruScan;
-       return 0;
-} 
-
-static long 
-init_fru_ai_record(struct aiRecord *pai)
-{
-MchRec  recPvt  = 0; /* Info stored with record */
-MchDev  mch     = 0; /* MCH device data structures */
-char   *node;        /* Network node name, stored in parm */
-char   *task    = 0; /* Optional additional parameter appended to parm */
-char   *p;
-long    status  = SUCCESS;
-char    str[40];
-
-	if ( ! ( recPvt = init_record_chk( &pai->inp, &status, str )) )
-		goto bail;
-
-	/* Break parm into node name and optional parameter */
-	node = strtok( pai->inp.value.camacio.parm, "+" );
-	if ( (p = strtok( NULL, "+" )) ) {
-		task = p;
-		if ( strcmp( task, "type" ) && strcmp( task, "fan") && strcmp( task, "pwr")  ) {
-			sprintf( str, "Unknown task parameter %s", task);
-			status = S_dev_badSignal;
-		}
-	}
-
-	if ( init_record_find( mch, recPvt, node, task, &status, str ) )
-		goto bail;
-	else
-		pai->dpvt = recPvt;
-
-bail:
-	if ( status ) {
-	       recGblRecordError( status, (void *)pai , (const char *)str );
-	       pai->pact=TRUE;
-	}
-
-	return status;
+*/
+static long ai_fru_ioint_info(int cmd, struct aiRecord* pai, IOSCANPVT* iopvt) {
+    *iopvt = drvMchFruScan;
+    return 0;
 }
 
-static long 
-read_fru_ai(struct aiRecord *pai)
-{
-uint8_t  data[MSG_MAX_LENGTH] = { 0 };
-MchRec   recPvt  = pai->dpvt;
-MchDev   mch;
-MchData  mchData;
-MchSess  mchSess;
-MchSys   mchSys;
-char    *task;
-short    index;
-int      id     = pai->inp.value.camacio.b;
-int      parm   = pai->inp.value.camacio.c;
-long     status = NO_CONVERT;
-Fru      fru;
-int      s = 0, inst;
-uint8_t  prop, level, draw, mult;
+static long init_fru_ai_record(struct aiRecord* pai) {
+    MchRec recPvt = 0; /* Info stored with record */
+    MchDev mch    = 0; /* MCH device data structures */
+    char*  node;       /* Network node name, stored in parm */
+    char*  task = 0;   /* Optional additional parameter appended to parm */
+    char*  p;
+    long   status = SUCCESS;
+    char   str[40];
 
-	if ( !recPvt )
-		return status;
+    if (!(recPvt = init_record_chk(&pai->inp, &status, str))) {
+        goto bail;
+    }
 
-	mch     = recPvt->mch;
-	mchData = mch->udata;
-	mchSess = mchData->mchSess;
-	mchSys  = mchData->mchSys;
+    /* Break parm into node name and optional parameter */
+    node = strtok(pai->inp.value.camacio.parm, "+");
+    if ((p = strtok(NULL, "+"))) {
+        task = p;
+        if (strcmp(task, "type") && strcmp(task, "fan") && strcmp(task, "pwr")) {
+            sprintf(str, "Unknown task parameter %s", task);
+            status = S_dev_badSignal;
+        }
+    }
 
-	if ( -1 == (index = fruLkup( mchSys, pai->inp.value.camacio )) )
-		return ERROR;
+    if (init_record_find(mch, recPvt, node, task, &status, str)) {
+        goto bail;
+    } else {
+        pai->dpvt = recPvt;
+    }
 
-	inst = mchSess->instance;
-	task = recPvt->task;
-	fru  = &mchSys->fru[index];
-
-	if ( checkMchOnlnSessInitDone( mchSess ) ) {
-
-		if ( !(strcmp( task, "fan")) ) {
-
-			epicsMutexLock( mch->mutex );
-
-			if ( mchSys->mchcb->get_fan_level ) {
-				if ( !(s = mchSys->mchcb->get_fan_level( mchData, data, index, &level )) )
-					pai->rval = level;
-			}
-			else
-				s = -1;
-			epicsMutexUnlock( mch->mutex );
-		}
-		else if ( !(strcmp( task, "pwr")) ) {
-
-			/* Check for systems and FRU IDs that support this query; 
-			 * kludgey implementation, needs re-work
-			 */
-			if ( !((mchSys->mchcb->get_power_level) && (FRU_PWR_MSG_CMPTBL( id ))) )
-				goto bail;
-
-			epicsMutexLock( mch->mutex );
-
-			if ( parm < 4 ) {
-
-				if ( !(s = mchSys->mchcb->get_power_level( mchData, data, index, parm )) ) {
-
-					prop  = data[PICMG_RPLY_IMSG2_GET_POWER_LEVEL_PROP_OFFSET];
-
-					if ( (level = FRU_PWR_LEVEL( prop )) ) {
-						draw  = data[PICMG_RPLY_IMSG2_GET_POWER_LEVEL_DRAW_OFFSET + (level - 1)];
-						mult  = data[PICMG_RPLY_IMSG2_GET_POWER_LEVEL_MULT_OFFSET];
-						pai->rval = draw * mult * 0.1; /* Convert from 0.1 Watts to Watts */
-					}
-
-					/* If these don't change, consider i/o scanning these after initialization */
-					switch ( parm ) {
-
-						default: 
-							break;
-
-						case FRU_PWR_STEADY_STATE:
-							fru->pwrDyn = FRU_PWR_DYNAMIC( prop ) ? 1 : 0;
-							break;
-
-						case FRU_PWR_EARLY:
-							fru->pwrDly = data[PICMG_RPLY_IMSG2_GET_POWER_LEVEL_DELAY_OFFSET];
-							break;
-					}
-			       	}
-			}
-
-			else if ( parm == 4 )
-					pai->rval = fru->pwrDly * 0.1; /* Convert from 0.1 seconds to seconds */
-
-			epicsMutexUnlock( mch->mutex );
-		}
-
-		if ( s )
-			goto bail;
-
-		pai->val  = pai->rval;
-
-		if ( MCH_DBG( mchStat[inst] ) >= MCH_DBG_MED )
-			printf("read_fru_ai: %s FRU id is %i, index is %i, value is %.0f\n", pai->name, id, index, pai->val);
-
-		pai->udf = FALSE;
-		return status;
-	}
 bail:
-	recGblSetSevr( pai, READ_ALARM, INVALID_ALARM );
-	return ERROR;
+    if (status) {
+        recGblRecordError(status, (void*)pai, (const char*)str);
+        pai->pact = TRUE;
+    }
+
+    return status;
 }
 
-static long
-init_fru_stringin(struct stringinRecord *pstringin)
-{
-	scanIoInit( &drvMchFruScan );
-	return 0;
+static long read_fru_ai(struct aiRecord* pai) {
+    uint8_t data[MSG_MAX_LENGTH] = {0};
+    MchRec  recPvt               = pai->dpvt;
+    MchDev  mch;
+    MchData mchData;
+    MchSess mchSess;
+    MchSys  mchSys;
+    char*   task;
+    short   index;
+    int     id     = pai->inp.value.camacio.b;
+    int     parm   = pai->inp.value.camacio.c;
+    long    status = NO_CONVERT;
+    Fru     fru;
+    int     s = 0, inst;
+    uint8_t prop, level, draw, mult;
+
+    if (!recPvt) {
+        return status;
+    }
+
+    mch     = recPvt->mch;
+    mchData = mch->udata;
+    mchSess = mchData->mchSess;
+    mchSys  = mchData->mchSys;
+
+    if (-1 == (index = fruLkup(mchSys, pai->inp.value.camacio))) {
+        return ERROR;
+    }
+
+    inst = mchSess->instance;
+    task = recPvt->task;
+    fru  = &mchSys->fru[index];
+
+    if (checkMchOnlnSessInitDone(mchSess)) {
+
+        if (!(strcmp(task, "fan"))) {
+
+            epicsMutexLock(mch->mutex);
+
+            if (mchSys->mchcb->get_fan_level) {
+                if (!(s = mchSys->mchcb->get_fan_level(mchData, data, index, &level))) {
+                    pai->rval = level;
+                }
+            } else {
+                s = -1;
+            }
+            epicsMutexUnlock(mch->mutex);
+        } else if (!(strcmp(task, "pwr"))) {
+
+            /* Check for systems and FRU IDs that support this query;
+             * kludgey implementation, needs re-work
+             */
+            if (!((mchSys->mchcb->get_power_level) && (FRU_PWR_MSG_CMPTBL(id)))) {
+                goto bail;
+            }
+
+            epicsMutexLock(mch->mutex);
+
+            if (parm < 4) {
+
+                if (!(s = mchSys->mchcb->get_power_level(mchData, data, index, parm))) {
+
+                    prop = data[PICMG_RPLY_IMSG2_GET_POWER_LEVEL_PROP_OFFSET];
+
+                    if ((level = FRU_PWR_LEVEL(prop))) {
+                        draw      = data[PICMG_RPLY_IMSG2_GET_POWER_LEVEL_DRAW_OFFSET + (level - 1)];
+                        mult      = data[PICMG_RPLY_IMSG2_GET_POWER_LEVEL_MULT_OFFSET];
+                        pai->rval = draw * mult * 0.1; /* Convert from 0.1 Watts to Watts */
+                    }
+
+                    /* If these don't change, consider i/o scanning these after initialization */
+                    switch (parm) {
+
+                        default:
+                            break;
+
+                        case FRU_PWR_STEADY_STATE:
+                            fru->pwrDyn = FRU_PWR_DYNAMIC(prop) ? 1 : 0;
+                            break;
+
+                        case FRU_PWR_EARLY:
+                            fru->pwrDly = data[PICMG_RPLY_IMSG2_GET_POWER_LEVEL_DELAY_OFFSET];
+                            break;
+                    }
+                }
+            }
+
+            else if (parm == 4) {
+                pai->rval = fru->pwrDly * 0.1; /* Convert from 0.1 seconds to seconds */
+            }
+
+            epicsMutexUnlock(mch->mutex);
+        }
+
+        if (s) {
+            goto bail;
+        }
+
+        pai->val = pai->rval;
+
+        if (MCH_DBG(mchStat[inst]) >= MCH_DBG_MED) {
+            printf("read_fru_ai: %s FRU id is %i, index is %i, value is %.0f\n", pai->name, id, index, pai->val);
+        }
+
+        pai->udf = FALSE;
+        return status;
+    }
+bail:
+    recGblSetSevr(pai, READ_ALARM, INVALID_ALARM);
+    return ERROR;
+}
+
+static long init_fru_stringin(struct stringinRecord* pstringin) {
+    scanIoInit(&drvMchFruScan);
+    return 0;
 }
 
 /*
 ** Add this record to our IOSCANPVT list
- */
+*/
 
-static long 
-stringin_fru_ioint_info(int cmd, struct stringinRecord *pstringin, IOSCANPVT *iopvt)
-{
-       *iopvt = drvMchFruScan;
-       return 0;
-} 
+static long stringin_fru_ioint_info(int cmd, struct stringinRecord* pstringin, IOSCANPVT* iopvt) {
+    *iopvt = drvMchFruScan;
+    return 0;
+}
 
 /* Create the dset for stringin support */
-static long 
-init_fru_stringin_record(struct stringinRecord *pstringin)
-{
-MchRec  recPvt  = 0; /* Info stored with record */
-MchDev  mch     = 0; /* MCH device data structures */
-char    *node;       /* Network node name, stored in parm */
-char    *task   = 0; /* Optional additional parameter appended to parm */
-char    *p;
-long    status  = SUCCESS;
-char    str[40];
+static long init_fru_stringin_record(struct stringinRecord* pstringin) {
+    MchRec recPvt = 0; /* Info stored with record */
+    MchDev mch    = 0; /* MCH device data structures */
+    char*  node;       /* Network node name, stored in parm */
+    char*  task = 0;   /* Optional additional parameter appended to parm */
+    char*  p;
+    long   status = SUCCESS;
+    char   str[40];
 
-	if ( ! ( recPvt = init_record_chk( &pstringin->inp, &status, str )) )
-		goto bail;
+    if (!(recPvt = init_record_chk(&pstringin->inp, &status, str))) {
+        goto bail;
+    }
 
-	/* Break parm into node name and optional parameter */
-	node = strtok( pstringin->inp.value.camacio.parm, "+" );
-	if ( (p = strtok( NULL, "+" )) ) {
-		task = p;
-		if ( strcmp( task, "bmf" ) && strcmp( task, "bp" ) && strcmp( task, "pmf" ) && strcmp( task, "pp") 
-		    && strcmp( task, "bpn" ) && strcmp( task, "ppn") && strcmp( task, "bsn" ) && strcmp( task, "psn" )) {
-			sprintf( str, "Unknown task parameter %s", task);
-			status = S_dev_badSignal;
-		}
-	}
+    /* Break parm into node name and optional parameter */
+    node = strtok(pstringin->inp.value.camacio.parm, "+");
+    if ((p = strtok(NULL, "+"))) {
+        task = p;
+        if (strcmp(task, "bmf") && strcmp(task, "bp") && strcmp(task, "pmf") && strcmp(task, "pp") &&
+            strcmp(task, "bpn") && strcmp(task, "ppn") && strcmp(task, "bsn") && strcmp(task, "psn")) {
+            sprintf(str, "Unknown task parameter %s", task);
+            status = S_dev_badSignal;
+        }
+    }
 
-	if ( init_record_find( mch, recPvt, node, task, &status, str ) )
-		goto bail;
-	else
-		pstringin->dpvt = recPvt;
+    if (init_record_find(mch, recPvt, node, task, &status, str)) {
+        goto bail;
+    } else {
+        pstringin->dpvt = recPvt;
+    }
 
 bail:
-	if ( status ) {
-	       recGblRecordError( status, (void *)pstringin , (const char *)str );
-	       pstringin->pact=TRUE;
-	}
+    if (status) {
+        recGblRecordError(status, (void*)pstringin, (const char*)str);
+        pstringin->pact = TRUE;
+    }
 
-	return status;
+    return status;
 }
 
 /*
@@ -1554,268 +1507,268 @@ mchConvertData(uint8_t type, uint8_t *input, uint8_t *output, size_t bytes, size
 }
 */
 
-static long 
-read_fru_stringin(struct stringinRecord *pstringin)
-{
-MchRec   recPvt  = pstringin->dpvt;
-MchDev   mch;
-MchData  mchData;
-MchSess  mchSess;
-MchSys   mchSys;
-char    *task;
-short    index;
-int      id = pstringin->inp.value.camacio.b; /* FRU ID; correct type? */
-int      i, inst;
-long     status = SUCCESS;//NO_CONVERT;
-Fru      fru;
-uint8_t  l = 0, *d = 0; /* FRU data length and raw */
+static long read_fru_stringin(struct stringinRecord* pstringin) {
+    MchRec  recPvt = pstringin->dpvt;
+    MchDev  mch;
+    MchData mchData;
+    MchSess mchSess;
+    MchSys  mchSys;
+    char*   task;
+    short   index;
+    int     id = pstringin->inp.value.camacio.b; /* FRU ID; correct type? */
+    int     i, inst;
+    long    status = SUCCESS; // NO_CONVERT;
+    Fru     fru;
+    uint8_t l = 0, *d = 0; /* FRU data length and raw */
 
-	if ( !recPvt )
-		return status;
+    if (!recPvt) {
+        return status;
+    }
 
-	mch     = recPvt->mch;
-	mchData = mch->udata;
-	mchSess = mchData->mchSess;
-	mchSys  = mchData->mchSys;
-	inst    = mchSess->instance;
+    mch     = recPvt->mch;
+    mchData = mch->udata;
+    mchSess = mchData->mchSess;
+    mchSys  = mchData->mchSys;
+    inst    = mchSess->instance;
 
-	task    = recPvt->task;
+    task = recPvt->task;
 
-	if ( -1 == (index = fruLkup( mchSys, pstringin->inp.value.camacio )) )
-		goto bail;
+    if (-1 == (index = fruLkup(mchSys, pstringin->inp.value.camacio))) {
+        goto bail;
+    }
 
-	fru = &mchSys->fru[index];
+    fru = &mchSys->fru[index];
 
-	/* index check may be sufficient; may no longer need to check recType */
+    /* index check may be sufficient; may no longer need to check recType */
 
-	if ( checkMchInitDone( mchSess ) ) {
+    if (checkMchInitDone(mchSess)) {
 
-		if ( !(strcmp( task, "bmf" )) ) {
-			if (fru->board.manuf.length == 0) {
-				d = "N/A";
-				l = 4;
-			} else {
-				d = fru->board.manuf.data;
-				l = fru->board.manuf.length;
-			}
-		}
-		else if ( !(strcmp( task, "bp" )) ) {
-			if (fru->board.prod.length == 0) {
-				d = "N/A";
-				l = 4;
-			} else {
-				d = fru->board.prod.data;
-				l = fru->board.prod.length;
-			}
-		}
-		else if ( !(strcmp( task, "pmf" )) ) {
-			if (fru->prod.manuf.length == 0) {
-				d = "N/A";
-				l = 4;
-			} else {
-				d = fru->prod.manuf.data;
-				l = fru->prod.manuf.length;
-			}
-		}
-		else if ( !(strcmp( task, "pp" )) ) {
-			if (fru->prod.prod.length == 0) {
-				d = "N/A";
-				l = 4;
-			} else {
-				d = fru->prod.prod.data;
-				l = fru->prod.prod.length;
-			}
-		}
-		else if ( !(strcmp( task, "bpn" )) ) {
-			if (fru->board.part.length == 0) {
-				d = "N/A";
-				l = 4;
-			} else {
-				d = fru->board.part.data;
-				l = fru->board.part.length;
-			}
-		}
-		else if ( !(strcmp( task, "ppn" )) ) {
-			if (fru->prod.part.length == 0) {
-				d = "N/A";
-				l = 4;
-			} else {
-				d = fru->prod.part.data;
-				l = fru->prod.part.length;
-			}
-		}
-		else if ( !(strcmp( task, "bsn" )) ) {
-			if (fru->board.sn.length == 0) {
-				d = "N/A";
-				l = 4;
-			} else {
-				d = fru->board.sn.data;
-				l = fru->board.sn.length;
-			}
-		} 
+        if (!(strcmp(task, "bmf"))) {
+            if (fru->board.manuf.length == 0) {
+                d = "N/A";
+                l = 4;
+            } else {
+                d = fru->board.manuf.data;
+                l = fru->board.manuf.length;
+            }
+        } else if (!(strcmp(task, "bp"))) {
+            if (fru->board.prod.length == 0) {
+                d = "N/A";
+                l = 4;
+            } else {
+                d = fru->board.prod.data;
+                l = fru->board.prod.length;
+            }
+        } else if (!(strcmp(task, "pmf"))) {
+            if (fru->prod.manuf.length == 0) {
+                d = "N/A";
+                l = 4;
+            } else {
+                d = fru->prod.manuf.data;
+                l = fru->prod.manuf.length;
+            }
+        } else if (!(strcmp(task, "pp"))) {
+            if (fru->prod.prod.length == 0) {
+                d = "N/A";
+                l = 4;
+            } else {
+                d = fru->prod.prod.data;
+                l = fru->prod.prod.length;
+            }
+        } else if (!(strcmp(task, "bpn"))) {
+            if (fru->board.part.length == 0) {
+                d = "N/A";
+                l = 4;
+            } else {
+                d = fru->board.part.data;
+                l = fru->board.part.length;
+            }
+        } else if (!(strcmp(task, "ppn"))) {
+            if (fru->prod.part.length == 0) {
+                d = "N/A";
+                l = 4;
+            } else {
+                d = fru->prod.part.data;
+                l = fru->prod.part.length;
+            }
+        } else if (!(strcmp(task, "bsn"))) {
+            if (fru->board.sn.length == 0) {
+                d = "N/A";
+                l = 4;
+            } else {
+                d = fru->board.sn.data;
+                l = fru->board.sn.length;
+            }
+        }
 
-		else if ( !(strcmp( task, "psn" )) ) {
-			if (fru->prod.sn.length == 0) {
-				d = "N/A";
-				l = 4;
-			} else {
-				d = fru->prod.sn.data;
-				l = fru->prod.sn.length;
-			}
-		}
+        else if (!(strcmp(task, "psn"))) {
+            if (fru->prod.sn.length == 0) {
+                d = "N/A";
+                l = 4;
+            } else {
+                d = fru->prod.sn.data;
+                l = fru->prod.sn.length;
+            }
+        }
 
-		if ( d ) {
+        if (d) {
 
-			l = ( l <= MAX_STRING_LENGTH ) ? l : MAX_STRING_LENGTH;
-			for ( i = 0; i < l; i++ )
-					pstringin->val[i] = d[i];
-		}
+            l = (l <= MAX_STRING_LENGTH) ? l : MAX_STRING_LENGTH;
+            for (i = 0; i < l; i++) {
+                pstringin->val[i] = d[i];
+            }
+        }
 
-		if ( MCH_DBG( mchStat[inst] ) >= MCH_DBG_MED )
-			printf("%s read_fru_stringin: task is %s, FRU id %i index %i\n", pstringin->name, task, id, index);
-		pstringin->udf = FALSE;
-		return status;
-	}
+        if (MCH_DBG(mchStat[inst]) >= MCH_DBG_MED) {
+            printf("%s read_fru_stringin: task is %s, FRU id %i index %i\n", pstringin->name, task, id, index);
+        }
+        pstringin->udf = FALSE;
+        return status;
+    }
 
 bail:
-		recGblSetSevr( pstringin, READ_ALARM, INVALID_ALARM );
-		return ERROR;
+    recGblSetSevr(pstringin, READ_ALARM, INVALID_ALARM);
+    return ERROR;
 }
 
-static long
-init_fru_longout_record(struct longoutRecord *plongout)
-{
-MchRec  recPvt  = 0; /* Info stored with record */
-MchDev  mch     = 0; /* MCH device data structures */
-char   *node;        /* Network node name, stored in parm */
-char   *task    = 0; /* Optional additional parameter appended to parm */
-char   *p;
-long    status = 0;
-char    str[40];
-short   index;
-MchData  mchData;
-MchSess  mchSess;
-MchSys   mchSys;
+static long init_fru_longout_record(struct longoutRecord* plongout) {
+    MchRec  recPvt = 0; /* Info stored with record */
+    MchDev  mch    = 0; /* MCH device data structures */
+    char*   node;       /* Network node name, stored in parm */
+    char*   task = 0;   /* Optional additional parameter appended to parm */
+    char*   p;
+    long    status = 0;
+    char    str[40];
+    short   index;
+    MchData mchData;
+    MchSess mchSess;
+    MchSys  mchSys;
 
-	if ( ! ( recPvt = init_record_chk( &plongout->out, &status, str )) )
-		goto bail;
+    if (!(recPvt = init_record_chk(&plongout->out, &status, str))) {
+        goto bail;
+    }
 
-	/* Break parm into node name and optional parameter */
-	node = strtok( plongout->out.value.camacio.parm, "+" );
-	if ( (p = strtok( NULL, "+" )) ) {
-		task = p;
-		if ( strcmp( task, "fan" ) ) {
-			sprintf( str, "Unknown task parameter %s", task);
-			status = S_dev_badSignal;
-		}
-	}
+    /* Break parm into node name and optional parameter */
+    node = strtok(plongout->out.value.camacio.parm, "+");
+    if ((p = strtok(NULL, "+"))) {
+        task = p;
+        if (strcmp(task, "fan")) {
+            sprintf(str, "Unknown task parameter %s", task);
+            status = S_dev_badSignal;
+        }
+    }
 
-	if ( init_record_find( mch, recPvt, node, task, &status, str ) )
-		goto bail;
-	else {
+    if (init_record_find(mch, recPvt, node, task, &status, str)) {
+        goto bail;
+    } else {
 
-		mch     = recPvt->mch;
-		mchData = mch->udata;
-		mchSess = mchData->mchSess;
-		mchSys  = mchData->mchSys;
+        mch     = recPvt->mch;
+        mchData = mch->udata;
+        mchSess = mchData->mchSess;
+        mchSys  = mchData->mchSys;
 
-		if ( -1 == (index = fruLkup( mchSys, plongout->out.value.camacio )) )
-			goto bail;
+        if (-1 == (index = fruLkup(mchSys, plongout->out.value.camacio))) {
+            goto bail;
+        }
 
-		if ( checkMchInitDone( mchSess ) ) {
+        if (checkMchInitDone(mchSess)) {
 
-			plongout->dpvt = recPvt;
+            plongout->dpvt = recPvt;
 
-			if ( 0 == strcmp( task, "fan" ) ) {
-       			plongout->drvl = plongout->lopr = mchSys->fru[index].fanMin;
-       			plongout->drvh = plongout->hopr = mchSys->fru[index].fanMax;
-			}
-		}
-	}
+            if (0 == strcmp(task, "fan")) {
+                plongout->drvl = plongout->lopr = mchSys->fru[index].fanMin;
+                plongout->drvh = plongout->hopr = mchSys->fru[index].fanMax;
+            }
+        }
+    }
 
 bail:
-	if ( status ) {
-	       recGblRecordError( status, (void *)plongout , (const char *)str );
-	       plongout->pact=TRUE;
-	}
+    if (status) {
+        recGblRecordError(status, (void*)plongout, (const char*)str);
+        plongout->pact = TRUE;
+    }
 
-	return status;
+    return status;
 }
 
 /* scan i/o int? */
-static long 
-write_fru_longout(struct longoutRecord *plongout)
-{
-MchRec   recPvt  = plongout->dpvt;
-MchDev   mch;
-MchData  mchData;
-MchSess  mchSess;
-MchSys   mchSys;
-char    *task;
-int      id      = plongout->out.value.camacio.b; /* FRU ID */
-short    index;  /* FRU index in data structure */
-long     status  = 0;
-Fru      fru;
-uint8_t  data[MSG_MAX_LENGTH] = { 0 };
-int      s = 0, inst;
+static long write_fru_longout(struct longoutRecord* plongout) {
+    MchRec  recPvt = plongout->dpvt;
+    MchDev  mch;
+    MchData mchData;
+    MchSess mchSess;
+    MchSys  mchSys;
+    char*   task;
+    int     id = plongout->out.value.camacio.b; /* FRU ID */
+    short   index;                              /* FRU index in data structure */
+    long    status = 0;
+    Fru     fru;
+    uint8_t data[MSG_MAX_LENGTH] = {0};
+    int     s                    = 0, inst;
 
-	if ( !recPvt )
-		return status;
+    if (!recPvt) {
+        return status;
+    }
 
-	mch     = recPvt->mch;
-	mchData = mch->udata;
-	mchSess = mchData->mchSess;
-	mchSys  = mchData->mchSys;
-	inst    = mchSess->instance;
+    mch     = recPvt->mch;
+    mchData = mch->udata;
+    mchSess = mchData->mchSess;
+    mchSys  = mchData->mchSys;
+    inst    = mchSess->instance;
 
-	task    = recPvt->task;
+    task = recPvt->task;
 
-	if ( -1 == (index = fruLkup( mchSys, plongout->out.value.camacio )) )
-		goto bail;
+    if (-1 == (index = fruLkup(mchSys, plongout->out.value.camacio))) {
+        goto bail;
+    }
 
-	fru = &mchSys->fru[index];
+    fru = &mchSys->fru[index];
 
-	if ( MCH_DBG( mchStat[inst] ) >= MCH_DBG_MED )
-		printf("%s write_fru_longout: FRU id is %i, index is %i, value is %.0f\n",plongout->name, id, index, (double)plongout->val);
+    if (MCH_DBG(mchStat[inst]) >= MCH_DBG_MED) {
+        printf("%s write_fru_longout: FRU id is %i, index is %i, value is %.0f\n", plongout->name, id, index,
+               (double)plongout->val);
+    }
 
-	if ( checkMchOnlnSessInitDone( mchSess ) ) {
-		if ( !(strcmp( task, "fan" )) ) {
+    if (checkMchOnlnSessInitDone(mchSess)) {
+        if (!(strcmp(task, "fan"))) {
 
-       			/* Need to change this so that these limits are also set after a config update
-			 * instead of setting them on every write
-			 */
-       			plongout->drvl = plongout->lopr = mchSys->fru[index].fanMin;
-       			plongout->drvh = plongout->hopr = mchSys->fru[index].fanMax;
+            /* Need to change this so that these limits are also set after a config update
+             * instead of setting them on every write
+             */
+            plongout->drvl = plongout->lopr = mchSys->fru[index].fanMin;
+            plongout->drvh = plongout->hopr = mchSys->fru[index].fanMax;
 
-			epicsMutexLock( mch->mutex );
+            epicsMutexLock(mch->mutex);
 
-/* Need to test this for all archs */
-			if ( mchData->mchSys->mchcb->set_fan_level )
-				s = mchData->mchSys->mchcb->set_fan_level( mchData, data, index, plongout->val );
-			else
-				s = -1;
+            /* Need to test this for all archs */
+            if (mchData->mchSys->mchcb->set_fan_level) {
+                s = mchData->mchSys->mchcb->set_fan_level(mchData, data, index, plongout->val);
+            } else {
+                s = -1;
+            }
 
-			epicsMutexUnlock( mch->mutex );
+            epicsMutexUnlock(mch->mutex);
 
-			if ( s )
-				goto bail;
-		}
+            if (s) {
+                goto bail;
+            }
+        }
 
-		plongout->udf = FALSE;
-		return status;
-	}
+        plongout->udf = FALSE;
+        return status;
+    }
 bail:
-       	       	recGblSetSevr( plongout, WRITE_ALARM, INVALID_ALARM );
-		return ERROR;		
+    recGblSetSevr(plongout, WRITE_ALARM, INVALID_ALARM);
+    return ERROR;
 }
 
 /*
 ** Add this record to our IOSCANPVT list.
 
-static long 
+static long
 longout_fru_ioint_info(int cmd, struct longoutRecord *plongout, IOSCANPVT *iopvt)
 {
        *iopvt = drvMchFruScan;
        return 0;
-} 
+}
 */

--- a/src/devMch.h
+++ b/src/devMch.h
@@ -1,10 +1,10 @@
 //////////////////////////////////////////////////////////////////////////////
 // This file is part of 'ipmiComm'.
-// It is subject to the license terms in the LICENSE.txt file found in the 
-// top-level directory of this distribution and at: 
-//    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
-// No part of 'ipmiComm', including this file, 
-// may be copied, modified, propagated, or distributed except according to 
+// It is subject to the license terms in the LICENSE.txt file found in the
+// top-level directory of this distribution and at:
+//    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+// No part of 'ipmiComm', including this file,
+// may be copied, modified, propagated, or distributed except according to
 // the terms contained in the LICENSE.txt file.
 //////////////////////////////////////////////////////////////////////////////
 #ifndef DEV_MCH_H
@@ -16,42 +16,41 @@
 #include <epicsTypes.h>
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 #define RESET_TIMEOUT 180 /* seconds */
 
 /* Some arbitrary sizes */
-#define MAX_NAME_LENGTH 50 
+#define MAX_NAME_LENGTH 50
 #define MAX_TASK_LENGTH 10
 
-extern IOSCANPVT drvMchStatScan;
-extern IOSCANPVT drvMchInitScan;
-extern IOSCANPVT drvMchFruScan;
+    extern IOSCANPVT drvMchStatScan;
+    extern IOSCANPVT drvMchInitScan;
+    extern IOSCANPVT drvMchFruScan;
 
-/* Much of this stolen from devBusMapped */
+    /* Much of this stolen from devBusMapped */
 
-/* Per-MCH information kept in the registry */
-typedef struct MchDevRec_ {
-	epicsMutexId  mutex;     /* any other driver/devSup sharing resources must with devMch MUST LOCK THIS MUTEX when
-                                    performing modifications or non-atomical reads. */                                   
-	void         *udata;	 /* for use by the driver / user */
-	const char    name[MAX_NAME_LENGTH]; /* space for the terminating NULL; the entire string is appended here, however. */
-} MchDevRec, *MchDev;
+    /* Per-MCH information kept in the registry */
+    typedef struct MchDevRec_ {
+        epicsMutexId mutex; /* any other driver/devSup sharing resources must with devMch MUST LOCK THIS MUTEX when
+                                   performing modifications or non-atomical reads. */
+        void* udata;        /* for use by the driver / user */
+        const char
+            name[MAX_NAME_LENGTH]; /* space for the terminating NULL; the entire string is appended here, however. */
+    } MchDevRec, *MchDev;
 
-/* Data private to IPMI MCH device support; to be stored in record's DPVT field */
-typedef struct MchRec_ {
-	MchDev      mch;
-        char        task[MAX_TASK_LENGTH]; /* operation type */
-} *MchRec;
+    /* Data private to IPMI MCH device support; to be stored in record's DPVT field */
+    typedef struct MchRec_ {
+        MchDev mch;
+        char   task[MAX_TASK_LENGTH]; /* operation type */
+    }* MchRec;
 
+    MchDev devMchRegister(const char* name);
 
-MchDev
-devMchRegister(const char *name);
-
-/* Find the structure of a registered MCH by name */
-MchDev
-devMchFind(const char *name);
+    /* Find the structure of a registered MCH by name */
+    MchDev devMchFind(const char* name);
 
 #ifdef __cplusplus
 };

--- a/src/drvMch.c
+++ b/src/drvMch.c
@@ -1,17 +1,17 @@
 //////////////////////////////////////////////////////////////////////////////
 // This file is part of 'ipmiComm'.
-// It is subject to the license terms in the LICENSE.txt file found in the 
-// top-level directory of this distribution and at: 
-//    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
-// No part of 'ipmiComm', including this file, 
-// may be copied, modified, propagated, or distributed except according to 
+// It is subject to the license terms in the LICENSE.txt file found in the
+// top-level directory of this distribution and at:
+//    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+// No part of 'ipmiComm', including this file,
+// may be copied, modified, propagated, or distributed except according to
 // the terms contained in the LICENSE.txt file.
 //////////////////////////////////////////////////////////////////////////////
 #include <stdint.h>
-#include <stdio.h>   /* fopen, etc. */
+#include <stdio.h> /* fopen, etc. */
 #include <string.h>
-#include <math.h>    /* floor, pow */
-#include <ctype.h>   /* toupper */
+#include <math.h>  /* floor, pow */
+#include <ctype.h> /* toupper */
 #include <unistd.h>
 
 #include <arpa/inet.h>
@@ -34,105 +34,99 @@
 #include <picmgDef.h>
 #include <initHooks.h>
 
-#undef DEBUG 
+#undef DEBUG
 
-#define PING_PERIOD  5
+#define PING_PERIOD 5
 
-/* Sensor scan period [seconds] 
+/* Sensor scan period [seconds]
  * Set to 10 seconds by default.
  * Can be over-ridden by EPICS PV
  */
 volatile uint8_t mchSensorScanPeriod = 10;
 
 /* For use by mchCnfg routine */
-#define MCH_CNFG_INIT 1
+#define MCH_CNFG_INIT     1
 #define MCH_CNFG_NOT_INIT 0
 
-const void *mchCbRegistryId = (void*)&mchCbRegistryId;
+const void* mchCbRegistryId = (void*)&mchCbRegistryId;
 
-char mchDescString[MCH_TYPE_MAX][MCH_DESC_MAX_LENGTH] =
-                {   "Unknown device\0", 
-                    "MicroTCA Crate, VT MCH\0",
-                    "MicroTCA Crate, NAT MCH\0",
-                    "Supermicro Server\0",
-                    "ATCA Crate, Pentair",
-                    "ATCA Crate, Artesyn",
-                    "Advantech Server\0",
-                    "",
-                    "",
-                    ""
-                };
+char mchDescString[MCH_TYPE_MAX][MCH_DESC_MAX_LENGTH] = {"Unknown device\0",
+                                                         "MicroTCA Crate, VT MCH\0",
+                                                         "MicroTCA Crate, NAT MCH\0",
+                                                         "Supermicro Server\0",
+                                                         "ATCA Crate, Pentair",
+                                                         "ATCA Crate, Artesyn",
+                                                         "Advantech Server\0",
+                                                         "",
+                                                         "",
+                                                         ""};
 
-static int mchCounter = 0;
+static int mchCounter            = 0;
 static int mchInitSuccessCounter = 0;
-static int mchInitFailCounter = 0;
-static int postIocStart = 0;
+static int mchInitFailCounter    = 0;
+static int postIocStart          = 0;
 
 epicsMutexId mchStatMtx[MAX_MCH];
-uint32_t     mchStat[MAX_MCH] = { 0 };
+uint32_t     mchStat[MAX_MCH] = {0};
 
-IOSCANPVT drvSensorScan[MAX_MCH];
-struct MchCbRec_ *MchCb;
+IOSCANPVT         drvSensorScan[MAX_MCH];
+struct MchCbRec_* MchCb;
 
-static int mchSdrGetDataAll(MchData mchData);
-static int mchFruGetDataAll(MchData mchData);
-int mchGetFruIdFromIndex(MchData mchData, int index);
+static int  mchSdrGetDataAll(MchData mchData);
+static int  mchFruGetDataAll(MchData mchData);
+int         mchGetFruIdFromIndex(MchData mchData, int index);
 static int  mchCnfg(MchData mchData, int initFlag);
 static void mchCnfgReset(MchData mchData);
 
-
 // we must wait for the IPMI sessions to finish initializing before
 // the IOC continues on and tries to write/read IPMI SDRs.
-static void mchInitHook(initHookState state)
-{
-	if (state != initHookAtIocBuild) {
-		return;
-	}
+static void mchInitHook(initHookState state) {
+    if (state != initHookAtIocBuild) {
+        return;
+    }
 
-	postIocStart = 1;
+    postIocStart = 1;
 
-	printf("sync %d mchInit\n", mchCounter);
-	while (mchInitSuccessCounter + mchInitFailCounter < mchCounter) {
-		sleep(1);
-	}
+    printf("sync %d mchInit\n", mchCounter);
+    while (mchInitSuccessCounter + mchInitFailCounter < mchCounter) {
+        sleep(1);
+    }
 
-	printf("sync mchInit: %d succeeded, %d failed\n", mchInitSuccessCounter, mchInitFailCounter);
+    printf("sync mchInit: %d succeeded, %d failed\n", mchInitSuccessCounter, mchInitFailCounter);
 }
 
-static void
-mchSeqInit(IpmiSess ipmiSess)
-{
-int i;
-	/* Initialize IPMI sequence */
-	ipmiSess->seq = 0;
+static void mchSeqInit(IpmiSess ipmiSess) {
+    int i;
+    /* Initialize IPMI sequence */
+    ipmiSess->seq = 0;
 
-        /* Initialize our stored sequence number for messages from MCH */
-	ipmiSess->seqRply[0] = IPMI_WRAPPER_SEQ_INITIAL;
-        for ( i = 1; i < IPMI_RPLY_SEQ_LENGTH - 1 ; i++)
-                ipmiSess->seqRply[i] = 0;	
+    /* Initialize our stored sequence number for messages from MCH */
+    ipmiSess->seqRply[0] = IPMI_WRAPPER_SEQ_INITIAL;
+    for (i = 1; i < IPMI_RPLY_SEQ_LENGTH - 1; i++) {
+        ipmiSess->seqRply[i] = 0;
+    }
 
-	for ( i = 0; i < IPMI_WRAPPER_SEQ_LENGTH ; i++)
-	        ipmiSess->seqSend[i] = 0;
+    for (i = 0; i < IPMI_WRAPPER_SEQ_LENGTH; i++) {
+        ipmiSess->seqSend[i] = 0;
+    }
 
-	for ( i = 0; i < IPMI_WRAPPER_ID_LENGTH ; i++)
-		ipmiSess->id[i] = 0;
+    for (i = 0; i < IPMI_WRAPPER_ID_LENGTH; i++) {
+        ipmiSess->id[i] = 0;
+    }
 }
 
-static void
-mchSetAuth(MchSess mchSess, IpmiSess ipmiSess, uint8_t authByte)
-{
-	ipmiSess->authReq = 0xFF; /* Default to illegal value */
-	ipmiSess->authSup = IPMI_AUTH_TYPE_SUPPORT( authByte );
+static void mchSetAuth(MchSess mchSess, IpmiSess ipmiSess, uint8_t authByte) {
+    ipmiSess->authReq = 0xFF; /* Default to illegal value */
+    ipmiSess->authSup = IPMI_AUTH_TYPE_SUPPORT(authByte);
 
-	if ( ipmiSess->authSup & (1<<IPMI_MSG_AUTH_TYPE_NONE) ) {
-		ipmiSess->authReq = IPMI_MSG_AUTH_TYPE_NONE;
-	}
-	else if (  ipmiSess->authSup & (1<<IPMI_MSG_AUTH_TYPE_PWD_KEY) ) {
-		ipmiSess->authReq = IPMI_MSG_AUTH_TYPE_PWD_KEY;
-	}
-	else
-		printf("mchSetAuth: No supported auth type for %s, supported mask is 0x%02x\n", 
-		    mchSess->name, ipmiSess->authSup);
+    if (ipmiSess->authSup & (1 << IPMI_MSG_AUTH_TYPE_NONE)) {
+        ipmiSess->authReq = IPMI_MSG_AUTH_TYPE_NONE;
+    } else if (ipmiSess->authSup & (1 << IPMI_MSG_AUTH_TYPE_PWD_KEY)) {
+        ipmiSess->authReq = IPMI_MSG_AUTH_TYPE_PWD_KEY;
+    } else {
+        printf("mchSetAuth: No supported auth type for %s, supported mask is 0x%02x\n", mchSess->name,
+               ipmiSess->authSup);
+    }
 }
 
 /* Start communication session with MCH
@@ -143,62 +137,64 @@ mchSetAuth(MchSess mchSess, IpmiSess ipmiSess, uint8_t authByte)
  *   RETURNS:
  *         0 on success
  *         non-zero on failure
- */		
-static int 
-mchCommStart(MchSess mchSess, IpmiSess ipmiSess)
-{	
-uint8_t response[MSG_MAX_LENGTH] = { 0 };
-int     i;
+ */
+static int mchCommStart(MchSess mchSess, IpmiSess ipmiSess) {
+    uint8_t response[MSG_MAX_LENGTH] = {0};
+    int     i;
 
-	printf("%s Connecting...\n", mchSess->name);
+    printf("%s Connecting...\n", mchSess->name);
 
-	mchSeqInit( ipmiSess );
+    mchSeqInit(ipmiSess);
 
-	if ( mchMsgGetChanAuth( mchSess, ipmiSess, response ) ) {
-		printf("%s Get Channel Authentication failed\n", mchSess->name);
-		return -1;	
-	}
+    if (mchMsgGetChanAuth(mchSess, ipmiSess, response)) {
+        printf("%s Get Channel Authentication failed\n", mchSess->name);
+        return -1;
+    }
 
-	mchSetAuth( mchSess, ipmiSess, response[IPMI_RPLY_IMSG2_AUTH_CAP_AUTH_OFFSET] );
+    mchSetAuth(mchSess, ipmiSess, response[IPMI_RPLY_IMSG2_AUTH_CAP_AUTH_OFFSET]);
 
-	if ( mchMsgGetSess( mchSess, ipmiSess, response ) ) {
-		printf("%s Get Session failed\n", mchSess->name);
-		return -1;
-	}
+    if (mchMsgGetSess(mchSess, ipmiSess, response)) {
+        printf("%s Get Session failed\n", mchSess->name);
+        return -1;
+    }
 
-        /* Extract temporary session ID */
-        for ( i = 0; i < IPMI_RPLY_IMSG2_SESSION_ID_LENGTH ; i++)
-                ipmiSess->id[i] = response[IPMI_RPLY_IMSG2_GET_SESS_TEMP_ID_OFFSET + i];
+    /* Extract temporary session ID */
+    for (i = 0; i < IPMI_RPLY_IMSG2_SESSION_ID_LENGTH; i++) {
+        ipmiSess->id[i] = response[IPMI_RPLY_IMSG2_GET_SESS_TEMP_ID_OFFSET + i];
+    }
 
-        /* Extract challenge string */
-        for ( i = 0; i < IPMI_RPLY_CHALLENGE_STR_LENGTH ; i++)                
-		ipmiSess->str[i] = response[IPMI_RPLY_IMSG2_GET_SESS_CHALLENGE_STR_OFFSET + i];
+    /* Extract challenge string */
+    for (i = 0; i < IPMI_RPLY_CHALLENGE_STR_LENGTH; i++) {
+        ipmiSess->str[i] = response[IPMI_RPLY_IMSG2_GET_SESS_CHALLENGE_STR_OFFSET + i];
+    }
 
-	if ( mchMsgActSess( mchSess, ipmiSess, response ) ) {
-		printf("%s Activate session failed\n", mchSess->name);
-		goto bail;;
-	}
+    if (mchMsgActSess(mchSess, ipmiSess, response)) {
+        printf("%s Activate session failed\n", mchSess->name);
+        goto bail;
+        ;
+    }
 
-        /* Extract session ID */
-        for ( i = 0; i < IPMI_RPLY_IMSG2_SESSION_ID_LENGTH ; i++)
-                ipmiSess->id[i] = response[IPMI_RPLY_IMSG2_ACT_SESS_ID_OFFSET + i];
+    /* Extract session ID */
+    for (i = 0; i < IPMI_RPLY_IMSG2_SESSION_ID_LENGTH; i++) {
+        ipmiSess->id[i] = response[IPMI_RPLY_IMSG2_ACT_SESS_ID_OFFSET + i];
+    }
 
-        /* Extract initial sequence number for messages to MCH */
-        for ( i = 0; i < IPMI_RPLY_INIT_SEND_SEQ_LENGTH ; i++)
-                ipmiSess->seqSend[i] = response[IPMI_RPLY_IMSG2_ACT_SESS_INIT_SEND_SEQ_OFFSET + i];
+    /* Extract initial sequence number for messages to MCH */
+    for (i = 0; i < IPMI_RPLY_INIT_SEND_SEQ_LENGTH; i++) {
+        ipmiSess->seqSend[i] = response[IPMI_RPLY_IMSG2_ACT_SESS_INIT_SEND_SEQ_OFFSET + i];
+    }
 
-	/* Need a non-hard-coded way to determine privilege level */
-	if ( mchMsgSetPriv( mchSess, ipmiSess, response, IPMI_MSG_PRIV_LEVEL_OPER ) ) {
-		printf("%s Set session privilege failed\n", mchSess->name);
-		goto bail;
-	}
+    /* Need a non-hard-coded way to determine privilege level */
+    if (mchMsgSetPriv(mchSess, ipmiSess, response, IPMI_MSG_PRIV_LEVEL_OPER)) {
+        printf("%s Set session privilege failed\n", mchSess->name);
+        goto bail;
+    }
 
-	return 0;
+    return 0;
 
 bail:
-	mchMsgCloseSess( mchSess, ipmiSess, response );
-	return -1;
-
+    mchMsgCloseSess(mchSess, ipmiSess, response);
+    return -1;
 }
 
 /* Start new session with MCH
@@ -209,231 +205,225 @@ bail:
  *
  *   RETURNS: (return val from mchCommStart)
  *           0 on success
- *           non-zero on failure          
+ *           non-zero on failure
  */
-int
-mchNewSession(MchSess mchSess, IpmiSess ipmiSess)
-{
-int rval = -1;
+int mchNewSession(MchSess mchSess, IpmiSess ipmiSess) {
+    int rval = -1;
 
-	mchSeqInit( ipmiSess );
+    mchSeqInit(ipmiSess);
 
-	if ( MCH_ONLN( mchStat[mchSess->instance] ) )
-		rval = mchCommStart( mchSess, ipmiSess );
+    if (MCH_ONLN(mchStat[mchSess->instance])) {
+        rval = mchCommStart(mchSess, ipmiSess);
+    }
 
-	return rval;
+    return rval;
 }
 
-static uint8_t
-bcdPlusConvert(uint8_t raw)
-{
+static uint8_t bcdPlusConvert(uint8_t raw) {
 
-	switch( raw ) {
+    switch (raw) {
 
-		default:
-			printf("Illegal or reserved BCD PLUS byte 0x%02x\n", raw);
-		case 0:
-			return '0';
-		case 1:
-			return '1';
-			break;
-		case 2:
-			return '2';
-			break;
-		case 3:
-			return '3';
-			break;
-		case 4:
-			return '4';
-			break;
-		case 5:
-			return '5';
-			break;
-		case 6:
-			return '6';
-			break;
-		case 7:
-			return '7';
-			break;
-		case 8:
-			return '8';
-			break;
-		case 9:
-			return '9';
-			break;
-		case 0xA:
-			return ' ';
-			break;
-		case 0xB:
-			return '-';
-			break;
-		case 0xC:
-			return '.';
-			break;
-	}
+        default:
+            printf("Illegal or reserved BCD PLUS byte 0x%02x\n", raw);
+        case 0:
+            return '0';
+        case 1:
+            return '1';
+            break;
+        case 2:
+            return '2';
+            break;
+        case 3:
+            return '3';
+            break;
+        case 4:
+            return '4';
+            break;
+        case 5:
+            return '5';
+            break;
+        case 6:
+            return '6';
+            break;
+        case 7:
+            return '7';
+            break;
+        case 8:
+            return '8';
+            break;
+        case 9:
+            return '9';
+            break;
+        case 0xA:
+            return ' ';
+            break;
+        case 0xB:
+            return '-';
+            break;
+        case 0xC:
+            return '.';
+            break;
+    }
 }
 
-static void
-sixBitAsciiConvert(uint8_t *input, uint8_t *output, uint8_t n_input, uint8_t n_output)
-{
-int i = 0, j = 0;
+static void sixBitAsciiConvert(uint8_t* input, uint8_t* output, uint8_t n_input, uint8_t n_output) {
+    int i = 0, j = 0;
 
-	while( 1 ) {
+    while (1) {
 
-			output[i++] = (input[j*3 + 0] & 0x3F) + 0x20;
-			if ( i >= n_output)
-				break;
+        output[i++] = (input[j * 3 + 0] & 0x3F) + 0x20;
+        if (i >= n_output) {
+            break;
+        }
 
-			output[i++] = (((input[j*3 + 0] & 0xC0) >> 6) | ((input[j*3 + 1] & 0xF) << 2)) + 0x20;
-			if ( i >= n_output)
-				break;
+        output[i++] = (((input[j * 3 + 0] & 0xC0) >> 6) | ((input[j * 3 + 1] & 0xF) << 2)) + 0x20;
+        if (i >= n_output) {
+            break;
+        }
 
-			output[i++] = (((input[j*3 + 1] & 0xF0) >> 4) | ((input[j*3 + 2] & 0x3) << 4)) + 0x20;
-			if ( i >= n_output)
-				break;
+        output[i++] = (((input[j * 3 + 1] & 0xF0) >> 4) | ((input[j * 3 + 2] & 0x3) << 4)) + 0x20;
+        if (i >= n_output) {
+            break;
+        }
 
-			output[i++] = ((input[j*3 + 2] & 0xFC) >> 2) + 0x20;
-			if ( i >= n_output)
-				break;
+        output[i++] = ((input[j * 3 + 2] & 0xFC) >> 2) + 0x20;
+        if (i >= n_output) {
+            break;
+        }
 
-			j++;
-	}
+        j++;
+    }
 }
 
-static void
-hexAsciiConvert(uint8_t *input, uint8_t *output, uint8_t n_output)
-{
-int i, j = 0, k;
-uint8_t a;
+static void hexAsciiConvert(uint8_t* input, uint8_t* output, uint8_t n_output) {
+    int     i, j = 0, k;
+    uint8_t a;
 
-	for ( i = 0; i < n_output/2; i++ ) {
+    for (i = 0; i < n_output / 2; i++) {
 
-		for ( k = 1; k > -1; k-- ) {
+        for (k = 1; k > -1; k--) {
 
-			a = (input[i] & (0xF<<(k*4))) >> k*4;
+            a = (input[i] & (0xF << (k * 4))) >> k * 4;
 
-			if ( a == 0 )
-				output[j] = '0';
-			else if ( a == 1 ) 
-				output[j] = '1';
-			else if ( a == 2 ) 
-				output[j] = '2';
-			else if ( a == 3 ) 
-				output[j] = '3';
-			else if ( a == 4 ) 
-				output[j] = '4';
-			else if ( a == 5 ) 
-				output[j] = '5';
-			else if ( a == 6 ) 
-				output[j] = '6';
-			else if ( a == 7 ) 
-				output[j] = '7';
-			else if ( a == 8 ) 
-				output[j] = '8';
-			else if ( a == 9 ) 
-				output[j] = '9';
-			else if ( a == 10 ) 
-				output[j] = 'A';
-			else if ( a == 11 ) 
-				output[j] = 'B';
-			else if ( a == 12 ) 
-				output[j] = 'C';
-			else if ( a == 13 ) 
-				output[j] = 'D';
-			else if ( a == 14 ) 
-				output[j] = 'E';
-			else if ( a == 15 ) 
-				output[j] = 'F';
+            if (a == 0) {
+                output[j] = '0';
+            } else if (a == 1) {
+                output[j] = '1';
+            } else if (a == 2) {
+                output[j] = '2';
+            } else if (a == 3) {
+                output[j] = '3';
+            } else if (a == 4) {
+                output[j] = '4';
+            } else if (a == 5) {
+                output[j] = '5';
+            } else if (a == 6) {
+                output[j] = '6';
+            } else if (a == 7) {
+                output[j] = '7';
+            } else if (a == 8) {
+                output[j] = '8';
+            } else if (a == 9) {
+                output[j] = '9';
+            } else if (a == 10) {
+                output[j] = 'A';
+            } else if (a == 11) {
+                output[j] = 'B';
+            } else if (a == 12) {
+                output[j] = 'C';
+            } else if (a == 13) {
+                output[j] = 'D';
+            } else if (a == 14) {
+                output[j] = 'E';
+            } else if (a == 15) {
+                output[j] = 'F';
+            }
 
-			j++;
-		} 
-	}
+            j++;
+        }
+    }
 }
 
 /* Should instead check actual size of destination (data/rdata) */
-static int
-mchFruFieldCheckLength(uint8_t length, int type)
-{
-	if ( type == FRU_FIELD_LENGTH_TYPE_RAW ) {
-		if ( length > MAX_FRU_FIELD_RAW_LENGTH ) {
-			printf("FRU field raw length %i and but allocated %i\n", 
-			    length, MAX_FRU_FIELD_RAW_LENGTH);
-			return -1;
-		}
-	}
-	else if ( type == FRU_FIELD_LENGTH_TYPE_CONVERTED ) {
-		if ( length > MAX_FRU_FIELD_RAW_LENGTH ) {
-			printf("FRU field converted length %i and but allocated %i\n", 
-			    length, MAX_FRU_FIELD_LENGTH);
-			return -1;
-		}
-	}
-	else {
-		printf("ERROR: Undefined FRU field length type\n");
-		return -1;
-	}
+static int mchFruFieldCheckLength(uint8_t length, int type) {
+    if (type == FRU_FIELD_LENGTH_TYPE_RAW) {
+        if (length > MAX_FRU_FIELD_RAW_LENGTH) {
+            printf("FRU field raw length %i and but allocated %i\n", length, MAX_FRU_FIELD_RAW_LENGTH);
+            return -1;
+        }
+    } else if (type == FRU_FIELD_LENGTH_TYPE_CONVERTED) {
+        if (length > MAX_FRU_FIELD_RAW_LENGTH) {
+            printf("FRU field converted length %i and but allocated %i\n", length, MAX_FRU_FIELD_LENGTH);
+            return -1;
+        }
+    } else {
+        printf("ERROR: Undefined FRU field length type\n");
+        return -1;
+    }
 
-	return 0;
-
+    return 0;
 }
 /* If error, set field->length to zero to indicate no valid data */
-static int
-mchFruFieldConvertData(FruField field, uint8_t lang)
-{
-int i;
+static int mchFruFieldConvertData(FruField field, uint8_t lang) {
+    int i;
 
-	switch( field->type ) {
+    switch (field->type) {
 
-	default:
-			printf("FRU field data type %i is not supported\n", field->type);
-			return -1;
+        default:
+            printf("FRU field data type %i is not supported\n", field->type);
+            return -1;
 
-		case FRU_DATA_TYPE_BINARY:
+        case FRU_DATA_TYPE_BINARY:
 #ifdef DEBUG
-	printf("\nFRU field data type binary or unspecified. Add support!\n");
+            printf("\nFRU field data type binary or unspecified. Add support!\n");
 #endif
 
-			field->length = 2*field->rlength;
-			if ( mchFruFieldCheckLength(field->length , FRU_FIELD_LENGTH_TYPE_CONVERTED ) )
-				return -1;
+            field->length = 2 * field->rlength;
+            if (mchFruFieldCheckLength(field->length, FRU_FIELD_LENGTH_TYPE_CONVERTED)) {
+                return -1;
+            }
 
-       			hexAsciiConvert( field->rdata, field->data, field->length );
-	       		return 0;
+            hexAsciiConvert(field->rdata, field->data, field->length);
+            return 0;
 
+        case FRU_DATA_TYPE_BCDPLUS:
 
-		case FRU_DATA_TYPE_BCDPLUS:
+            field->length = field->rlength;
+            if (mchFruFieldCheckLength(field->length, FRU_FIELD_LENGTH_TYPE_CONVERTED)) {
+                return -1;
+            }
+            for (i = 0; i < field->length; i++) {
+                field->data[i] = bcdPlusConvert(field->rdata[i]);
+            }
+            return 0;
 
-			field->length = field->rlength;
-			if ( mchFruFieldCheckLength( field->length, FRU_FIELD_LENGTH_TYPE_CONVERTED ) )
-				return -1;
-			for ( i = 0; i < field->length; i++ )
-				field->data[i] = bcdPlusConvert( field->rdata[i] );
-			return 0;
+        case FRU_DATA_TYPE_6BITASCII:
 
-		case FRU_DATA_TYPE_6BITASCII:
+            field->length = ceil(8 * ((float)field->rlength / 6));
+            if (field->rlength % 3) {
+                printf("6-bit ASCII data length not integer multiple of 3, something may be wrong.\n");
+            }
+            if (mchFruFieldCheckLength(field->length, FRU_FIELD_LENGTH_TYPE_CONVERTED)) {
+                return -1;
+            }
+            sixBitAsciiConvert(field->rdata, field->data, field->rlength, field->length);
+            return 0;
 
-			field->length = ceil( 8*((float)field->rlength/6) );
-			if ( field->rlength % 3 )
-				printf("6-bit ASCII data length not integer multiple of 3, something may be wrong.\n");
-			if ( mchFruFieldCheckLength( field->length, FRU_FIELD_LENGTH_TYPE_CONVERTED ) )
-				return -1;
-       			sixBitAsciiConvert( field->rdata, field->data, field->rlength, field->length);
-	       		return 0;
+        case FRU_DATA_TYPE_LANG:
 
-		case FRU_DATA_TYPE_LANG:
+            if (IPMI_DATA_LANG_ENGLISH(lang)) {
 
-			if ( IPMI_DATA_LANG_ENGLISH( lang ) ) {
-
-				field->length = field->rlength;
-				if ( mchFruFieldCheckLength( field->length, FRU_FIELD_LENGTH_TYPE_CONVERTED ) )
-					return -1;
-				memcpy( field->data, field->rdata, field->length );
-				return 0;
-			}
-			else
-				printf("Warning FRU data language %i is not english; need to add 2-byte unicode support\n", lang);		   
-	}
-	return 0;
+                field->length = field->rlength;
+                if (mchFruFieldCheckLength(field->length, FRU_FIELD_LENGTH_TYPE_CONVERTED)) {
+                    return -1;
+                }
+                memcpy(field->data, field->rdata, field->length);
+                return 0;
+            } else {
+                printf("Warning FRU data language %i is not english; need to add 2-byte unicode support\n", lang);
+            }
+    }
+    return 0;
 }
 
 /* Copy FRU area field to data structure
@@ -444,103 +434,108 @@ int i;
  *           0 on success
  *          -1 if no data to store
  */
-static int
-mchFruFieldGet(FruField field, uint8_t *raw, unsigned *offset, uint8_t lang)
-{
-int i;
-        if ( ( field->rlength = IPMI_DATA_LENGTH( raw[*offset] ) ) ) {
+static int mchFruFieldGet(FruField field, uint8_t* raw, unsigned* offset, uint8_t lang) {
+    int i;
+    if ((field->rlength = IPMI_DATA_LENGTH(raw[*offset]))) {
 
-                field->type = IPMI_DATA_TYPE( raw[*offset] );
+        field->type = IPMI_DATA_TYPE(raw[*offset]);
 
-                (*offset)++;
+        (*offset)++;
 
-		if ( mchFruFieldCheckLength( field->rlength, FRU_FIELD_LENGTH_TYPE_RAW ) )
-			return -1;
-
-		for ( i = 0; i < field->rlength; i++ )
-			field->rdata[i] = raw[*offset + i];
-
-		*offset += field->rlength;
-
-		return mchFruFieldConvertData( field, lang );
+        if (mchFruFieldCheckLength(field->rlength, FRU_FIELD_LENGTH_TYPE_RAW)) {
+            return -1;
         }
-        return -1;
+
+        for (i = 0; i < field->rlength; i++) {
+            field->rdata[i] = raw[*offset + i];
+        }
+
+        *offset += field->rlength;
+
+        return mchFruFieldConvertData(field, lang);
+    }
+    return -1;
 }
 
-/* 
+/*
  * Copy FRU Chassis area data to chassis structure
  *
  * Caller must perform locking.
  */
-static void
-mchFruChassisDataGet(FruChassis chas, uint8_t *raw, unsigned *offset)
-{
-	if ( 0 != (*offset = 8*raw[FRU_DATA_COMMON_HEADER_OFFSET + FRU_DATA_COMMON_HEADER_CHASSIS_AREA_OFFSET]) ) {
+static void mchFruChassisDataGet(FruChassis chas, uint8_t* raw, unsigned* offset) {
+    if (0 != (*offset = 8 * raw[FRU_DATA_COMMON_HEADER_OFFSET + FRU_DATA_COMMON_HEADER_CHASSIS_AREA_OFFSET])) {
 
-		chas->type = raw[*offset + FRU_DATA_CHASSIS_TYPE_OFFSET];
+        chas->type = raw[*offset + FRU_DATA_CHASSIS_TYPE_OFFSET];
 
-		*offset += FRU_DATA_CHASSIS_AREA_PART_LENGTH_OFFSET;
+        *offset += FRU_DATA_CHASSIS_AREA_PART_LENGTH_OFFSET;
 
-		if ( mchFruFieldGet( &(chas->part),   raw, offset, IPMI_DATA_LANG_CODE_ENGLISH1 ) )
-			(*offset)++;
-		if ( mchFruFieldGet( &(chas->sn),     raw, offset, IPMI_DATA_LANG_CODE_ENGLISH1 ) )
-			(*offset)++;
-	}
+        if (mchFruFieldGet(&(chas->part), raw, offset, IPMI_DATA_LANG_CODE_ENGLISH1)) {
+            (*offset)++;
+        }
+        if (mchFruFieldGet(&(chas->sn), raw, offset, IPMI_DATA_LANG_CODE_ENGLISH1)) {
+            (*offset)++;
+        }
+    }
 }
 
-/* 
+/*
  * Copy FRU Product area data to product structure
  *
  * Caller must perform locking.
  */
-static void
-mchFruProdDataGet(FruProd prod, uint8_t *raw, unsigned *offset)
-{
-	if ( 0 != (*offset = 8*raw[FRU_DATA_COMMON_HEADER_OFFSET + FRU_DATA_COMMON_HEADER_PROD_AREA_OFFSET]) ) {
+static void mchFruProdDataGet(FruProd prod, uint8_t* raw, unsigned* offset) {
+    if (0 != (*offset = 8 * raw[FRU_DATA_COMMON_HEADER_OFFSET + FRU_DATA_COMMON_HEADER_PROD_AREA_OFFSET])) {
 
-		prod->lang = raw[*offset + FRU_DATA_PROD_AREA_LANG_OFFSET];
+        prod->lang = raw[*offset + FRU_DATA_PROD_AREA_LANG_OFFSET];
 
-		*offset += FRU_DATA_PROD_AREA_MANUF_LENGTH_OFFSET;
+        *offset += FRU_DATA_PROD_AREA_MANUF_LENGTH_OFFSET;
 
-		if ( mchFruFieldGet( &(prod->manuf),   raw, offset, prod->lang ) )
-			(*offset)++;
-		if ( mchFruFieldGet( &(prod->prod),    raw, offset, prod->lang) )
-			(*offset)++;
-		if ( mchFruFieldGet( &(prod->part),    raw, offset, prod->lang ) )
-			(*offset)++;
-		if ( mchFruFieldGet( &(prod->version), raw, offset, prod->lang ) )
-			(*offset)++;
-		if ( mchFruFieldGet( &(prod->sn),      raw, offset, prod->lang ) )
-			(*offset)++;
-	}
+        if (mchFruFieldGet(&(prod->manuf), raw, offset, prod->lang)) {
+            (*offset)++;
+        }
+        if (mchFruFieldGet(&(prod->prod), raw, offset, prod->lang)) {
+            (*offset)++;
+        }
+        if (mchFruFieldGet(&(prod->part), raw, offset, prod->lang)) {
+            (*offset)++;
+        }
+        if (mchFruFieldGet(&(prod->version), raw, offset, prod->lang)) {
+            (*offset)++;
+        }
+        if (mchFruFieldGet(&(prod->sn), raw, offset, prod->lang)) {
+            (*offset)++;
+        }
+    }
 }
 
-/* 
+/*
  * Copy FRU Board area data to board structure
  *
  * Caller must perform locking.
  */
-static void
-mchFruBoardDataGet(FruBoard board, uint8_t *raw, unsigned *offset)
-{
-	if ( 0 != (*offset = 8*raw[FRU_DATA_COMMON_HEADER_OFFSET + FRU_DATA_COMMON_HEADER_BOARD_AREA_OFFSET] ) ) {
+static void mchFruBoardDataGet(FruBoard board, uint8_t* raw, unsigned* offset) {
+    if (0 != (*offset = 8 * raw[FRU_DATA_COMMON_HEADER_OFFSET + FRU_DATA_COMMON_HEADER_BOARD_AREA_OFFSET])) {
 
-		board->lang = raw[*offset + FRU_DATA_BOARD_AREA_LANG_OFFSET];
+        board->lang = raw[*offset + FRU_DATA_BOARD_AREA_LANG_OFFSET];
 
-		*offset += FRU_DATA_BOARD_AREA_MANUF_LENGTH_OFFSET;
+        *offset += FRU_DATA_BOARD_AREA_MANUF_LENGTH_OFFSET;
 
-		if ( mchFruFieldGet( &(board->manuf), raw, offset, board->lang ) )
-			(*offset)++;
-		if ( mchFruFieldGet( &(board->prod),  raw, offset, board->lang ) )
-			(*offset)++;
-		if ( mchFruFieldGet( &(board->sn),    raw, offset, board->lang ) )
-			(*offset)++;
-		if ( mchFruFieldGet( &(board->part),  raw, offset, board->lang ) )
-			(*offset)++;	       
-	}
+        if (mchFruFieldGet(&(board->manuf), raw, offset, board->lang)) {
+            (*offset)++;
+        }
+        if (mchFruFieldGet(&(board->prod), raw, offset, board->lang)) {
+            (*offset)++;
+        }
+        if (mchFruFieldGet(&(board->sn), raw, offset, board->lang)) {
+            (*offset)++;
+        }
+        if (mchFruFieldGet(&(board->part), raw, offset, board->lang)) {
+            (*offset)++;
+        }
+    }
 }
 
-/* 
+/*
  * Get data for one FRU
  *
  * Read FRU inventory info. If error in response
@@ -549,153 +544,163 @@ mchFruBoardDataGet(FruBoard board, uint8_t *raw, unsigned *offset)
  *
  * Caller must perform locking.
  */
-static int
-mchFruDataGet(MchData mchData, Fru fru) 
-{
-MchSess    mchSess = mchData->mchSess;
-int        inst    = mchSess->instance;
-uint8_t    response[MSG_MAX_LENGTH] = { 0 };
-uint8_t   *raw = 0; 
-int        i;
-uint16_t   sizeInt;  /* Size of FRU data area in bytes */
-unsigned   nread;    /* Number of FRU data reads */
-unsigned   offset;   /* Offset into FRU data */
-int        rval;
+static int mchFruDataGet(MchData mchData, Fru fru) {
+    MchSess  mchSess                  = mchData->mchSess;
+    int      inst                     = mchSess->instance;
+    uint8_t  response[MSG_MAX_LENGTH] = {0};
+    uint8_t* raw                      = 0;
+    int      i;
+    uint16_t sizeInt; /* Size of FRU data area in bytes */
+    unsigned nread;   /* Number of FRU data reads */
+    unsigned offset;  /* Offset into FRU data */
+    int      rval;
 
-	/* Get FRU Inventory Info */
-	if ( mchMsgGetFruInvInfoWrapper( mchData, response, fru ) )
-		return -1;
+    /* Get FRU Inventory Info */
+    if (mchMsgGetFruInvInfoWrapper(mchData, response, fru)) {
+        return -1;
+    }
 
-	fru->size[0] = response[IPMI_RPLY_IMSG2_FRU_AREA_SIZE_LSB_OFFSET];
-	fru->size[1] = response[IPMI_RPLY_IMSG2_FRU_AREA_SIZE_MSB_OFFSET];
-	fru->access  = response[IPMI_RPLY_IMSG2_FRU_AREA_ACCESS_OFFSET];  
+    fru->size[0] = response[IPMI_RPLY_IMSG2_FRU_AREA_SIZE_LSB_OFFSET];
+    fru->size[1] = response[IPMI_RPLY_IMSG2_FRU_AREA_SIZE_MSB_OFFSET];
+    fru->access  = response[IPMI_RPLY_IMSG2_FRU_AREA_ACCESS_OFFSET];
 
-	if ( 0 == (sizeInt = arrayToUint16( fru->size )) )
-		return 0;
+    if (0 == (sizeInt = arrayToUint16(fru->size))) {
+        return 0;
+    }
 
-	if ( MCH_DBG( mchStat[inst] ) >= MCH_DBG_MED )
-		printf("%s mchFruDataGet: FRU addr 0x%02x ID %i inventory info size %i\n", 
-		    mchSess->name, fru->sdr.addr, fru->sdr.fruId, sizeInt);
+    if (MCH_DBG(mchStat[inst]) >= MCH_DBG_MED) {
+        printf("%s mchFruDataGet: FRU addr 0x%02x ID %i inventory info size %i\n", mchSess->name, fru->sdr.addr,
+               fru->sdr.fruId, sizeInt);
+    }
 
-	if ( !(raw = calloc( 1, sizeInt ) ) ) {
-		printf("mchFruDataGet: No memory for FRU addr 0x%02x ID %i data\n", fru->sdr.addr, fru->sdr.fruId);
-		return -1;
-	}
+    if (!(raw = calloc(1, sizeInt))) {
+        printf("mchFruDataGet: No memory for FRU addr 0x%02x ID %i data\n", fru->sdr.addr, fru->sdr.fruId);
+        return -1;
+    }
 
-	/* Too many reads! But no way to determine the end of the data until we read it, so for now... */
-	if ( ( nread = floor( sizeInt/MSG_FRU_DATA_READ_SIZE ) ) > 50 )
-		nread = 50;
+    /* Too many reads! But no way to determine the end of the data until we read it, so for now... */
+    if ((nread = floor(sizeInt / MSG_FRU_DATA_READ_SIZE)) > 50) {
+        nread = 50;
+    }
 
-	/* Initialize read offset to 0 */
-	for ( i = 0; i < sizeof( fru->readOffset ); i ++ )
-		fru->readOffset[i] = 0;
+    /* Initialize read offset to 0 */
+    for (i = 0; i < sizeof(fru->readOffset); i++) {
+        fru->readOffset[i] = 0;
+    }
 
-	/* Read FRU data, store in raw, increment our read offset for next read. If error returned for requested FRU ID, abort */
-	for ( i = 0; i < nread; i++ ) {
-		fru->read = i;
+    /* Read FRU data, store in raw, increment our read offset for next read. If error returned for requested FRU ID,
+     * abort */
+    for (i = 0; i < nread; i++) {
+        fru->read = i;
 
-		rval = mchMsgReadFruWrapper( mchData, response, fru, fru->readOffset, MSG_FRU_DATA_READ_SIZE );
-		if ( rval ) {
-			if ( IPMI_COMP_CODE_REQUESTED_DATA == rval )
-				break;
-		}
-		else
-			memcpy( raw + i*MSG_FRU_DATA_READ_SIZE, response + IPMI_RPLY_IMSG2_FRU_DATA_READ_OFFSET, MSG_FRU_DATA_READ_SIZE );
-		incr2Uint8Array( fru->readOffset, MSG_FRU_DATA_READ_SIZE );
-	}
+        rval = mchMsgReadFruWrapper(mchData, response, fru, fru->readOffset, MSG_FRU_DATA_READ_SIZE);
+        if (rval) {
+            if (IPMI_COMP_CODE_REQUESTED_DATA == rval) {
+                break;
+            }
+        } else {
+            memcpy(raw + i * MSG_FRU_DATA_READ_SIZE, response + IPMI_RPLY_IMSG2_FRU_DATA_READ_OFFSET,
+                   MSG_FRU_DATA_READ_SIZE);
+        }
+        incr2Uint8Array(fru->readOffset, MSG_FRU_DATA_READ_SIZE);
+    }
 
-	if ( MCH_DBG( mchStat[inst] ) >= MCH_DBG_HIGH ) {
-		printf("%s FRU addr 0x%02x ID %i raw data, size %i: \n", mchSess->name, fru->sdr.addr, fru->sdr.fruId, sizeInt);
-		for ( i = 0; i < sizeInt; i++)
-			printf("0x%02x ",raw[i]);
-		printf("\n");
+    if (MCH_DBG(mchStat[inst]) >= MCH_DBG_HIGH) {
+        printf("%s FRU addr 0x%02x ID %i raw data, size %i: \n", mchSess->name, fru->sdr.addr, fru->sdr.fruId, sizeInt);
+        for (i = 0; i < sizeInt; i++) {
+            printf("0x%02x ", raw[i]);
+        }
+        printf("\n");
 
-		printf("%s FRU addr 0x%02x ID %i raw data, size %i: \n", mchSess->name, fru->sdr.addr, fru->sdr.fruId, sizeInt);
-		for ( i = 0; i < sizeInt; i++)
-			printf("%c ",raw[i]);
-		printf("\n");
-	}
+        printf("%s FRU addr 0x%02x ID %i raw data, size %i: \n", mchSess->name, fru->sdr.addr, fru->sdr.fruId, sizeInt);
+        for (i = 0; i < sizeInt; i++) {
+            printf("%c ", raw[i]);
+        }
+        printf("\n");
+    }
 
-	/* Add chassis data get */
-	memset( &(fru->board),   0, sizeof( fru->board ) );
-	memset( &(fru->prod),    0, sizeof( fru->prod ) );
-	memset( &(fru->chassis), 0, sizeof( fru->chassis ) );
-	mchFruBoardDataGet( &(fru->board), raw, &offset );
-	mchFruProdDataGet(  &(fru->prod) , raw, &offset );
-	mchFruChassisDataGet( &(fru->chassis), raw, &offset );
-	free( raw );
+    /* Add chassis data get */
+    memset(&(fru->board), 0, sizeof(fru->board));
+    memset(&(fru->prod), 0, sizeof(fru->prod));
+    memset(&(fru->chassis), 0, sizeof(fru->chassis));
+    mchFruBoardDataGet(&(fru->board), raw, &offset);
+    mchFruProdDataGet(&(fru->prod), raw, &offset);
+    mchFruChassisDataGet(&(fru->chassis), raw, &offset);
+    free(raw);
 
-	return 0;
+    return 0;
 }
 
-int
-mchGetFruIdFromIndex(MchData mchData, int index)
-{
-int i;
-	for ( i = 0; i < MAX_FRU_MGMT; i++ ) {
-		if ( mchData->mchSys->fruLkup[i] == index )
-			return i;
-	}
-	return -1;
+int mchGetFruIdFromIndex(MchData mchData, int index) {
+    int i;
+    for (i = 0; i < MAX_FRU_MGMT; i++) {
+        if (mchData->mchSys->fruLkup[i] == index) {
+            return i;
+        }
+    }
+    return -1;
 }
 
-/* 
+/*
  * Get data for all FRUs. Must be done after SDR data has been stored in FRU struct.
  * If FRU is cooling unit, get fan properties.
  *
  * Caller must perform locking.
  */
-static int
-mchFruGetDataAll(MchData mchData)
-{
-MchSess mchSess = mchData->mchSess;
-MchSys  mchSys  = mchData->mchSys;
-uint8_t i;
-Fru fru;
-int rval = 0;
+static int mchFruGetDataAll(MchData mchData) {
+    MchSess mchSess = mchData->mchSess;
+    MchSys  mchSys  = mchData->mchSys;
+    uint8_t i;
+    Fru     fru;
+    int     rval = 0;
 
-	if ( mchData->mchSys->mchcb->assign_site_info )
-		mchData->mchSys->mchcb->assign_site_info( mchData );
+    if (mchData->mchSys->mchcb->assign_site_info) {
+        mchData->mchSys->mchcb->assign_site_info(mchData);
+    }
 
-	if ( mchData->mchSys->mchcb->assign_fru_lkup )
-		mchData->mchSys->mchcb->assign_fru_lkup( mchData );
+    if (mchData->mchSys->mchcb->assign_fru_lkup) {
+        mchData->mchSys->mchcb->assign_fru_lkup(mchData);
+    }
 
-	for ( i = 0; i < mchSys->fruCount ; i++ ) {
+    for (i = 0; i < mchSys->fruCount; i++) {
 
-	       	fru = &mchSys->fru[i];
+        fru = &mchSys->fru[i];
 
-		if ( mchSys->fruLkup[fru->id] != -1 ) {
+        if (mchSys->fruLkup[fru->id] != -1) {
 
-			if ( mchFruDataGet( mchData, fru ) )
-				rval = -1;
+            if (mchFruDataGet(mchData, fru)) {
+                rval = -1;
+            }
 
-			if ( mchData->mchSys->mchcb->fru_data_suppl )
-				rval = mchData->mchSys->mchcb->fru_data_suppl( mchData, i );
-		}	
-	}
+            if (mchData->mchSys->mchcb->fru_data_suppl) {
+                rval = mchData->mchSys->mchcb->fru_data_suppl(mchData, i);
+            }
+        }
+    }
 
+    if (MCH_DBG(mchStat[mchSess->instance]) >= MCH_DBG_MED) {
+        printf("%s mchFruGetDataAll: FRU Summary:\n", mchSess->name);
+        for (i = 0; i < mchSys->fruCount; i++) {
+            fru = &mchSys->fru[i];
+            if (fru->sdr.fruId || (arrayToUint16(fru->size) > 0)) {
+                printf("SDR FRU index %i ID %i %i %s was found, ent id 0x%02x instance 0x%02x, addr 0x%02x id 0x%02x "
+                       "lun %i lkup %i\n",
+                       i, fru->sdr.fruId, fru->id, fru->board.prod.data, fru->sdr.entityId, fru->sdr.entityInst,
+                       fru->sdr.addr, fru->sdr.fruId, fru->sdr.lun, mchSys->fruLkup[fru->id]);
+            }
+        }
+    }
 
-	if ( MCH_DBG( mchStat[mchSess->instance] ) >= MCH_DBG_MED ) {
-		printf("%s mchFruGetDataAll: FRU Summary:\n", mchSess->name);
-		for ( i = 0; i < mchSys->fruCount; i++) {
-			fru = &mchSys->fru[i];
-			if ( fru->sdr.fruId || (arrayToUint16( fru->size ) > 0) )
-				printf("SDR FRU index %i ID %i %i %s was found, ent id 0x%02x instance 0x%02x, addr 0x%02x id 0x%02x lun %i lkup %i\n", 
-				    i, fru->sdr.fruId, fru->id, fru->board.prod.data, fru->sdr.entityId, fru->sdr.entityInst, fru->sdr.addr, fru->sdr.fruId, 
-				    fru->sdr.lun, mchSys->fruLkup[fru->id]);
-		}
-	}
-
-	return rval;
+    return rval;
 }
 
-/* 
+/*
  * Get sensor/FRU association
  *
- * -Given a sensor index, identify the associated FRU or Management Controller 
- *  and store its identity in the sensor structure. 
- *  For MicroTCA AMC and RTM non-FRU entities, identify the associated 
- *  FRU and do the same. For NAT hot-swap sensors, parse description string 
+ * -Given a sensor index, identify the associated FRU or Management Controller
+ *  and store its identity in the sensor structure.
+ *  For MicroTCA AMC and RTM non-FRU entities, identify the associated
+ *  FRU and do the same. For NAT hot-swap sensors, parse description string
  *  to find associated FRU ID.
  *
  * Note: these indices refer to our arrays of Sensors and FRUs--
@@ -704,661 +709,643 @@ int rval = 0;
  *
  * Caller must perform locking.
  */
-static void
-mchSensorGetFru(MchData mchData, int index)
-{
-MchSys mchSys = mchData->mchSys;
-Sensor sens   = &mchSys->sens[index];
+static void mchSensorGetFru(MchData mchData, int index) {
+    MchSys mchSys = mchData->mchSys;
+    Sensor sens   = &mchSys->sens[index];
 
-	/* Set default indices to indicate no corresponding fru/mgmt */
-	sens->fruIndex = sens->mgmtIndex = -1; 
+    /* Set default indices to indicate no corresponding fru/mgmt */
+    sens->fruIndex = sens->mgmtIndex = -1;
 
-	if ( mchSys->mchcb->sensor_get_fru )
-		mchSys->mchcb->sensor_get_fru( mchData, sens );
+    if (mchSys->mchcb->sensor_get_fru) {
+        mchSys->mchcb->sensor_get_fru(mchData, sens);
+    }
 }
 
 /* Caller must perform locking */
-static int
-mchSdrRepGetInfoMsg(MchData mchData, uint8_t *response, uint8_t parm, uint8_t addr) 
-{
+static int mchSdrRepGetInfoMsg(MchData mchData, uint8_t* response, uint8_t parm, uint8_t addr) {
 
-	return mchMsgGetSdrRepInfoWrapper( mchData, response, parm, addr );
-
+    return mchMsgGetSdrRepInfoWrapper(mchData, response, parm, addr);
 }
 
 /* Caller must perform locking */
-static void
-mchSdrRepGetTs(uint8_t *response, uint32_t *addTs, uint32_t *delTs) 
-{
+static void mchSdrRepGetTs(uint8_t* response, uint32_t* addTs, uint32_t* delTs) {
 
-       	*addTs = ntohl( *(uint32_t *)(response + IPMI_RPLY_IMSG2_SDRREP_ADD_TS_OFFSET) );
-       	*delTs = ntohl( *(uint32_t *)(response + IPMI_RPLY_IMSG2_SDRREP_DEL_TS_OFFSET) );
+    *addTs = ntohl(*(uint32_t*)(response + IPMI_RPLY_IMSG2_SDRREP_ADD_TS_OFFSET));
+    *delTs = ntohl(*(uint32_t*)(response + IPMI_RPLY_IMSG2_SDRREP_DEL_TS_OFFSET));
 }
 
 /* Compare SDR repository timestamps to detect changes
  *
  * Caller must perform locking
  */
-static int
-mchSdrRepTsDiff(MchData mchData) {
-MchSess   mchSess = mchData->mchSess;
-MchSys    mchSys  = mchData->mchSys;
-uint32_t  add, del;
-uint32_t *addTs = &mchSys->sdrRep.addTs, *delTs = &mchSys->sdrRep.delTs;
-uint8_t   buff[MSG_MAX_LENGTH] = { 0 };
+static int mchSdrRepTsDiff(MchData mchData) {
+    MchSess   mchSess = mchData->mchSess;
+    MchSys    mchSys  = mchData->mchSys;
+    uint32_t  add, del;
+    uint32_t *addTs = &mchSys->sdrRep.addTs, *delTs = &mchSys->sdrRep.delTs;
+    uint8_t   buff[MSG_MAX_LENGTH] = {0};
 
-	if ( mchSdrRepGetInfoMsg( mchData, buff, IPMI_SDRREP_PARM_GET_SDR, IPMI_MSG_ADDR_BMC ) )
-		return 0;
+    if (mchSdrRepGetInfoMsg(mchData, buff, IPMI_SDRREP_PARM_GET_SDR, IPMI_MSG_ADDR_BMC)) {
+        return 0;
+    }
 
-	mchSdrRepGetTs( buff, &add, &del );
+    mchSdrRepGetTs(buff, &add, &del);
 
-	if ( (add != *addTs) || (del != *delTs) ) {
+    if ((add != *addTs) || (del != *delTs)) {
 
-		if ( MCH_DBG( mchStat[mchSess->instance] ) >= MCH_DBG_MED )
-			printf("%s SDR rep TS before: 0x%08x 0x%08x, after: 0x%08x 0x%08x\n", 
-			    mchSess->name, *addTs, *delTs, add, del);
+        if (MCH_DBG(mchStat[mchSess->instance]) >= MCH_DBG_MED) {
+            printf("%s SDR rep TS before: 0x%08x 0x%08x, after: 0x%08x 0x%08x\n", mchSess->name, *addTs, *delTs, add,
+                   del);
+        }
 
-		*addTs = add;
-		*delTs = del;
+        *addTs = add;
+        *delTs = del;
 
-		return -1;
-	}
+        return -1;
+    }
 
-	return 0;
+    return 0;
 }
 
-/* 
- * Store SDR Repository info 
+/*
+ * Store SDR Repository info
  *
  * Caller must perform locking.
  */
-static int
-mchSdrRepGetInfo(MchData mchData, uint8_t parm, uint8_t addr, SdrRep sdrRep, uint32_t *sdrCount)
-{
-uint8_t response[MSG_MAX_LENGTH] = { 0 };
-uint8_t flags;
-int     rval;
+static int mchSdrRepGetInfo(MchData mchData, uint8_t parm, uint8_t addr, SdrRep sdrRep, uint32_t* sdrCount) {
+    uint8_t response[MSG_MAX_LENGTH] = {0};
+    uint8_t flags;
+    int     rval;
 
-	rval = mchSdrRepGetInfoMsg( mchData, response, parm, addr );
+    rval = mchSdrRepGetInfoMsg(mchData, response, parm, addr);
 
-	if (  parm == IPMI_SDRREP_PARM_GET_SDR ) {
+    if (parm == IPMI_SDRREP_PARM_GET_SDR) {
 
-		if ( rval )
-			return -1;
+        if (rval) {
+            return -1;
+        }
 
-		sdrRep->ver     = response[IPMI_RPLY_IMSG2_SDRREP_VER_OFFSET];
-		sdrRep->size[0] = response[IPMI_RPLY_IMSG2_SDRREP_CNT_LSB_OFFSET];
-		sdrRep->size[1] = response[IPMI_RPLY_IMSG2_SDRREP_CNT_MSB_OFFSET];
+        sdrRep->ver     = response[IPMI_RPLY_IMSG2_SDRREP_VER_OFFSET];
+        sdrRep->size[0] = response[IPMI_RPLY_IMSG2_SDRREP_CNT_LSB_OFFSET];
+        sdrRep->size[1] = response[IPMI_RPLY_IMSG2_SDRREP_CNT_MSB_OFFSET];
 
-		*sdrCount = arrayToUint16( sdrRep->size );
+        *sdrCount = arrayToUint16(sdrRep->size);
 
-		mchSdrRepGetTs( response, &sdrRep->addTs, &sdrRep->delTs );
-	}
-	else {
+        mchSdrRepGetTs(response, &sdrRep->addTs, &sdrRep->delTs);
+    } else {
 
-		if ( response[0] ) // completion code
-			return -1;
+        if (response[0]) { // completion code
+            return -1;
+        }
 
-		*sdrCount = sdrRep->devSdrSize = response[IPMI_RPLY_IMSG2_DEV_SDR_INFO_CNT_OFFSET];
-		flags = response[IPMI_RPLY_IMSG2_DEV_SDR_INFO_FLAGS_OFFSET];
-		sdrRep->devSdrDyn  = DEV_SENSOR_DYNAMIC(flags);
-		sdrRep->lun0       = DEV_SENSOR_LUN0(flags);
-		sdrRep->lun1       = DEV_SENSOR_LUN1(flags);
-		sdrRep->lun2       = DEV_SENSOR_LUN2(flags);
-		sdrRep->lun3       = DEV_SENSOR_LUN3(flags);
-	}
+        *sdrCount = sdrRep->devSdrSize = response[IPMI_RPLY_IMSG2_DEV_SDR_INFO_CNT_OFFSET];
+        flags                          = response[IPMI_RPLY_IMSG2_DEV_SDR_INFO_FLAGS_OFFSET];
+        sdrRep->devSdrDyn              = DEV_SENSOR_DYNAMIC(flags);
+        sdrRep->lun0                   = DEV_SENSOR_LUN0(flags);
+        sdrRep->lun1                   = DEV_SENSOR_LUN1(flags);
+        sdrRep->lun2                   = DEV_SENSOR_LUN2(flags);
+        sdrRep->lun3                   = DEV_SENSOR_LUN3(flags);
+    }
 
-	return 0;
+    return 0;
 }
 
-static void
-mchStoreAssocDevEntInfo(Entity entity, DevEntAssoc dassoc, uint8_t cntnrAddr, uint8_t id, uint8_t inst, uint8_t cntndAddr, uint8_t cntndChan, int parm, int *count)
-{
-uint8_t ownerAddr = dassoc->ownerAddr;
-uint8_t ownerChan = dassoc->ownerChan;
+static void mchStoreAssocDevEntInfo(Entity entity, DevEntAssoc dassoc, uint8_t cntnrAddr, uint8_t id, uint8_t inst,
+                                    uint8_t cntndAddr, uint8_t cntndChan, int parm, int* count) {
+    uint8_t ownerAddr = dassoc->ownerAddr;
+    uint8_t ownerChan = dassoc->ownerChan;
 
-	if ( parm ) {
+    if (parm) {
 
-		entity[*count].entityId   = id;
-		entity[*count].entityInst = inst;
+        entity[*count].entityId   = id;
+        entity[*count].entityInst = inst;
 
-		/* If container address not defined in SDR, use owner address
-		 * that was used when querying this FRU or management controller */
-		if ( cntnrAddr == 0 ) {
-			entity[*count].addr = ownerAddr;
-			entity[*count].chan = ownerChan;
-		}
-		else {
-			entity[*count].addr = cntndAddr;
-			entity[*count].chan = cntndChan;
-		}
+        /* If container address not defined in SDR, use owner address
+         * that was used when querying this FRU or management controller */
+        if (cntnrAddr == 0) {
+            entity[*count].addr = ownerAddr;
+            entity[*count].chan = ownerChan;
+        } else {
+            entity[*count].addr = cntndAddr;
+            entity[*count].chan = cntndChan;
+        }
 
 #ifdef DEBUG
-printf("mchStoreAssocDevEntInfo: Found assoc dev rel entity owner 0x%02x contained id 0x%02x inst 0x%02x index %i entity point addr %i %i\n", 
-    entity[*count].addr, entity[*count].entityId, entity[*count].entityInst, *count, (int)(&entity[*count]), (int)entity);
+        printf("mchStoreAssocDevEntInfo: Found assoc dev rel entity owner 0x%02x contained id 0x%02x inst 0x%02x index "
+               "%i entity point addr %i %i\n",
+               entity[*count].addr, entity[*count].entityId, entity[*count].entityInst, *count, (int)(&entity[*count]),
+               (int)entity);
 #endif
+    }
 
-	}
-
-	(*count)++;
+    (*count)++;
 }
 
-static void
-mchStoreAssocEntInfo(Entity entity, uint8_t id, uint8_t inst, int parm, int *count)
-{
+static void mchStoreAssocEntInfo(Entity entity, uint8_t id, uint8_t inst, int parm, int* count) {
 
-	if ( parm ) {
+    if (parm) {
 
-		entity[*count].entityId   = id;
-		entity[*count].entityInst = inst;
+        entity[*count].entityId   = id;
+        entity[*count].entityInst = inst;
+    }
 
-	}
-
-	(*count)++;
+    (*count)++;
 }
 
 /* Parm of 0 return count of contained entities
- * Parm of 1 stores contained entity info 
+ * Parm of 1 stores contained entity info
  */
-static int
-mchGetAssocEntInfo(MchSys mchSys, Entity entity, uint8_t addr, uint8_t chan, uint8_t entityId, uint8_t entityInst, int parm)
-{
-EntAssoc       eassoc;
-DevEntAssoc    dassoc;
-SdrEntAssoc    esdr;
-SdrDevEntAssoc dsdr;
-int i, j, range, count = 0;
+static int mchGetAssocEntInfo(MchSys mchSys, Entity entity, uint8_t addr, uint8_t chan, uint8_t entityId,
+                              uint8_t entityInst, int parm) {
+    EntAssoc       eassoc;
+    DevEntAssoc    dassoc;
+    SdrEntAssoc    esdr;
+    SdrDevEntAssoc dsdr;
+    int            i, j, range, count = 0;
 
-	for ( i = 0; i < mchSys->devEntAssocCount; i++ ) {
-		dassoc = &mchSys->devEntAssoc[i];
-		dsdr   = &dassoc->sdr;
+    for (i = 0; i < mchSys->devEntAssocCount; i++) {
+        dassoc = &mchSys->devEntAssoc[i];
+        dsdr   = &dassoc->sdr;
 
-		if ( ((addr == dassoc->ownerAddr)  || (addr == dsdr->cntnrAddr)) &&
-		     ((chan == dassoc->ownerChan)  || (chan == dsdr->cntnrChan)) &&
-		     (entityId   == dsdr->cntnrId) &&
-		     (entityInst == dsdr->cntnrInst) ) {
-			
-			if ( ENTITY_ASSOC_FLAGS_RANGE( dsdr->flags ) ) { /* If contained entities are stored in range */
-				
-				range = dsdr->cntndInst2 - dsdr->cntndInst1;
+        if (((addr == dassoc->ownerAddr) || (addr == dsdr->cntnrAddr)) &&
+            ((chan == dassoc->ownerChan) || (chan == dsdr->cntnrChan)) && (entityId == dsdr->cntnrId) &&
+            (entityInst == dsdr->cntnrInst)) {
 
-				for ( j = 0; j < range; j++ )
+            if (ENTITY_ASSOC_FLAGS_RANGE(dsdr->flags)) { /* If contained entities are stored in range */
 
-					mchStoreAssocDevEntInfo( entity, dassoc, dsdr->cntnrAddr, dsdr->cntndId1, dsdr->cntndInst1 + j, 
-								 dsdr->cntndAddr1, dsdr->cntndChan1, parm, &count );
+                range = dsdr->cntndInst2 - dsdr->cntndInst1;
 
-				if ( dsdr->cntndInst2 > 0 ) { /* If second range is also populated */
+                for (j = 0; j < range; j++) {
 
-					range = dsdr->cntndInst4 - dsdr->cntndInst3;
+                    mchStoreAssocDevEntInfo(entity, dassoc, dsdr->cntnrAddr, dsdr->cntndId1, dsdr->cntndInst1 + j,
+                                            dsdr->cntndAddr1, dsdr->cntndChan1, parm, &count);
+                }
 
-					for ( j = 0; j < range; j++ )
+                if (dsdr->cntndInst2 > 0) { /* If second range is also populated */
 
-						mchStoreAssocDevEntInfo( entity, dassoc, dsdr->cntnrAddr, dsdr->cntndId1, dsdr->cntndInst2 + j, 
-									dsdr->cntndAddr2, dsdr->cntndChan2, parm, &count );
-				}
-			}
-			else { /* If contained entities are stored in list */
+                    range = dsdr->cntndInst4 - dsdr->cntndInst3;
 
-				mchStoreAssocDevEntInfo( entity, dassoc, dsdr->cntnrAddr, dsdr->cntndId1, dsdr->cntndInst1, 
-								 dsdr->cntndAddr1, dsdr->cntndChan1, parm, &count );
+                    for (j = 0; j < range; j++) {
 
-				if ( dsdr->cntndInst2 > 0 ) /* Second in list exists */
+                        mchStoreAssocDevEntInfo(entity, dassoc, dsdr->cntnrAddr, dsdr->cntndId1, dsdr->cntndInst2 + j,
+                                                dsdr->cntndAddr2, dsdr->cntndChan2, parm, &count);
+                    }
+                }
+            } else { /* If contained entities are stored in list */
 
-					mchStoreAssocDevEntInfo( entity, dassoc, dsdr->cntnrAddr, dsdr->cntndId2, dsdr->cntndInst2, 
-								dsdr->cntndAddr2, dsdr->cntndChan2, parm, &count );
+                mchStoreAssocDevEntInfo(entity, dassoc, dsdr->cntnrAddr, dsdr->cntndId1, dsdr->cntndInst1,
+                                        dsdr->cntndAddr1, dsdr->cntndChan1, parm, &count);
 
-				if ( dsdr->cntndInst3 > 0 ) /* Third in list exists */
+                if (dsdr->cntndInst2 > 0) { /* Second in list exists */
 
-					mchStoreAssocDevEntInfo( entity, dassoc, dsdr->cntnrAddr, dsdr->cntndId3, dsdr->cntndInst3, 
-								dsdr->cntndAddr3, dsdr->cntndChan3, parm, &count );
+                    mchStoreAssocDevEntInfo(entity, dassoc, dsdr->cntnrAddr, dsdr->cntndId2, dsdr->cntndInst2,
+                                            dsdr->cntndAddr2, dsdr->cntndChan2, parm, &count);
+                }
 
-				if ( dsdr->cntndInst4 > 0 ) /* Fourth in list exists */
+                if (dsdr->cntndInst3 > 0) { /* Third in list exists */
 
-					mchStoreAssocDevEntInfo( entity, dassoc, dsdr->cntnrAddr, dsdr->cntndId4, dsdr->cntndInst4, 
-								dsdr->cntndAddr4, dsdr->cntndChan4, parm, &count );
-			}
+                    mchStoreAssocDevEntInfo(entity, dassoc, dsdr->cntnrAddr, dsdr->cntndId3, dsdr->cntndInst3,
+                                            dsdr->cntndAddr3, dsdr->cntndChan3, parm, &count);
+                }
 
-			if ( 0 == ENTITY_ASSOC_FLAGS_LINK( dassoc->sdr.flags ) )
-				break; /* Should be no further assocated entities for this container */
-		}
-       	}
+                if (dsdr->cntndInst4 > 0) { /* Fourth in list exists */
 
-	for ( i = 0; i < mchSys->entAssocCount; i++ ) {
-		eassoc = &mchSys->entAssoc[i];
-		esdr   = &eassoc->sdr;
+                    mchStoreAssocDevEntInfo(entity, dassoc, dsdr->cntnrAddr, dsdr->cntndId4, dsdr->cntndInst4,
+                                            dsdr->cntndAddr4, dsdr->cntndChan4, parm, &count);
+                }
+            }
 
-		if ( (entityId   == eassoc->sdr.cntnrId) &&
-		     (entityInst == eassoc->sdr.cntnrInst) ) {
-			
-			if ( ENTITY_ASSOC_FLAGS_RANGE( esdr->flags ) ) { /* If contained entities are stored in range */
-				
-				range = esdr->cntndInst2 - esdr->cntndInst1;
+            if (0 == ENTITY_ASSOC_FLAGS_LINK(dassoc->sdr.flags)) {
+                break; /* Should be no further assocated entities for this container */
+            }
+        }
+    }
 
-				for ( j = 0; j < range; j++ )
+    for (i = 0; i < mchSys->entAssocCount; i++) {
+        eassoc = &mchSys->entAssoc[i];
+        esdr   = &eassoc->sdr;
 
-					mchStoreAssocEntInfo( entity, esdr->cntndId1, esdr->cntndInst1 + j, parm, &count );
+        if ((entityId == eassoc->sdr.cntnrId) && (entityInst == eassoc->sdr.cntnrInst)) {
 
-				if ( esdr->cntndInst2 > 0 ) { /* If second range is also populated */
+            if (ENTITY_ASSOC_FLAGS_RANGE(esdr->flags)) { /* If contained entities are stored in range */
 
-					range = esdr->cntndInst4 - esdr->cntndInst3;
+                range = esdr->cntndInst2 - esdr->cntndInst1;
 
-					for ( j = 0; j < range; j++ )
+                for (j = 0; j < range; j++) {
 
-						mchStoreAssocEntInfo( entity, esdr->cntndId2, esdr->cntndInst2 + j, parm, &count );
-				}
-			}
-			else { /* If contained entities are stored in list */
+                    mchStoreAssocEntInfo(entity, esdr->cntndId1, esdr->cntndInst1 + j, parm, &count);
+                }
 
-				mchStoreAssocEntInfo( entity, esdr->cntndId1, esdr->cntndInst1, parm, &count );
+                if (esdr->cntndInst2 > 0) { /* If second range is also populated */
 
-				if ( esdr->cntndInst2 > 0 ) /* Second in list exists */
+                    range = esdr->cntndInst4 - esdr->cntndInst3;
 
-					mchStoreAssocEntInfo( entity, esdr->cntndId2, esdr->cntndInst2, parm, &count );
+                    for (j = 0; j < range; j++) {
 
-				if ( esdr->cntndInst3 > 0 ) /* Third in list exists */
+                        mchStoreAssocEntInfo(entity, esdr->cntndId2, esdr->cntndInst2 + j, parm, &count);
+                    }
+                }
+            } else { /* If contained entities are stored in list */
 
-					mchStoreAssocEntInfo( entity, esdr->cntndId3, esdr->cntndInst3, parm, &count );
+                mchStoreAssocEntInfo(entity, esdr->cntndId1, esdr->cntndInst1, parm, &count);
 
-				if ( esdr->cntndInst4 > 0 ) /* Fourth in list exists */
+                if (esdr->cntndInst2 > 0) { /* Second in list exists */
 
-					mchStoreAssocEntInfo( entity, esdr->cntndId4, esdr->cntndInst4, parm, &count );
-			}
+                    mchStoreAssocEntInfo(entity, esdr->cntndId2, esdr->cntndInst2, parm, &count);
+                }
 
-			if ( 0 == ENTITY_ASSOC_FLAGS_LINK( eassoc->sdr.flags ) )
-				break; /* Should be no further assocated entities for this container */
-		}
-       	}
+                if (esdr->cntndInst3 > 0) { /* Third in list exists */
 
-	if ( parm )
-		return 0;
-	else
-		return count; 
+                    mchStoreAssocEntInfo(entity, esdr->cntndId3, esdr->cntndInst3, parm, &count);
+                }
+
+                if (esdr->cntndInst4 > 0) { /* Fourth in list exists */
+
+                    mchStoreAssocEntInfo(entity, esdr->cntndId4, esdr->cntndInst4, parm, &count);
+                }
+            }
+
+            if (0 == ENTITY_ASSOC_FLAGS_LINK(eassoc->sdr.flags)) {
+                break; /* Should be no further assocated entities for this container */
+            }
+        }
+    }
+
+    if (parm) {
+        return 0;
+    } else {
+        return count;
+    }
 }
 
-static void
-mchSdrGetAssocEntInfo(MchData mchData, int parm)
-{
-MchSys mchSys  = mchData->mchSys;
-int  rval, i;
-Fru  fru;
-Mgmt mgmt;
+static void mchSdrGetAssocEntInfo(MchData mchData, int parm) {
+    MchSys mchSys = mchData->mchSys;
+    int    rval, i;
+    Fru    fru;
+    Mgmt   mgmt;
 
-/* Modify to not duplicate between fru and mgmt */
+    /* Modify to not duplicate between fru and mgmt */
 
-	for ( i = 0; i < mchSys->fruCount; i++ ) {
-		fru = &mchSys->fru[i];
+    for (i = 0; i < mchSys->fruCount; i++) {
+        fru = &mchSys->fru[i];
 
-		rval = mchGetAssocEntInfo( mchSys, fru->entity, fru->sdr.addr, fru->sdr.chan, fru->sdr.entityId, fru->sdr.entityInst, parm);
+        rval = mchGetAssocEntInfo(mchSys, fru->entity, fru->sdr.addr, fru->sdr.chan, fru->sdr.entityId,
+                                  fru->sdr.entityInst, parm);
 
-		if ( 0 == parm ) {
-			if ( (fru->entityCount = rval) > 0 ) {
-				if ( 0 == (fru->entity = calloc( rval, sizeof( EntityRec ) ) ) )
-					cantProceed("FATAL ERROR: No memory for FRU entity structure for %s\n", mchData->mchSess->name);
-				fru->entityAlloc = 1;
-			}
-		}
-	}
+        if (0 == parm) {
+            if ((fru->entityCount = rval) > 0) {
+                if (0 == (fru->entity = calloc(rval, sizeof(EntityRec)))) {
+                    cantProceed("FATAL ERROR: No memory for FRU entity structure for %s\n", mchData->mchSess->name);
+                }
+                fru->entityAlloc = 1;
+            }
+        }
+    }
 
-	for ( i = 0; i < mchSys->mgmtCount; i++ ) {
-		mgmt = &mchSys->mgmt[i];
-		rval = mchGetAssocEntInfo( mchSys, mgmt->entity, mgmt->sdr.addr, mgmt->sdr.chan, mgmt->sdr.entityId, mgmt->sdr.entityInst, parm);
+    for (i = 0; i < mchSys->mgmtCount; i++) {
+        mgmt = &mchSys->mgmt[i];
+        rval = mchGetAssocEntInfo(mchSys, mgmt->entity, mgmt->sdr.addr, mgmt->sdr.chan, mgmt->sdr.entityId,
+                                  mgmt->sdr.entityInst, parm);
 
-		if ( 0 == parm ) {
-			if ( (mgmt->entityCount = rval) > 0 ) {
-				if ( 0 == (mgmt->entity = calloc( rval, sizeof( EntityRec ) ) ) )
-					cantProceed("FATAL ERROR: No memory for MGMT entity structure for %s\n", mchData->mchSess->name);
-				mgmt->entityAlloc = 1;
-			}
-		}
-	}
+        if (0 == parm) {
+            if ((mgmt->entityCount = rval) > 0) {
+                if (0 == (mgmt->entity = calloc(rval, sizeof(EntityRec)))) {
+                    cantProceed("FATAL ERROR: No memory for MGMT entity structure for %s\n", mchData->mchSess->name);
+                }
+                mgmt->entityAlloc = 1;
+            }
+        }
+    }
 }
 
-static void
-mchSdrGetAssocEnt(MchData mchData)
-{
+static void mchSdrGetAssocEnt(MchData mchData) {
 
-	mchSdrGetAssocEntInfo( mchData, 0 );
-	mchSdrGetAssocEntInfo( mchData, 1 );
-
+    mchSdrGetAssocEntInfo(mchData, 0);
+    mchSdrGetAssocEntInfo(mchData, 1);
 }
 
-/* 
+/*
  * Store SDR for one Entity Assocation Record into Entity Assoc data structure
  *
  * Caller must perform locking.
  */
-static void
-mchSdrEntAssoc(SdrEntAssoc sdr, uint8_t *raw)
-{
-int n;
+static void mchSdrEntAssoc(SdrEntAssoc sdr, uint8_t* raw) {
+    int n;
 
-	n = SDR_HEADER_LENGTH + raw[SDR_LENGTH_OFFSET];
+    n = SDR_HEADER_LENGTH + raw[SDR_LENGTH_OFFSET];
 
-	sdr->id[0]      = raw[SDR_ID_LSB_OFFSET];
-	sdr->id[1]      = raw[SDR_ID_MSB_OFFSET];
-	sdr->ver        = raw[SDR_VER_OFFSET];
-	sdr->recType    = raw[SDR_REC_TYPE_OFFSET];
-	sdr->length     = raw[SDR_LENGTH_OFFSET];
+    sdr->id[0]   = raw[SDR_ID_LSB_OFFSET];
+    sdr->id[1]   = raw[SDR_ID_MSB_OFFSET];
+    sdr->ver     = raw[SDR_VER_OFFSET];
+    sdr->recType = raw[SDR_REC_TYPE_OFFSET];
+    sdr->length  = raw[SDR_LENGTH_OFFSET];
 
-	sdr->cntnrId    = raw[SDR_CNTNR_ENTITY_ID_OFFSET];   
-	sdr->cntnrInst  = raw[SDR_CNTNR_ENTITY_INST_OFFSET]; 
-	sdr->flags         = raw[SDR_ENTITY_ASSOC_FLAGS_OFFSET];         
-	sdr->cntndId1   = raw[SDR_CNTND_ENTITY_ID1_OFFSET];  
-	sdr->cntndInst1 = raw[SDR_CNTND_ENTITY_INST1_OFFSET];
-	sdr->cntndId2   = raw[SDR_CNTND_ENTITY_ID2_OFFSET];  
-	sdr->cntndInst2 = raw[SDR_CNTND_ENTITY_INST2_OFFSET];
-	sdr->cntndId3   = raw[SDR_CNTND_ENTITY_ID3_OFFSET];  
-	sdr->cntndInst3 = raw[SDR_CNTND_ENTITY_INST3_OFFSET];
-	sdr->cntndId4   = raw[SDR_CNTND_ENTITY_ID4_OFFSET];  
-	sdr->cntndInst4 = raw[SDR_CNTND_ENTITY_INST4_OFFSET];
+    sdr->cntnrId    = raw[SDR_CNTNR_ENTITY_ID_OFFSET];
+    sdr->cntnrInst  = raw[SDR_CNTNR_ENTITY_INST_OFFSET];
+    sdr->flags      = raw[SDR_ENTITY_ASSOC_FLAGS_OFFSET];
+    sdr->cntndId1   = raw[SDR_CNTND_ENTITY_ID1_OFFSET];
+    sdr->cntndInst1 = raw[SDR_CNTND_ENTITY_INST1_OFFSET];
+    sdr->cntndId2   = raw[SDR_CNTND_ENTITY_ID2_OFFSET];
+    sdr->cntndInst2 = raw[SDR_CNTND_ENTITY_INST2_OFFSET];
+    sdr->cntndId3   = raw[SDR_CNTND_ENTITY_ID3_OFFSET];
+    sdr->cntndInst3 = raw[SDR_CNTND_ENTITY_INST3_OFFSET];
+    sdr->cntndId4   = raw[SDR_CNTND_ENTITY_ID4_OFFSET];
+    sdr->cntndInst4 = raw[SDR_CNTND_ENTITY_INST4_OFFSET];
 }
 
-/* 
+/*
  * Store SDR for one Device-relative Entity Assocation Record into Device-relative Entity Assoc data structure
  *
  * Caller must perform locking.
  */
-static void
-mchSdrDevEntAssoc(SdrDevEntAssoc sdr, uint8_t *raw, uint8_t owner)
-{
-int n;
+static void mchSdrDevEntAssoc(SdrDevEntAssoc sdr, uint8_t* raw, uint8_t owner) {
+    int n;
 
-	n = SDR_HEADER_LENGTH + raw[SDR_LENGTH_OFFSET];
+    n = SDR_HEADER_LENGTH + raw[SDR_LENGTH_OFFSET];
 
-	sdr->id[0]      = raw[SDR_ID_LSB_OFFSET];
-	sdr->id[1]      = raw[SDR_ID_MSB_OFFSET];
-	sdr->ver        = raw[SDR_VER_OFFSET];
-	sdr->recType    = raw[SDR_REC_TYPE_OFFSET];
-	sdr->length     = raw[SDR_LENGTH_OFFSET];
+    sdr->id[0]   = raw[SDR_ID_LSB_OFFSET];
+    sdr->id[1]   = raw[SDR_ID_MSB_OFFSET];
+    sdr->ver     = raw[SDR_VER_OFFSET];
+    sdr->recType = raw[SDR_REC_TYPE_OFFSET];
+    sdr->length  = raw[SDR_LENGTH_OFFSET];
 
-	sdr->cntnrId    = raw[SDR_CNTNR_ENTITY_ID_OFFSET];   
-	sdr->cntnrInst  = raw[SDR_CNTNR_ENTITY_INST_OFFSET]; 
-	sdr->cntnrAddr     = raw[SDR_DEV_CNTNR_ADDR_OFFSET];    
-	sdr->cntnrChan     = raw[SDR_DEV_CNTNR_CHAN_OFFSET];    
-	sdr->flags         = raw[SDR_DEV_ENTITY_ASSOC_FLAGS_OFFSET];        
-	sdr->cntndAddr1    = raw[SDR_DEV_CNTND_ADDR1_OFFSET];  
-	sdr->cntndChan1    = raw[SDR_DEV_CNTND_CHAN1_OFFSET];  
-	sdr->cntndId1   = raw[SDR_DEV_CNTND_ENTITY_ID1_OFFSET];  
-	sdr->cntndInst1 = raw[SDR_DEV_CNTND_ENTITY_INST1_OFFSET];
-	sdr->cntndAddr2    = raw[SDR_DEV_CNTND_ADDR2_OFFSET];  
-	sdr->cntndChan2    = raw[SDR_DEV_CNTND_CHAN2_OFFSET];  
-	sdr->cntndId2   = raw[SDR_DEV_CNTND_ENTITY_ID2_OFFSET];  
-	sdr->cntndInst2 = raw[SDR_DEV_CNTND_ENTITY_INST2_OFFSET];
-	sdr->cntndAddr3    = raw[SDR_DEV_CNTND_ADDR3_OFFSET];  
-	sdr->cntndChan3    = raw[SDR_DEV_CNTND_CHAN3_OFFSET];  
-	sdr->cntndId3   = raw[SDR_DEV_CNTND_ENTITY_ID3_OFFSET];  
-	sdr->cntndInst3 = raw[SDR_DEV_CNTND_ENTITY_INST3_OFFSET];
-	sdr->cntndAddr4    = raw[SDR_DEV_CNTND_ADDR4_OFFSET];  
-	sdr->cntndChan4    = raw[SDR_DEV_CNTND_CHAN4_OFFSET];  
-	sdr->cntndId4   = raw[SDR_DEV_CNTND_ENTITY_ID4_OFFSET];  
-	sdr->cntndInst4 = raw[SDR_DEV_CNTND_ENTITY_INST4_OFFSET];
+    sdr->cntnrId    = raw[SDR_CNTNR_ENTITY_ID_OFFSET];
+    sdr->cntnrInst  = raw[SDR_CNTNR_ENTITY_INST_OFFSET];
+    sdr->cntnrAddr  = raw[SDR_DEV_CNTNR_ADDR_OFFSET];
+    sdr->cntnrChan  = raw[SDR_DEV_CNTNR_CHAN_OFFSET];
+    sdr->flags      = raw[SDR_DEV_ENTITY_ASSOC_FLAGS_OFFSET];
+    sdr->cntndAddr1 = raw[SDR_DEV_CNTND_ADDR1_OFFSET];
+    sdr->cntndChan1 = raw[SDR_DEV_CNTND_CHAN1_OFFSET];
+    sdr->cntndId1   = raw[SDR_DEV_CNTND_ENTITY_ID1_OFFSET];
+    sdr->cntndInst1 = raw[SDR_DEV_CNTND_ENTITY_INST1_OFFSET];
+    sdr->cntndAddr2 = raw[SDR_DEV_CNTND_ADDR2_OFFSET];
+    sdr->cntndChan2 = raw[SDR_DEV_CNTND_CHAN2_OFFSET];
+    sdr->cntndId2   = raw[SDR_DEV_CNTND_ENTITY_ID2_OFFSET];
+    sdr->cntndInst2 = raw[SDR_DEV_CNTND_ENTITY_INST2_OFFSET];
+    sdr->cntndAddr3 = raw[SDR_DEV_CNTND_ADDR3_OFFSET];
+    sdr->cntndChan3 = raw[SDR_DEV_CNTND_CHAN3_OFFSET];
+    sdr->cntndId3   = raw[SDR_DEV_CNTND_ENTITY_ID3_OFFSET];
+    sdr->cntndInst3 = raw[SDR_DEV_CNTND_ENTITY_INST3_OFFSET];
+    sdr->cntndAddr4 = raw[SDR_DEV_CNTND_ADDR4_OFFSET];
+    sdr->cntndChan4 = raw[SDR_DEV_CNTND_CHAN4_OFFSET];
+    sdr->cntndId4   = raw[SDR_DEV_CNTND_ENTITY_ID4_OFFSET];
+    sdr->cntndInst4 = raw[SDR_DEV_CNTND_ENTITY_INST4_OFFSET];
 }
 
 /* Check if this FRU has already been stored in data
  * structure. If so, return -1, else 0
  */
-static int
-mchSdrFruDuplicate(MchSys mchSys, uint8_t *raw)
-{
-int i;
-SdrFruRec tmp;
-FruRec     fru;
+static int mchSdrFruDuplicate(MchSys mchSys, uint8_t* raw) {
+    int       i;
+    SdrFruRec tmp;
+    FruRec    fru;
 
-	tmp.addr       = raw[SDR_FRU_ADDR_OFFSET];
-	tmp.lun        = raw[SDR_FRU_LUN_OFFSET];
-	tmp.chan       = raw[SDR_FRU_CHAN_OFFSET];
-	tmp.entityId   = raw[SDR_FRU_ENTITY_ID_OFFSET];
-	tmp.entityInst = raw[SDR_FRU_ENTITY_INST_OFFSET];
+    tmp.addr       = raw[SDR_FRU_ADDR_OFFSET];
+    tmp.lun        = raw[SDR_FRU_LUN_OFFSET];
+    tmp.chan       = raw[SDR_FRU_CHAN_OFFSET];
+    tmp.entityId   = raw[SDR_FRU_ENTITY_ID_OFFSET];
+    tmp.entityInst = raw[SDR_FRU_ENTITY_INST_OFFSET];
 
-	for ( i = 0; i < mchSys->fruCount; i++ ) {
+    for (i = 0; i < mchSys->fruCount; i++) {
 
-		fru = mchSys->fru[i];
+        fru = mchSys->fru[i];
 
-		if ( (tmp.addr       == fru.sdr.addr)     &&
-		     (tmp.lun        == fru.sdr.lun)      &&
-		     (tmp.chan       == fru.sdr.chan)     &&
-		     (tmp.entityId   == fru.sdr.entityId) &&
-		     (tmp.entityInst == fru.sdr.entityInst) ) {
+        if ((tmp.addr == fru.sdr.addr) && (tmp.lun == fru.sdr.lun) && (tmp.chan == fru.sdr.chan) &&
+            (tmp.entityId == fru.sdr.entityId) && (tmp.entityInst == fru.sdr.entityInst)) {
 
-			return -1;
-		}
-	}
-	return 0;
+            return -1;
+        }
+    }
+    return 0;
 }
 
-/* 
+/*
  * Store SDR for one FRU into FRU data structure
  *
  * Caller must perform locking.
  */
-static void
-mchSdrFruDev(SdrFru sdr, uint8_t *raw)
-{
-int n, l, i;
-	n = SDR_HEADER_LENGTH + raw[SDR_LENGTH_OFFSET];
+static void mchSdrFruDev(SdrFru sdr, uint8_t* raw) {
+    int n, l, i;
+    n = SDR_HEADER_LENGTH + raw[SDR_LENGTH_OFFSET];
 
-	sdr->id[0]      = raw[SDR_ID_LSB_OFFSET];
-	sdr->id[1]      = raw[SDR_ID_MSB_OFFSET];
-	sdr->ver        = raw[SDR_VER_OFFSET];
-	sdr->recType    = raw[SDR_REC_TYPE_OFFSET];
-	sdr->length     = raw[SDR_LENGTH_OFFSET];
-	sdr->addr       = raw[SDR_FRU_ADDR_OFFSET];
-	sdr->fruId      = raw[SDR_FRU_ID_OFFSET];
-	sdr->lun        = raw[SDR_FRU_LUN_OFFSET];
-	sdr->chan       = raw[SDR_FRU_CHAN_OFFSET];
-	sdr->devType    = raw[SDR_FRU_TYPE_OFFSET];
-	sdr->devMod     = raw[SDR_FRU_TYPE_MOD_OFFSET];
-	sdr->entityId   = raw[SDR_FRU_ENTITY_ID_OFFSET];
-	sdr->entityInst = raw[SDR_FRU_ENTITY_INST_OFFSET];
-	sdr->strLength  = raw[SDR_FRU_STR_LENGTH_OFFSET];
+    sdr->id[0]      = raw[SDR_ID_LSB_OFFSET];
+    sdr->id[1]      = raw[SDR_ID_MSB_OFFSET];
+    sdr->ver        = raw[SDR_VER_OFFSET];
+    sdr->recType    = raw[SDR_REC_TYPE_OFFSET];
+    sdr->length     = raw[SDR_LENGTH_OFFSET];
+    sdr->addr       = raw[SDR_FRU_ADDR_OFFSET];
+    sdr->fruId      = raw[SDR_FRU_ID_OFFSET];
+    sdr->lun        = raw[SDR_FRU_LUN_OFFSET];
+    sdr->chan       = raw[SDR_FRU_CHAN_OFFSET];
+    sdr->devType    = raw[SDR_FRU_TYPE_OFFSET];
+    sdr->devMod     = raw[SDR_FRU_TYPE_MOD_OFFSET];
+    sdr->entityId   = raw[SDR_FRU_ENTITY_ID_OFFSET];
+    sdr->entityInst = raw[SDR_FRU_ENTITY_INST_OFFSET];
+    sdr->strLength  = raw[SDR_FRU_STR_LENGTH_OFFSET];
 
-	l = IPMI_DATA_LENGTH( sdr->strLength );
-	for ( i = 0; i < l; i++ )
-	       	sdr->str[i] = raw[SDR_FRU_STR_OFFSET + i];
-       	sdr->str[i+1] = '\0';
-
+    l = IPMI_DATA_LENGTH(sdr->strLength);
+    for (i = 0; i < l; i++) {
+        sdr->str[i] = raw[SDR_FRU_STR_OFFSET + i];
+    }
+    sdr->str[i + 1] = '\0';
 }
 
 /* Check if this management controller has already been stored in data
  * structure. If so, return -1, else 0
  */
-static int
-mchSdrMgmtCtrlDuplicate(MchSys mchSys, uint8_t *raw)
-{
-int i;
-SdrMgmtRec tmp;
-MgmtRec    mgmt;
+static int mchSdrMgmtCtrlDuplicate(MchSys mchSys, uint8_t* raw) {
+    int        i;
+    SdrMgmtRec tmp;
+    MgmtRec    mgmt;
 
-	tmp.addr       = raw[SDR_MGMT_ADDR_OFFSET];
-	tmp.chan       = IPMI_CHAN_NUMBER( raw[SDR_MGMT_CHAN_OFFSET] );
+    tmp.addr = raw[SDR_MGMT_ADDR_OFFSET];
+    tmp.chan = IPMI_CHAN_NUMBER(raw[SDR_MGMT_CHAN_OFFSET]);
 
-	for ( i = 0; i < mchSys->mgmtCount; i++ ) {
+    for (i = 0; i < mchSys->mgmtCount; i++) {
 
-		mgmt = mchSys->mgmt[i];
+        mgmt = mchSys->mgmt[i];
 
-		if ( (tmp.addr == mgmt.sdr.addr)    &&
-		     (tmp.chan == mgmt.sdr.chan) ) {
-			return -1;
-		}
-	}
-	return 0;
+        if ((tmp.addr == mgmt.sdr.addr) && (tmp.chan == mgmt.sdr.chan)) {
+            return -1;
+        }
+    }
+    return 0;
 }
 
-/* 
+/*
  * Store SDR for one management controller device into data structure
  *
  * Caller must perform locking.
  */
-static void
-mchSdrMgmtCtrlDev(SdrMgmt sdr, uint8_t *raw)
-{
-int n, l, i;
+static void mchSdrMgmtCtrlDev(SdrMgmt sdr, uint8_t* raw) {
+    int n, l, i;
 
-	n = SDR_HEADER_LENGTH + raw[SDR_LENGTH_OFFSET];
+    n = SDR_HEADER_LENGTH + raw[SDR_LENGTH_OFFSET];
 
-	sdr->id[0]      = raw[SDR_ID_LSB_OFFSET];
-	sdr->id[1]      = raw[SDR_ID_MSB_OFFSET];
-	sdr->ver        = raw[SDR_VER_OFFSET];
-	sdr->recType    = raw[SDR_REC_TYPE_OFFSET];
-	sdr->length     = raw[SDR_LENGTH_OFFSET];
-	sdr->addr       = /*IPMI_DEVICE_SLAVE_ADDR( */raw[SDR_MGMT_ADDR_OFFSET] /*)*/;
-	sdr->chan       = IPMI_CHAN_NUMBER( raw[SDR_MGMT_CHAN_OFFSET] );
-	sdr->pwr        = raw[SDR_MGMT_PWR_OFFSET];
-	sdr->cap        = raw[SDR_MGMT_CAP_OFFSET];
-	sdr->entityId   = raw[SDR_MGMT_ENTITY_ID_OFFSET];
-	sdr->entityInst = raw[SDR_MGMT_ENTITY_INST_OFFSET];
-	sdr->strLength  = raw[SDR_MGMT_STR_LENGTH_OFFSET];
-			
-	l = IPMI_DATA_LENGTH( sdr->strLength );
+    sdr->id[0]      = raw[SDR_ID_LSB_OFFSET];
+    sdr->id[1]      = raw[SDR_ID_MSB_OFFSET];
+    sdr->ver        = raw[SDR_VER_OFFSET];
+    sdr->recType    = raw[SDR_REC_TYPE_OFFSET];
+    sdr->length     = raw[SDR_LENGTH_OFFSET];
+    sdr->addr       = /*IPMI_DEVICE_SLAVE_ADDR( */ raw[SDR_MGMT_ADDR_OFFSET] /*)*/;
+    sdr->chan       = IPMI_CHAN_NUMBER(raw[SDR_MGMT_CHAN_OFFSET]);
+    sdr->pwr        = raw[SDR_MGMT_PWR_OFFSET];
+    sdr->cap        = raw[SDR_MGMT_CAP_OFFSET];
+    sdr->entityId   = raw[SDR_MGMT_ENTITY_ID_OFFSET];
+    sdr->entityInst = raw[SDR_MGMT_ENTITY_INST_OFFSET];
+    sdr->strLength  = raw[SDR_MGMT_STR_LENGTH_OFFSET];
 
-	for ( i = 0; i < l; i++ )
-	       	sdr->str[i] = raw[SDR_MGMT_STR_OFFSET + i];
-       	sdr->str[i+1] = '\0';
+    l = IPMI_DATA_LENGTH(sdr->strLength);
+
+    for (i = 0; i < l; i++) {
+        sdr->str[i] = raw[SDR_MGMT_STR_OFFSET + i];
+    }
+    sdr->str[i + 1] = '\0';
 }
 
 /* Check if this sensor has already been stored in data
  * structure. If so, return -1, else 0
  */
-static int
-mchSdrSensDuplicate(MchSys mchSys, uint8_t *raw)
-{
-int i;
-SdrFullRec tmp;
-SensorRec  sens;
+static int mchSdrSensDuplicate(MchSys mchSys, uint8_t* raw) {
+    int        i;
+    SdrFullRec tmp;
+    SensorRec  sens;
 
-	tmp.owner      = raw[SDR_OWNER_OFFSET];
-	tmp.lun        = raw[SDR_LUN_OFFSET];
-	tmp.number     = raw[SDR_NUMBER_OFFSET];
-	tmp.entityId   = raw[SDR_ENTITY_ID_OFFSET];
-	tmp.entityInst = raw[SDR_ENTITY_INST_OFFSET];
+    tmp.owner      = raw[SDR_OWNER_OFFSET];
+    tmp.lun        = raw[SDR_LUN_OFFSET];
+    tmp.number     = raw[SDR_NUMBER_OFFSET];
+    tmp.entityId   = raw[SDR_ENTITY_ID_OFFSET];
+    tmp.entityInst = raw[SDR_ENTITY_INST_OFFSET];
 
-	for ( i = 0; i < mchSys->sensCount; i++ ) {
+    for (i = 0; i < mchSys->sensCount; i++) {
 
-		sens = mchSys->sens[i];
+        sens = mchSys->sens[i];
 
-		if ( (tmp.owner      == sens.sdr.owner)    &&
-		     (tmp.lun        == sens.sdr.lun)      &&
-		     (tmp.number     == sens.sdr.number)   &&
-		     (tmp.entityId   == sens.sdr.entityId) &&
-		     (tmp.entityInst == sens.sdr.entityInst) ) {
+        if ((tmp.owner == sens.sdr.owner) && (tmp.lun == sens.sdr.lun) && (tmp.number == sens.sdr.number) &&
+            (tmp.entityId == sens.sdr.entityId) && (tmp.entityInst == sens.sdr.entityInst)) {
 
-			return -1;
-		}
-	}
-	return 0;
+            return -1;
+        }
+    }
+    return 0;
 }
 
-/* 
+/*
  * Store SDR for one sensor into sensor data structure
  *
  * Caller must perform locking.
  */
-static void
-mchSdrFullSens(SdrFull sdr, uint8_t *raw, int type)
-{
-int n, i, l = 0;
-int m = 0, b = 0;
+static void mchSdrFullSens(SdrFull sdr, uint8_t* raw, int type) {
+    int n, i, l = 0;
+    int m = 0, b = 0;
 
-	n = SDR_HEADER_LENGTH + raw[SDR_LENGTH_OFFSET];
+    n = SDR_HEADER_LENGTH + raw[SDR_LENGTH_OFFSET];
 
-	sdr->id[0]      = raw[SDR_ID_LSB_OFFSET];
-	sdr->id[1]      = raw[SDR_ID_MSB_OFFSET];
-	sdr->ver        = raw[SDR_VER_OFFSET];
-	sdr->recType    = raw[SDR_REC_TYPE_OFFSET];
-	sdr->length     = raw[SDR_LENGTH_OFFSET];
-	sdr->owner      = raw[SDR_OWNER_OFFSET];
-	sdr->lun        = raw[SDR_LUN_OFFSET];
-	sdr->number     = raw[SDR_NUMBER_OFFSET];
-	sdr->entityId   = raw[SDR_ENTITY_ID_OFFSET];
-	sdr->entityInst = raw[SDR_ENTITY_INST_OFFSET];
-	sdr->init       = raw[SDR_INIT_OFFSET];
-	sdr->cap        = raw[SDR_CAP_OFFSET];
-	sdr->sensType   = raw[SDR_SENS_TYPE_OFFSET];
-	sdr->readType   = raw[SDR_READ_TYPE_OFFSET];
+    sdr->id[0]      = raw[SDR_ID_LSB_OFFSET];
+    sdr->id[1]      = raw[SDR_ID_MSB_OFFSET];
+    sdr->ver        = raw[SDR_VER_OFFSET];
+    sdr->recType    = raw[SDR_REC_TYPE_OFFSET];
+    sdr->length     = raw[SDR_LENGTH_OFFSET];
+    sdr->owner      = raw[SDR_OWNER_OFFSET];
+    sdr->lun        = raw[SDR_LUN_OFFSET];
+    sdr->number     = raw[SDR_NUMBER_OFFSET];
+    sdr->entityId   = raw[SDR_ENTITY_ID_OFFSET];
+    sdr->entityInst = raw[SDR_ENTITY_INST_OFFSET];
+    sdr->init       = raw[SDR_INIT_OFFSET];
+    sdr->cap        = raw[SDR_CAP_OFFSET];
+    sdr->sensType   = raw[SDR_SENS_TYPE_OFFSET];
+    sdr->readType   = raw[SDR_READ_TYPE_OFFSET];
 
-	if ( type == SDR_TYPE_COMPACT_SENSOR ) {
-		sdr->strLength  = raw[SDR_COMPACT_STR_LENGTH_OFFSET];    
+    if (type == SDR_TYPE_COMPACT_SENSOR) {
+        sdr->strLength = raw[SDR_COMPACT_STR_LENGTH_OFFSET];
 
-		l = IPMI_DATA_LENGTH( sdr->strLength );
-		for ( i = 0; i < l; i++ )
-			sdr->str[i] = raw[SDR_COMPACT_STR_OFFSET + i];
-		sdr->str[i+1] = '\0';
-	}
+        l = IPMI_DATA_LENGTH(sdr->strLength);
+        for (i = 0; i < l; i++) {
+            sdr->str[i] = raw[SDR_COMPACT_STR_OFFSET + i];
+        }
+        sdr->str[i + 1] = '\0';
+    }
 
-	/* Full Sensor fields */
-	if ( type == SDR_TYPE_FULL_SENSOR ) {
+    /* Full Sensor fields */
+    if (type == SDR_TYPE_FULL_SENSOR) {
 
-		sdr->units1     = raw[SDR_UNITS1_OFFSET];      
-		sdr->units2     = raw[SDR_UNITS2_OFFSET];    
-		sdr->units3     = raw[SDR_UNITS3_OFFSET];    
-		sdr->linear     = raw[SDR_LINEAR_OFFSET];   
-		sdr->M          = raw[SDR_M_OFFSET];   
-		sdr->MTol       = raw[SDR_M_TOL_OFFSET];   
-		sdr->B          = raw[SDR_B_OFFSET];   
-		sdr->BAcc       = raw[SDR_B_ACC_OFFSET];
-		sdr->acc        = raw[SDR_ACC_OFFSET];   
-		sdr->RexpBexp   = raw[SDR_EXP_OFFSET];   
-		sdr->anlgChar   = raw[SDR_ANLG_CHAR_OFFSET];   
-		sdr->nominal    = raw[SDR_NOMINAL_OFFSET];   
-		sdr->normMax    = raw[SDR_NORM_MAX_OFFSET];   
-		sdr->normMin    = raw[SDR_NORM_MIN_OFFSET];   
-		sdr->strLength  = raw[SDR_STR_LENGTH_OFFSET];    
+        sdr->units1    = raw[SDR_UNITS1_OFFSET];
+        sdr->units2    = raw[SDR_UNITS2_OFFSET];
+        sdr->units3    = raw[SDR_UNITS3_OFFSET];
+        sdr->linear    = raw[SDR_LINEAR_OFFSET];
+        sdr->M         = raw[SDR_M_OFFSET];
+        sdr->MTol      = raw[SDR_M_TOL_OFFSET];
+        sdr->B         = raw[SDR_B_OFFSET];
+        sdr->BAcc      = raw[SDR_B_ACC_OFFSET];
+        sdr->acc       = raw[SDR_ACC_OFFSET];
+        sdr->RexpBexp  = raw[SDR_EXP_OFFSET];
+        sdr->anlgChar  = raw[SDR_ANLG_CHAR_OFFSET];
+        sdr->nominal   = raw[SDR_NOMINAL_OFFSET];
+        sdr->normMax   = raw[SDR_NORM_MAX_OFFSET];
+        sdr->normMin   = raw[SDR_NORM_MIN_OFFSET];
+        sdr->strLength = raw[SDR_STR_LENGTH_OFFSET];
 
-		m = SENSOR_CONV_M_B( sdr->M, sdr->MTol );
-		b = SENSOR_CONV_M_B( sdr->B, sdr->BAcc );
+        m = SENSOR_CONV_M_B(sdr->M, sdr->MTol);
+        b = SENSOR_CONV_M_B(sdr->B, sdr->BAcc);
 
-		sdr->m    = TWOS_COMP_SIGNED_NBIT( m, 10 );
-		sdr->b    = TWOS_COMP_SIGNED_NBIT( b, 10 );
-		sdr->rexp = TWOS_COMP_SIGNED_NBIT(SENSOR_CONV_REXP( sdr->RexpBexp ), 4 );
-		sdr->bexp = TWOS_COMP_SIGNED_NBIT(SENSOR_CONV_BEXP( sdr->RexpBexp ), 4 );
+        sdr->m    = TWOS_COMP_SIGNED_NBIT(m, 10);
+        sdr->b    = TWOS_COMP_SIGNED_NBIT(b, 10);
+        sdr->rexp = TWOS_COMP_SIGNED_NBIT(SENSOR_CONV_REXP(sdr->RexpBexp), 4);
+        sdr->bexp = TWOS_COMP_SIGNED_NBIT(SENSOR_CONV_BEXP(sdr->RexpBexp), 4);
 
-
-		l = IPMI_DATA_LENGTH( sdr->strLength );
-		for ( i = 0; i < l; i++ )
-			sdr->str[i] = raw[SDR_STR_OFFSET + i];
-		sdr->str[i+1] = '\0';
-       	}     
+        l = IPMI_DATA_LENGTH(sdr->strLength);
+        for (i = 0; i < l; i++) {
+            sdr->str[i] = raw[SDR_STR_OFFSET + i];
+        }
+        sdr->str[i + 1] = '\0';
+    }
 
 #ifdef DEBUG
-if ( l > 0 )
-printf("mchSdrFullSens: owner 0x%02x lun %i sdr number %i type 0x%02x, m %i, b %i, rexp %i bexp %i, is logical entity %i, %s\n", 
-	sdr->owner, sdr->lun, sdr->number, sdr->sensType, sdr->m, sdr->b, sdr->rexp, sdr->bexp, SDR_ENTITY_LOGICAL(sdr->entityInst), sdr->str);
-else
-printf("mchSdrFullSens: owner 0x%02x lun %i sdr number %i type 0x%02x, m %i, b %i, rexp %i bexp %i, is logical entity %i\n", 
-	sdr->owner, sdr->lun, sdr->number, sdr->sensType, sdr->m, sdr->b, sdr->rexp, sdr->bexp, SDR_ENTITY_LOGICAL(sdr->entityInst));
+    if (l > 0) {
+        printf("mchSdrFullSens: owner 0x%02x lun %i sdr number %i type 0x%02x, m %i, b %i, rexp %i bexp %i, is logical "
+               "entity %i, %s\n",
+               sdr->owner, sdr->lun, sdr->number, sdr->sensType, sdr->m, sdr->b, sdr->rexp, sdr->bexp,
+               SDR_ENTITY_LOGICAL(sdr->entityInst), sdr->str);
+    } else {
+        printf("mchSdrFullSens: owner 0x%02x lun %i sdr number %i type 0x%02x, m %i, b %i, rexp %i bexp %i, is logical "
+               "entity %i\n",
+               sdr->owner, sdr->lun, sdr->number, sdr->sensType, sdr->m, sdr->b, sdr->rexp, sdr->bexp,
+               SDR_ENTITY_LOGICAL(sdr->entityInst));
+    }
 #endif
-
 }
 
 /* If sensor read error or disabled, return error and indicate 'unavailable' in sensor data structure */
-int
-mchGetSensorReadingStat(MchData mchData, uint8_t *response, Sensor sens)//, uint8_t number, uint8_t lun, size_t *sensReadMsgLength)
+int mchGetSensorReadingStat(MchData mchData, uint8_t* response,
+                            Sensor sens) //, uint8_t number, uint8_t lun, size_t *sensReadMsgLength)
 {
-uint8_t bits;
-uint8_t rval;
-size_t  tmp = sens->readMsgLength; /* Initially set to requested msg length, 
-				    * then mchMsgReadSensorWrapper sets it to actual message length */
+    uint8_t bits;
+    uint8_t rval;
+    size_t  tmp = sens->readMsgLength; /* Initially set to requested msg length,
+                                        * then mchMsgReadSensorWrapper sets it to actual message length */
 
-	rval = mchMsgReadSensorWrapper( mchData, response, sens, &tmp );
+    rval = mchMsgReadSensorWrapper(mchData, response, sens, &tmp);
 
-	/* If error code ... */
-	if ( rval ) {
-		if ( rval == IPMI_COMP_CODE_REQUESTED_DATA || rval == IPMI_COMP_CODE_DESTINATION_UNAVAIL )
-			sens->unavail = 1;
-		return -1;
-	}
-	else
-		sens->readMsgLength = tmp;
+    /* If error code ... */
+    if (rval) {
+        if (rval == IPMI_COMP_CODE_REQUESTED_DATA || rval == IPMI_COMP_CODE_DESTINATION_UNAVAIL) {
+            sens->unavail = 1;
+        }
+        return -1;
+    } else {
+        sens->readMsgLength = tmp;
+    }
 
-	bits = response[IPMI_RPLY_IMSG2_SENSOR_ENABLE_BITS_OFFSET];
-	if ( IPMI_SENSOR_READING_DISABLED(bits) || IPMI_SENSOR_SCANNING_DISABLED(bits) ) {
-		if ( MCH_DBG( mchStat[mchData->mchSess->instance] ) >= MCH_DBG_LOW )
-			printf("%s mchGetSensorReadingStat: sensor %i reading/state unavailable or scanning disabled. Bits: %02x\n", 
-			    mchData->mchSess->name, sens->sdr.number, bits);
-		return -1;
-	}
+    bits = response[IPMI_RPLY_IMSG2_SENSOR_ENABLE_BITS_OFFSET];
+    if (IPMI_SENSOR_READING_DISABLED(bits) || IPMI_SENSOR_SCANNING_DISABLED(bits)) {
+        if (MCH_DBG(mchStat[mchData->mchSess->instance]) >= MCH_DBG_LOW) {
+            printf("%s mchGetSensorReadingStat: sensor %i reading/state unavailable or scanning disabled. Bits: %02x\n",
+                   mchData->mchSess->name, sens->sdr.number, bits);
+        }
+        return -1;
+    }
 
-	return 0;
+    return 0;
 }
 
 /*
@@ -1369,456 +1356,468 @@ size_t  tmp = sens->readMsgLength; /* Initially set to requested msg length,
  *
  * Caller must perform locking.
  */
-static void
-mchGetSensorInfo(MchData mchData, Sensor sens)
-{
-uint8_t  response[MSG_MAX_LENGTH] = { 0 };
-size_t   sensReadMsgLength;
+static void mchGetSensorInfo(MchData mchData, Sensor sens) {
+    uint8_t response[MSG_MAX_LENGTH] = {0};
+    size_t  sensReadMsgLength;
 
-	sensReadMsgLength = sens->readMsgLength = IPMI_RPLY_IMSG2_SENSOR_READ_MAX_LENGTH;
+    sensReadMsgLength = sens->readMsgLength = IPMI_RPLY_IMSG2_SENSOR_READ_MAX_LENGTH;
 
-	if( !(MCH_ONLN( mchStat[mchData->mchSess->instance] )) ) {
-		if ( MCH_DBG( mchStat[mchData->mchSess->instance] ) )
-			printf("%s mchGetSensorInfo: MCH offline; aborting\n", mchData->mchSess->name);
-		return;
-	}
+    if (!(MCH_ONLN(mchStat[mchData->mchSess->instance]))) {
+        if (MCH_DBG(mchStat[mchData->mchSess->instance])) {
+            printf("%s mchGetSensorInfo: MCH offline; aborting\n", mchData->mchSess->name);
+        }
+        return;
+    }
 
-	/* If sensor does not exist, do not read thresholds, etc. */
-	mchGetSensorReadingStat( mchData, response, sens);
+    /* If sensor does not exist, do not read thresholds, etc. */
+    mchGetSensorReadingStat(mchData, response, sens);
 
-	if ( sens->unavail )
-		return;
+    if (sens->unavail) {
+        return;
+    }
 
-	sens->tmask = 0; /* Set default to no readable thresholds */
+    sens->tmask = 0; /* Set default to no readable thresholds */
 
-	if ( IPMI_SENSOR_THRESH_IS_READABLE( IPMI_SDR_SENSOR_THRESH_ACCESS( sens->sdr.cap ) ) ) {
+    if (IPMI_SENSOR_THRESH_IS_READABLE(IPMI_SDR_SENSOR_THRESH_ACCESS(sens->sdr.cap))) {
 
-		if (  mchMsgGetSensorThresholdsWrapper( mchData, response, sens ) ) {
-			if ( (MCH_DBG( mchStat[mchData->mchSess->instance]) >=  MCH_DBG_LOW) )
-				printf("%s mchGetSensorInfo: mchMsgGetSensorThresholds error, assume no thresholds are readable\n", mchData->mchSess->name);
-			return;
-		}
+        if (mchMsgGetSensorThresholdsWrapper(mchData, response, sens)) {
+            if ((MCH_DBG(mchStat[mchData->mchSess->instance]) >= MCH_DBG_LOW)) {
+                printf("%s mchGetSensorInfo: mchMsgGetSensorThresholds error, assume no thresholds are readable\n",
+                       mchData->mchSess->name);
+            }
+            return;
+        }
 
-		sens->tmask = response[IPMI_RPLY_IMSG2_SENSOR_THRESH_MASK_OFFSET];
-		sens->tlnc  = response[IPMI_RPLY_IMSG2_SENSOR_THRESH_LNC_OFFSET];
-		sens->tlc   = response[IPMI_RPLY_IMSG2_SENSOR_THRESH_LC_OFFSET];
-		sens->tlnr  = response[IPMI_RPLY_IMSG2_SENSOR_THRESH_LNR_OFFSET];
-		sens->tunc  = response[IPMI_RPLY_IMSG2_SENSOR_THRESH_UNC_OFFSET];
-		sens->tuc   = response[IPMI_RPLY_IMSG2_SENSOR_THRESH_UC_OFFSET];
-		sens->tunr  = response[IPMI_RPLY_IMSG2_SENSOR_THRESH_UNR_OFFSET];
+        sens->tmask = response[IPMI_RPLY_IMSG2_SENSOR_THRESH_MASK_OFFSET];
+        sens->tlnc  = response[IPMI_RPLY_IMSG2_SENSOR_THRESH_LNC_OFFSET];
+        sens->tlc   = response[IPMI_RPLY_IMSG2_SENSOR_THRESH_LC_OFFSET];
+        sens->tlnr  = response[IPMI_RPLY_IMSG2_SENSOR_THRESH_LNR_OFFSET];
+        sens->tunc  = response[IPMI_RPLY_IMSG2_SENSOR_THRESH_UNC_OFFSET];
+        sens->tuc   = response[IPMI_RPLY_IMSG2_SENSOR_THRESH_UC_OFFSET];
+        sens->tunr  = response[IPMI_RPLY_IMSG2_SENSOR_THRESH_UNR_OFFSET];
 
-		if ( MCH_DBG( mchStat[mchData->mchSess->instance] ) >= MCH_DBG_HIGH )
-			printf("sensor %s thresholds tmask 0x%02x, tlnc %i tlc %i tlnr %i tunc %i tuc %i tunr %i\n", 
-				sens->sdr.str, sens->tmask, sens->tlnc, sens->tlc, sens->tlnr, sens->tunc, sens->tuc, sens->tunr);
-	}
+        if (MCH_DBG(mchStat[mchData->mchSess->instance]) >= MCH_DBG_HIGH) {
+            printf("sensor %s thresholds tmask 0x%02x, tlnc %i tlc %i tlnr %i tunc %i tuc %i tunr %i\n", sens->sdr.str,
+                   sens->tmask, sens->tlnc, sens->tlc, sens->tlnr, sens->tunc, sens->tuc, sens->tunr);
+        }
+    }
 }
 
 /* 'owner' and 'chan' args are address/channel of owner; used only for device-relative entity assocation record
- * 
+ *
  */
 
-static int
-mchSdrStoreData(MchData mchData, uint8_t *raw, uint8_t type, uint8_t owner, uint8_t chan)
-{
-MchSys   mchSys  = mchData->mchSys;
-Sensor   sens   = 0;
-Fru      fru;
-Mgmt     mgmt;
-EntAssoc entAssoc;
-DevEntAssoc devEntAssoc;
+static int mchSdrStoreData(MchData mchData, uint8_t* raw, uint8_t type, uint8_t owner, uint8_t chan) {
+    MchSys      mchSys = mchData->mchSys;
+    Sensor      sens   = 0;
+    Fru         fru;
+    Mgmt        mgmt;
+    EntAssoc    entAssoc;
+    DevEntAssoc devEntAssoc;
 
-	switch ( type ) {
+    switch (type) {
 
-		default:
-			break;
+        default:
+            break;
 
-		/* Store SDR data; for now we only support Compact/Full Sensor Records, 
-		 * FRU Device Locator Records, Management Controller Device Locator Records,
-		 * and Entity Association Records
-		 */
+            /* Store SDR data; for now we only support Compact/Full Sensor Records,
+             * FRU Device Locator Records, Management Controller Device Locator Records,
+             * and Entity Association Records
+             */
 
-		case SDR_TYPE_FULL_SENSOR:
-			if ( mchSdrSensDuplicate( mchSys, raw ) )
-				break;
-			sens = &mchSys->sens[mchSys->sensCount];
-			mchSdrFullSens( &sens->sdr , raw, type );
-			sens->instance = 0; /* Initialize instance to 0 */
-			mchGetSensorInfo( mchData, sens );
-			sens->cnfg = 0;
-			mchSys->sensCount++;
+        case SDR_TYPE_FULL_SENSOR:
+            if (mchSdrSensDuplicate(mchSys, raw)) {
+                break;
+            }
+            sens = &mchSys->sens[mchSys->sensCount];
+            mchSdrFullSens(&sens->sdr, raw, type);
+            sens->instance = 0; /* Initialize instance to 0 */
+            mchGetSensorInfo(mchData, sens);
+            sens->cnfg = 0;
+            mchSys->sensCount++;
 
-			break;
+            break;
 
-		case SDR_TYPE_COMPACT_SENSOR:
-			if ( mchSdrSensDuplicate( mchSys, raw ) )
-				break;
-			sens = &mchSys->sens[mchSys->sensCount];
-			mchSdrFullSens( &sens->sdr , raw, type );
-			sens->instance = 0; /* Initialize instance to 0 */
-			mchGetSensorInfo( mchData, sens );
-			sens->cnfg = 0;
-			mchSys->sensCount++;
+        case SDR_TYPE_COMPACT_SENSOR:
+            if (mchSdrSensDuplicate(mchSys, raw)) {
+                break;
+            }
+            sens = &mchSys->sens[mchSys->sensCount];
+            mchSdrFullSens(&sens->sdr, raw, type);
+            sens->instance = 0; /* Initialize instance to 0 */
+            mchGetSensorInfo(mchData, sens);
+            sens->cnfg = 0;
+            mchSys->sensCount++;
 
-			break;
+            break;
 
-		case SDR_TYPE_FRU_DEV:
-			if ( mchSdrFruDuplicate( mchSys, raw ) )
-				break;
+        case SDR_TYPE_FRU_DEV:
+            if (mchSdrFruDuplicate(mchSys, raw)) {
+                break;
+            }
 
-			if ( mchSys->fruCount >= mchSys->fruCountMax ) {
-				printf("ERROR: %s discovered %i FRUs but only allocated memory for %i.\n", 
-				    mchData->mchSess->name, mchSys->fruCount, (int)mchSys->fruCountMax);
-				return -1;
-			}
+            if (mchSys->fruCount >= mchSys->fruCountMax) {
+                printf("ERROR: %s discovered %i FRUs but only allocated memory for %i.\n", mchData->mchSess->name,
+                       mchSys->fruCount, (int)mchSys->fruCountMax);
+                return -1;
+            }
 
-			fru = &mchSys->fru[mchSys->fruCount];
-			mchSdrFruDev( &fru->sdr, raw );
-			fru->instance = 0;     /* Initialize instance to 0 */
-			mchSys->fruCount++;
+            fru = &mchSys->fru[mchSys->fruCount];
+            mchSdrFruDev(&fru->sdr, raw);
+            fru->instance = 0; /* Initialize instance to 0 */
+            mchSys->fruCount++;
 
-			break;
+            break;
 
-		case SDR_TYPE_MGMT_CTRL_DEV:
-			if ( mchSdrMgmtCtrlDuplicate( mchSys, raw ) )
-            	break;
+        case SDR_TYPE_MGMT_CTRL_DEV:
+            if (mchSdrMgmtCtrlDuplicate(mchSys, raw)) {
+                break;
+            }
 
-			if ( mchSys->mgmtCount >= mchSys->mgmtCountMax ) {
-				printf("ERROR: %s discovered %i MGMTs but only allocated memory for %i.\n", 
-				    mchData->mchSess->name, mchSys->mgmtCount, (int)mchSys->mgmtCountMax);
-				return -1;
-			}
+            if (mchSys->mgmtCount >= mchSys->mgmtCountMax) {
+                printf("ERROR: %s discovered %i MGMTs but only allocated memory for %i.\n", mchData->mchSess->name,
+                       mchSys->mgmtCount, (int)mchSys->mgmtCountMax);
+                return -1;
+            }
 
-			mgmt = &mchSys->mgmt[mchSys->mgmtCount];
-			mchSdrMgmtCtrlDev( &mgmt->sdr, raw );
-			mchSys->mgmtCount++;
+            mgmt = &mchSys->mgmt[mchSys->mgmtCount];
+            mchSdrMgmtCtrlDev(&mgmt->sdr, raw);
+            mchSys->mgmtCount++;
 
-			break;
+            break;
 
-		/* need to check duplicates for entity assoc records ? */
-		case SDR_TYPE_ENTITY_ASSOC:
-			entAssoc = &mchSys->entAssoc[mchSys->entAssocCount];
-			mchSdrEntAssoc( &entAssoc->sdr, raw );
-			mchSys->entAssocCount++;
+        /* need to check duplicates for entity assoc records ? */
+        case SDR_TYPE_ENTITY_ASSOC:
+            entAssoc = &mchSys->entAssoc[mchSys->entAssocCount];
+            mchSdrEntAssoc(&entAssoc->sdr, raw);
+            mchSys->entAssocCount++;
 
-			break;
+            break;
 
-		case SDR_TYPE_DEV_ENTITY_ASSOC:
-			devEntAssoc = &mchSys->devEntAssoc[mchSys->devEntAssocCount];
-			devEntAssoc->ownerAddr = owner;
-			devEntAssoc->ownerChan = chan;
-			mchSdrDevEntAssoc( &devEntAssoc->sdr, raw, owner );
+        case SDR_TYPE_DEV_ENTITY_ASSOC:
+            devEntAssoc            = &mchSys->devEntAssoc[mchSys->devEntAssocCount];
+            devEntAssoc->ownerAddr = owner;
+            devEntAssoc->ownerChan = chan;
+            mchSdrDevEntAssoc(&devEntAssoc->sdr, raw, owner);
 
-			if ( (devEntAssoc->sdr.cntnrAddr != 0) && (devEntAssoc->sdr.cntnrAddr != owner) ) {
-				printf("WARNING: %s Device-relative entity assocation record whose "
-				    "address 0x%02x does not match container address 0x%02x\n",
-				    mchData->mchSess->name, devEntAssoc->sdr.cntnrAddr, owner);
-			}
-			if ( (devEntAssoc->sdr.cntnrChan != 0) && (devEntAssoc->sdr.cntnrChan != chan) ) {
-				printf("WARNING: %s Device-relative entity assocation record whose "
-				    "chan 0x%02x does not match container chan 0x%02x\n",
-				    mchData->mchSess->name, devEntAssoc->sdr.cntnrChan, chan);
-			}
-			mchSys->devEntAssocCount++;
+            if ((devEntAssoc->sdr.cntnrAddr != 0) && (devEntAssoc->sdr.cntnrAddr != owner)) {
+                printf("WARNING: %s Device-relative entity assocation record whose "
+                       "address 0x%02x does not match container address 0x%02x\n",
+                       mchData->mchSess->name, devEntAssoc->sdr.cntnrAddr, owner);
+            }
+            if ((devEntAssoc->sdr.cntnrChan != 0) && (devEntAssoc->sdr.cntnrChan != chan)) {
+                printf("WARNING: %s Device-relative entity assocation record whose "
+                       "chan 0x%02x does not match container chan 0x%02x\n",
+                       mchData->mchSess->name, devEntAssoc->sdr.cntnrChan, chan);
+            }
+            mchSys->devEntAssocCount++;
 
-			break;
-	}
-	
-	return 0;
+            break;
+    }
+
+    return 0;
 }
 
-static void *
-ipmiReallocZeros(void *dest, size_t old_size, size_t new_size, int flag)
-{
-	if ( flag )
-		dest = realloc( dest, new_size );
-	else
-		dest = realloc( NULL, new_size );
+static void* ipmiReallocZeros(void* dest, size_t old_size, size_t new_size, int flag) {
+    if (flag) {
+        dest = realloc(dest, new_size);
+    } else {
+        dest = realloc(NULL, new_size);
+    }
 
-	 if ( 0 == dest) {
-		dest = NULL;
-		goto bail;
-	}
+    if (0 == dest) {
+        dest = NULL;
+        goto bail;
+    }
 
-	memset( dest + old_size, 0, new_size - old_size );
+    memset(dest + old_size, 0, new_size - old_size);
 
 bail:
-	return dest;
+    return dest;
 }
 
 /* First read of SDR to get record length */
 
-static int				  
-mchSdrGetLength(MchData mchData, uint8_t parm, uint8_t addr, SdrRep sdrRep, uint8_t *id, uint8_t *res, uint8_t *response)
-{
-uint8_t  offset = 0;
-int      size = 5; /* readSize = 5 because 5th byte is remaining record length; 0xFF reads entire record */
-int      err = 0;
+static int mchSdrGetLength(MchData mchData, uint8_t parm, uint8_t addr, SdrRep sdrRep, uint8_t* id, uint8_t* res,
+                           uint8_t* response) {
+    uint8_t offset = 0;
+    int     size   = 5; /* readSize = 5 because 5th byte is remaining record length; 0xFF reads entire record */
+    int     err    = 0;
 
-	while ( err <= 3 ) {
-		if ( (mchMsgGetSdrWrapper( mchData, response, id, res, offset, size, parm, addr )) ) {
-			err++;
-		}
-		else
-			return 0;
-	}
-	return -1;
+    while (err <= 3) {
+        if ((mchMsgGetSdrWrapper(mchData, response, id, res, offset, size, parm, addr))) {
+            err++;
+        } else {
+            return 0;
+        }
+    }
+    return -1;
 }
 
 /*
  * Read sensor data records. Call ipmiMsgGetSdr twice per record;
  * once to get record length, then to read record. This prevents timeouts,
- * saving much delay. 
+ * saving much delay.
  *
  * Caller must perform locking.
- */				  
-static int				  
-mchSdrGetData(MchData mchData, uint8_t parm, uint8_t addr, uint8_t chan, SdrRep sdrRep)
-{
-MchSess  mchSess = mchData->mchSess;
-MchSys   mchSys  = mchData->mchSys;
-uint8_t  response[MSG_MAX_LENGTH] = { 0 };
-uint32_t sdrCount;
-uint8_t  id[2]  = { 0 }, nextid[2]  = { 0 };
-uint8_t  res[2] = { 0 };
-Sensor   sens   = 0;
-uint8_t  offset = 0;
-uint8_t  type   = 0;
-uint8_t *raw    = 0;
-int      size; /* SDR record read size (after header) */
-uint32_t sdrCount_i  = mchSys->sdrCount; /* Initial SDR count */
-int      rval = -1, err = 0, sdrFailedCount = 0, i, remainder = 0;
+ */
+static int mchSdrGetData(MchData mchData, uint8_t parm, uint8_t addr, uint8_t chan, SdrRep sdrRep) {
+    MchSess  mchSess                  = mchData->mchSess;
+    MchSys   mchSys                   = mchData->mchSys;
+    uint8_t  response[MSG_MAX_LENGTH] = {0};
+    uint32_t sdrCount;
+    uint8_t  id[2] = {0}, nextid[2] = {0};
+    uint8_t  res[2] = {0};
+    Sensor   sens   = 0;
+    uint8_t  offset = 0;
+    uint8_t  type   = 0;
+    uint8_t* raw    = 0;
+    int      size;                          /* SDR record read size (after header) */
+    uint32_t sdrCount_i = mchSys->sdrCount; /* Initial SDR count */
+    int      rval = -1, err = 0, sdrFailedCount = 0, i, remainder = 0;
 
-	if ( mchSdrRepGetInfo( mchData, parm, addr, sdrRep, &sdrCount ) )
-		return rval;
+    if (mchSdrRepGetInfo(mchData, parm, addr, sdrRep, &sdrCount)) {
+        return rval;
+    }
 
-	/* Reluctant to statically assign memory to this structure because
-	 * size can vary so widely. For now, alloc dynamically and free
-	 * when configuration is re-read
-	 */
-	if ( !(mchSys->sens = ipmiReallocZeros( mchSys->sens, sdrCount_i*sizeof(*sens), (sdrCount_i+sdrCount)*sizeof(*sens), mchSys->sensAlloc ) ) ) {
-		printf("mchSdrGetData: No memory for sensor data for %s\n", mchSess->name);
-		goto bail;
-	}
-	mchSys->sensAlloc = 1;
+    /* Reluctant to statically assign memory to this structure because
+     * size can vary so widely. For now, alloc dynamically and free
+     * when configuration is re-read
+     */
+    if (!(mchSys->sens = ipmiReallocZeros(mchSys->sens, sdrCount_i * sizeof(*sens),
+                                          (sdrCount_i + sdrCount) * sizeof(*sens), mchSys->sensAlloc))) {
+        printf("mchSdrGetData: No memory for sensor data for %s\n", mchSess->name);
+        goto bail;
+    }
+    mchSys->sensAlloc = 1;
 
-	if ( mchMsgReserveSdrRepWrapper( mchData, response, parm, addr ) ) {
-		printf("mchSdrGetData: Error reserving SDR repository %s\n", mchSess->name);
-		goto bail;
-	}
-	res[0] = response[IPMI_RPLY_IMSG2_GET_SDR_RES_LSB_OFFSET];
-	res[1] = response[IPMI_RPLY_IMSG2_GET_SDR_RES_MSB_OFFSET];
+    if (mchMsgReserveSdrRepWrapper(mchData, response, parm, addr)) {
+        printf("mchSdrGetData: Error reserving SDR repository %s\n", mchSess->name);
+        goto bail;
+    }
+    res[0] = response[IPMI_RPLY_IMSG2_GET_SDR_RES_LSB_OFFSET];
+    res[1] = response[IPMI_RPLY_IMSG2_GET_SDR_RES_MSB_OFFSET];
 
-	for ( i = 0; i < sdrCount; i++) { /* memset raw to zeros on each sdr? */
+    for (i = 0; i < sdrCount; i++) { /* memset raw to zeros on each sdr? */
 
-		if ( !(raw = calloc( 1, SDR_MAX_LENGTH ) ) ) {
-			printf("mchSdrGetData: No memory for raw SDR data for %s\n", mchSess->name);
-			goto bail;
-		}
+        if (!(raw = calloc(1, SDR_MAX_LENGTH))) {
+            printf("mchSdrGetData: No memory for raw SDR data for %s\n", mchSess->name);
+            goto bail;
+        }
 
-		/* If failed to read this SDR, cannot get ID for subsequent units. */
-		if ( mchSdrGetLength( mchData, parm, addr, sdrRep, id, res, response) ) {
-			sdrFailedCount++;
-			printf("%s cannot read SDR %i nor subsequent SDRs\n", mchSess->name, i);
-			goto bail;
-		}
-		nextid[0]  = response[IPMI_RPLY_IMSG2_GET_SDR_NEXT_ID_LSB_OFFSET];
-		nextid[1]  = response[IPMI_RPLY_IMSG2_GET_SDR_NEXT_ID_MSB_OFFSET];
+        /* If failed to read this SDR, cannot get ID for subsequent units. */
+        if (mchSdrGetLength(mchData, parm, addr, sdrRep, id, res, response)) {
+            sdrFailedCount++;
+            printf("%s cannot read SDR %i nor subsequent SDRs\n", mchSess->name, i);
+            goto bail;
+        }
+        nextid[0] = response[IPMI_RPLY_IMSG2_GET_SDR_NEXT_ID_LSB_OFFSET];
+        nextid[1] = response[IPMI_RPLY_IMSG2_GET_SDR_NEXT_ID_MSB_OFFSET];
 
-		size = response[IPMI_RPLY_IMSG2_GET_SDR_DATA_OFFSET + SDR_LENGTH_OFFSET] + SDR_HEADER_LENGTH;
-		if ( size > SDR_MAX_LENGTH )
-			size = SDR_MAX_LENGTH;
-		type = response[IPMI_RPLY_IMSG2_GET_SDR_DATA_OFFSET + SDR_REC_TYPE_OFFSET];
-		if ( size > SDR_MAX_READ_SIZE ) {
-			remainder = size - SDR_MAX_READ_SIZE;
-			size = SDR_MAX_READ_SIZE;
-		}
-		err = 0;
-		offset = 0;
+        size = response[IPMI_RPLY_IMSG2_GET_SDR_DATA_OFFSET + SDR_LENGTH_OFFSET] + SDR_HEADER_LENGTH;
+        if (size > SDR_MAX_LENGTH) {
+            size = SDR_MAX_LENGTH;
+        }
+        type = response[IPMI_RPLY_IMSG2_GET_SDR_DATA_OFFSET + SDR_REC_TYPE_OFFSET];
+        if (size > SDR_MAX_READ_SIZE) {
+            remainder = size - SDR_MAX_READ_SIZE;
+            size      = SDR_MAX_READ_SIZE;
+        }
+        err    = 0;
+        offset = 0;
 
-		while ( size > 0 ) {
-			if ( mchMsgGetSdrWrapper( mchData, response, id, res, offset, size, parm, addr ) ) {
-				/* If too many errors, break out of while loop, move on to next SDR */
-				if ( err++ > 3 )
-					break;
-				continue;
-			}
-			memcpy( raw + offset, response + IPMI_RPLY_IMSG2_GET_SDR_DATA_OFFSET, size );
-			offset += size;
-			if ( remainder > SDR_MAX_READ_SIZE ) {
-				remainder = remainder - SDR_MAX_READ_SIZE;
-				size = SDR_MAX_READ_SIZE;
-			}
-			else {
-				size = remainder;
-				remainder = 0;
-			}
-		}
+        while (size > 0) {
+            if (mchMsgGetSdrWrapper(mchData, response, id, res, offset, size, parm, addr)) {
+                /* If too many errors, break out of while loop, move on to next SDR */
+                if (err++ > 3) {
+                    break;
+                }
+                continue;
+            }
+            memcpy(raw + offset, response + IPMI_RPLY_IMSG2_GET_SDR_DATA_OFFSET, size);
+            offset += size;
+            if (remainder > SDR_MAX_READ_SIZE) {
+                remainder = remainder - SDR_MAX_READ_SIZE;
+                size      = SDR_MAX_READ_SIZE;
+            } else {
+                size      = remainder;
+                remainder = 0;
+            }
+        }
 
-		/* If too many errors, move on to next SDR */
-		if ( err > 3 ) {
-			sdrFailedCount++;
-			continue;
-		}
-		if ( mchSdrStoreData( mchData, raw, type, addr, chan ) )
-			goto bail;
+        /* If too many errors, move on to next SDR */
+        if (err > 3) {
+            sdrFailedCount++;
+            continue;
+        }
+        if (mchSdrStoreData(mchData, raw, type, addr, chan)) {
+            goto bail;
+        }
 
-		id[0] = nextid[0];
-		id[1] = nextid[1];
+        id[0] = nextid[0];
+        id[1] = nextid[1];
 
-		if ( arrayToUint16( id ) == SDR_ID_LAST_SENSOR ) /* last record in SDR */
-			break;
-       	}
-	mchSys->sdrCount += sdrCount;
-	rval = 0;
+        if (arrayToUint16(id) == SDR_ID_LAST_SENSOR) { /* last record in SDR */
+            break;
+        }
+    }
+    mchSys->sdrCount += sdrCount;
+    rval = 0;
 
 bail:
-	if ( sdrFailedCount > 0 ) 
-	    printf("%s: failed to read %i SDRs due to too many read errors\n", mchSess->name, sdrFailedCount);
+    if (sdrFailedCount > 0) {
+        printf("%s: failed to read %i SDRs due to too many read errors\n", mchSess->name, sdrFailedCount);
+    }
 
-	if ( raw )
-		free( raw );
-	return rval;
+    if (raw) {
+        free(raw);
+    }
+    return rval;
 }
 
-static int				  
-mchSdrGetDataAll(MchData mchData)
-{
-MchSess  mchSess = mchData->mchSess;
-MchSys   mchSys  = mchData->mchSys;
-int      i, j;
-Mgmt     mgmt;
-uint8_t  addr = 0;
-int      inst = mchSess->instance;
-Sensor   sens   = 0;
-Fru      fru;
-uint8_t  response[MSG_MAX_LENGTH] = { 0 };
-EntAssoc entAssoc;
-DevEntAssoc devEntAssoc;
-uint8_t  chan = 0;
+static int mchSdrGetDataAll(MchData mchData) {
+    MchSess     mchSess = mchData->mchSess;
+    MchSys      mchSys  = mchData->mchSys;
+    int         i, j;
+    Mgmt        mgmt;
+    uint8_t     addr = 0;
+    int         inst = mchSess->instance;
+    Sensor      sens = 0;
+    Fru         fru;
+    uint8_t     response[MSG_MAX_LENGTH] = {0};
+    EntAssoc    entAssoc;
+    DevEntAssoc devEntAssoc;
+    uint8_t     chan = 0;
 
-	/* First get BMC SDR Rep info */
-	if ( mchSdrGetData( mchData, IPMI_SDRREP_PARM_GET_SDR, IPMI_MSG_ADDR_BMC, chan, &mchSys->sdrRep ) ) {
-		printf("mchSdrGetDataAll: Error in reading primary SDR\n");
-		return -1;
-	}
-	for ( i = 0; i < mchSys->mgmtCount; i++ ) {
+    /* First get BMC SDR Rep info */
+    if (mchSdrGetData(mchData, IPMI_SDRREP_PARM_GET_SDR, IPMI_MSG_ADDR_BMC, chan, &mchSys->sdrRep)) {
+        printf("mchSdrGetDataAll: Error in reading primary SDR\n");
+        return -1;
+    }
+    for (i = 0; i < mchSys->mgmtCount; i++) {
 
-		mgmt = &mchSys->mgmt[i];
-		addr = mgmt->sdr.addr;
-		chan = mgmt->sdr.chan;
+        mgmt = &mchSys->mgmt[i];
+        addr = mgmt->sdr.addr;
+        chan = mgmt->sdr.chan;
 
-		/* Skip primary BMC; already queried */
-		if ( addr == IPMI_MSG_ADDR_BMC )
-			continue;
+        /* Skip primary BMC; already queried */
+        if (addr == IPMI_MSG_ADDR_BMC) {
+            continue;
+        }
 
-		if ( mchMsgGetDeviceIdWrapper( mchData, response, addr ) ) {
-			printf("mchSdrGetDataAll: Error from Get Device ID command to mgmt controller at addr 0x%02x\n", addr);
-			continue;
-		}
+        if (mchMsgGetDeviceIdWrapper(mchData, response, addr)) {
+            printf("mchSdrGetDataAll: Error from Get Device ID command to mgmt controller at addr 0x%02x\n", addr);
+            continue;
+        }
 
-		/* If supports SDR... */
-		if ( (IPMI_DEV_CAP_SDRREP( response[IPMI_RPLY_IMSG2_GET_DEVICE_ID_SUPPORT_OFFSET] ) ) ) { 
-			if ( mchSdrGetData( mchData, IPMI_SDRREP_PARM_GET_SDR, addr, chan, &mgmt->sdrRep ) ) {
-				printf("mchSdrGetDataAll: Error in reading mgmt %i SDR\n", i);
-			}
-		}
-		/* Else if supports device SDR... */
-		else if ( IPMI_DEVICE_PROVIDES_DEVICE_SDR(response[IPMI_RPLY_IMSG2_GET_DEVICE_ID_DEVICE_VERS_OFFSET]) ) { 
+        /* If supports SDR... */
+        if ((IPMI_DEV_CAP_SDRREP(response[IPMI_RPLY_IMSG2_GET_DEVICE_ID_SUPPORT_OFFSET]))) {
+            if (mchSdrGetData(mchData, IPMI_SDRREP_PARM_GET_SDR, addr, chan, &mgmt->sdrRep)) {
+                printf("mchSdrGetDataAll: Error in reading mgmt %i SDR\n", i);
+            }
+        }
+        /* Else if supports device SDR... */
+        else if (IPMI_DEVICE_PROVIDES_DEVICE_SDR(response[IPMI_RPLY_IMSG2_GET_DEVICE_ID_DEVICE_VERS_OFFSET])) {
 
-			if ( mchSdrGetData( mchData, IPMI_SDRREP_PARM_GET_DEV_SDR, addr, chan, &mgmt->sdrRep ) ) {
-				printf("mchSdrGetDataAll: Error in reading mgmt %i SDR\n", i);
-			}
-		}
+            if (mchSdrGetData(mchData, IPMI_SDRREP_PARM_GET_DEV_SDR, addr, chan, &mgmt->sdrRep)) {
+                printf("mchSdrGetDataAll: Error in reading mgmt %i SDR\n", i);
+            }
+        }
 
-		/* If provides FRU info, create a FRU instance for it in our data structure */
-		if ( (IPMI_DEV_CAP_FRU_INV( response[IPMI_RPLY_IMSG2_GET_DEVICE_ID_SUPPORT_OFFSET] ) ) ) { 
+        /* If provides FRU info, create a FRU instance for it in our data structure */
+        if ((IPMI_DEV_CAP_FRU_INV(response[IPMI_RPLY_IMSG2_GET_DEVICE_ID_SUPPORT_OFFSET]))) {
 
-			fru = &mchSys->fru[mchSys->fruCount];
-			mchSys->fruCount++;
-			fru->sdr.addr  = mgmt->sdr.addr;
-			fru->sdr.chan  = mgmt->sdr.chan;
-			fru->sdr.fruId = 0; /* Arbitrarily set to 0 */
-			fru->sdr.entityId   = mgmt->sdr.entityId;
-			fru->sdr.entityInst = mgmt->sdr.entityInst;
-			fru->sdr.recType    = mgmt->sdr.recType; /* Because recType is used as validity check in various places */			
-		}
-	}
+            fru = &mchSys->fru[mchSys->fruCount];
+            mchSys->fruCount++;
+            fru->sdr.addr       = mgmt->sdr.addr;
+            fru->sdr.chan       = mgmt->sdr.chan;
+            fru->sdr.fruId      = 0; /* Arbitrarily set to 0 */
+            fru->sdr.entityId   = mgmt->sdr.entityId;
+            fru->sdr.entityInst = mgmt->sdr.entityInst;
+            fru->sdr.recType    = mgmt->sdr.recType; /* Because recType is used as validity check in various places */
+        }
+    }
 
-	/* Find associated entitites */
-	mchSdrGetAssocEnt( mchData );
+    /* Find associated entitites */
+    mchSdrGetAssocEnt(mchData);
 
-	if ( MCH_DBG( mchStat[inst] ) >= MCH_DBG_MED ) {
-		printf("%s mchSdrGetDataAll Summary:\n", mchSess->name);
-		for ( i = 0; i < mchSys->sensCount; i++ ) {
-			sens = &mchSys->sens[i];
-			printf("SDR %i, %s entity ID 0x%02x, entity inst 0x%02x, sensor number %i, sens type 0x%02x, "
-				"owner 0x%02x, LUN %i, RexpBexp %i, M %i, MTol %i, B %i, BAcc %i\n", 
-				sens->sdr.number, sens->sdr.str, sens->sdr.entityId, sens->sdr.entityInst, 
-				sens->sdr.number, sens->sdr.sensType, sens->sdr.owner, sens->sdr.lun, 
-				sens->sdr.RexpBexp, sens->sdr.M, sens->sdr.MTol, sens->sdr.B, sens->sdr.BAcc);
-		}
-		for ( i = 0; i < mchSys->fruCount; i++ ) {
-			fru = &mchSys->fru[i];
-			if ( fru->sdr.recType )
-				printf("FRU %i, recType 0x%02x, entity ID 0x%02x, entity inst 0x%02x,, addr 0x%02x, chan %i, FRU id %i, %s, entity count %i\n", 
-				i, fru->sdr.recType, fru->sdr.entityId, fru->sdr.entityInst, fru->sdr.addr, fru->sdr.chan, fru->sdr.fruId, fru->sdr.str, fru->entityCount);
-			for ( j = 0; j < fru->entityCount; j++ ) {
-				printf("     Associated entity addr 0x%02x chan %i entityId 0x%02x entityInst 0x%02x\n", 
-				fru->entity[j].addr, fru->entity[j].chan, fru->entity[j].entityId, fru->entity[j].entityInst); 
-			}
-		}
-		for ( i = 0; i < mchSys->mgmtCount; i++ ) {
-			mgmt = &mchSys->mgmt[i];
-       			printf("Mgmt Ctrl %i, FRU entity ID 0x%02x, entity inst 0x%02x, %s, addr 0x%02x, chan %i, cap 0x%02x entity count %i\n", 
-				i, mgmt->sdr.entityId, mgmt->sdr.entityInst, mgmt->sdr.str, mgmt->sdr.addr, mgmt->sdr.chan, mgmt->sdr.cap, mgmt->entityCount);
-			for ( j = 0; j < mgmt->entityCount; j++ ) {
-				printf("     Associated entity addr 0x%02x chan %i entityId 0x%02x entityInst 0x%02x\n", 
-				mgmt->entity[j].addr, mgmt->entity[j].chan, mgmt->entity[j].entityId, mgmt->entity[j].entityInst); 
-			}
-		}
+    if (MCH_DBG(mchStat[inst]) >= MCH_DBG_MED) {
+        printf("%s mchSdrGetDataAll Summary:\n", mchSess->name);
+        for (i = 0; i < mchSys->sensCount; i++) {
+            sens = &mchSys->sens[i];
+            printf("SDR %i, %s entity ID 0x%02x, entity inst 0x%02x, sensor number %i, sens type 0x%02x, "
+                   "owner 0x%02x, LUN %i, RexpBexp %i, M %i, MTol %i, B %i, BAcc %i\n",
+                   sens->sdr.number, sens->sdr.str, sens->sdr.entityId, sens->sdr.entityInst, sens->sdr.number,
+                   sens->sdr.sensType, sens->sdr.owner, sens->sdr.lun, sens->sdr.RexpBexp, sens->sdr.M, sens->sdr.MTol,
+                   sens->sdr.B, sens->sdr.BAcc);
+        }
+        for (i = 0; i < mchSys->fruCount; i++) {
+            fru = &mchSys->fru[i];
+            if (fru->sdr.recType) {
+                printf("FRU %i, recType 0x%02x, entity ID 0x%02x, entity inst 0x%02x,, addr 0x%02x, chan %i, FRU id "
+                       "%i, %s, entity count %i\n",
+                       i, fru->sdr.recType, fru->sdr.entityId, fru->sdr.entityInst, fru->sdr.addr, fru->sdr.chan,
+                       fru->sdr.fruId, fru->sdr.str, fru->entityCount);
+            }
+            for (j = 0; j < fru->entityCount; j++) {
+                printf("     Associated entity addr 0x%02x chan %i entityId 0x%02x entityInst 0x%02x\n",
+                       fru->entity[j].addr, fru->entity[j].chan, fru->entity[j].entityId, fru->entity[j].entityInst);
+            }
+        }
+        for (i = 0; i < mchSys->mgmtCount; i++) {
+            mgmt = &mchSys->mgmt[i];
+            printf("Mgmt Ctrl %i, FRU entity ID 0x%02x, entity inst 0x%02x, %s, addr 0x%02x, chan %i, cap 0x%02x "
+                   "entity count %i\n",
+                   i, mgmt->sdr.entityId, mgmt->sdr.entityInst, mgmt->sdr.str, mgmt->sdr.addr, mgmt->sdr.chan,
+                   mgmt->sdr.cap, mgmt->entityCount);
+            for (j = 0; j < mgmt->entityCount; j++) {
+                printf("     Associated entity addr 0x%02x chan %i entityId 0x%02x entityInst 0x%02x\n",
+                       mgmt->entity[j].addr, mgmt->entity[j].chan, mgmt->entity[j].entityId,
+                       mgmt->entity[j].entityInst);
+            }
+        }
 
-		for ( i = 0; i < mchSys->devEntAssocCount; i++ ) {
-			devEntAssoc = &mchSys->devEntAssoc[i];
-       			printf("Dev Ent Assoc %i, owner addr 0x%02x container ent id 0x%02x inst 0x%02x addr 0x%02x chan %i, flags %i\n"
-				"     contained 1 addr 0x%02x chan %i entity id 0x%02x inst 0x%02x\n" 
-				"     contained 2 addr 0x%02x chan %i entity id 0x%02x inst 0x%02x\n" 
-				"     contained 3 addr 0x%02x chan %i entity id 0x%02x inst 0x%02x\n" 
-				"     contained 4 addr 0x%02x chan %i entity id 0x%02x inst 0x%02x\n", 
-				i, devEntAssoc->ownerAddr, devEntAssoc->sdr.cntnrId, devEntAssoc->sdr.cntnrInst, devEntAssoc->sdr.cntnrAddr, devEntAssoc->sdr.cntnrChan, devEntAssoc->sdr.flags, 
-				devEntAssoc->sdr.cntndAddr1, devEntAssoc->sdr.cntndChan1, devEntAssoc->sdr.cntndId1, devEntAssoc->sdr.cntndInst1,
-				devEntAssoc->sdr.cntndAddr2, devEntAssoc->sdr.cntndChan2, devEntAssoc->sdr.cntndId2, devEntAssoc->sdr.cntndInst2,
-				devEntAssoc->sdr.cntndAddr3, devEntAssoc->sdr.cntndChan3, devEntAssoc->sdr.cntndId3, devEntAssoc->sdr.cntndInst3,
-				devEntAssoc->sdr.cntndAddr4, devEntAssoc->sdr.cntndChan4, devEntAssoc->sdr.cntndId4, devEntAssoc->sdr.cntndInst4);
-		}
-		for ( i = 0; i < mchSys->entAssocCount; i++ ) {
-			entAssoc = &mchSys->entAssoc[i];
-       			printf("Ent Assoc %i, container ent id 0x%02x inst 0x%02x, flags %i\n"
-				"     contained entity 1 id 0x%02x inst 0x%02x\n" 
-				"     contained entity 2 id 0x%02x inst 0x%02x\n" 
-				"     contained entity 3 id 0x%02x inst 0x%02x\n" 
-				"     contained entity 4 id 0x%02x inst 0x%02x\n",
-				i, entAssoc->sdr.cntnrId, entAssoc->sdr.cntnrInst, entAssoc->sdr.flags, 
-				entAssoc->sdr.cntndId1, entAssoc->sdr.cntndInst1,
-				entAssoc->sdr.cntndId2, entAssoc->sdr.cntndInst2,
-				entAssoc->sdr.cntndId3, entAssoc->sdr.cntndInst3,
-				entAssoc->sdr.cntndId4, entAssoc->sdr.cntndInst4);
-		}
-	}
+        for (i = 0; i < mchSys->devEntAssocCount; i++) {
+            devEntAssoc = &mchSys->devEntAssoc[i];
+            printf("Dev Ent Assoc %i, owner addr 0x%02x container ent id 0x%02x inst 0x%02x addr 0x%02x chan %i, flags "
+                   "%i\n"
+                   "     contained 1 addr 0x%02x chan %i entity id 0x%02x inst 0x%02x\n"
+                   "     contained 2 addr 0x%02x chan %i entity id 0x%02x inst 0x%02x\n"
+                   "     contained 3 addr 0x%02x chan %i entity id 0x%02x inst 0x%02x\n"
+                   "     contained 4 addr 0x%02x chan %i entity id 0x%02x inst 0x%02x\n",
+                   i, devEntAssoc->ownerAddr, devEntAssoc->sdr.cntnrId, devEntAssoc->sdr.cntnrInst,
+                   devEntAssoc->sdr.cntnrAddr, devEntAssoc->sdr.cntnrChan, devEntAssoc->sdr.flags,
+                   devEntAssoc->sdr.cntndAddr1, devEntAssoc->sdr.cntndChan1, devEntAssoc->sdr.cntndId1,
+                   devEntAssoc->sdr.cntndInst1, devEntAssoc->sdr.cntndAddr2, devEntAssoc->sdr.cntndChan2,
+                   devEntAssoc->sdr.cntndId2, devEntAssoc->sdr.cntndInst2, devEntAssoc->sdr.cntndAddr3,
+                   devEntAssoc->sdr.cntndChan3, devEntAssoc->sdr.cntndId3, devEntAssoc->sdr.cntndInst3,
+                   devEntAssoc->sdr.cntndAddr4, devEntAssoc->sdr.cntndChan4, devEntAssoc->sdr.cntndId4,
+                   devEntAssoc->sdr.cntndInst4);
+        }
+        for (i = 0; i < mchSys->entAssocCount; i++) {
+            entAssoc = &mchSys->entAssoc[i];
+            printf("Ent Assoc %i, container ent id 0x%02x inst 0x%02x, flags %i\n"
+                   "     contained entity 1 id 0x%02x inst 0x%02x\n"
+                   "     contained entity 2 id 0x%02x inst 0x%02x\n"
+                   "     contained entity 3 id 0x%02x inst 0x%02x\n"
+                   "     contained entity 4 id 0x%02x inst 0x%02x\n",
+                   i, entAssoc->sdr.cntnrId, entAssoc->sdr.cntnrInst, entAssoc->sdr.flags, entAssoc->sdr.cntndId1,
+                   entAssoc->sdr.cntndInst1, entAssoc->sdr.cntndId2, entAssoc->sdr.cntndInst2, entAssoc->sdr.cntndId3,
+                   entAssoc->sdr.cntndInst3, entAssoc->sdr.cntndId4, entAssoc->sdr.cntndInst4);
+        }
+    }
 
-	return 0;
+    return 0;
 }
 
-static void
-buildPingMsg(uint8_t *message, size_t *responseSize)
-{
-	memcpy( message, RMCP_HEADER, sizeof( RMCP_HEADER ) );
-	message[RMCP_MSG_CLASS_OFFSET] = RMCP_MSG_CLASS_ASF;
-	memcpy( message + ASF_MSG_OFFSET, ASF_MSG, sizeof( ASF_MSG ) );
-	*responseSize = RMCP_MSG_HEADER_LENGTH + ASF_MSG_HEADER_LENGTH + ASF_RPLY_PONG_PAYLOAD_LENGTH;
-
+static void buildPingMsg(uint8_t* message, size_t* responseSize) {
+    memcpy(message, RMCP_HEADER, sizeof(RMCP_HEADER));
+    message[RMCP_MSG_CLASS_OFFSET] = RMCP_MSG_CLASS_ASF;
+    memcpy(message + ASF_MSG_OFFSET, ASF_MSG, sizeof(ASF_MSG));
+    *responseSize = RMCP_MSG_HEADER_LENGTH + ASF_MSG_HEADER_LENGTH + ASF_RPLY_PONG_PAYLOAD_LENGTH;
 }
 
-/* 
+/*
  *  Periodically ping MCH. This runs in its own thread.
  *  If MCH online/offline status changes, update global
  *  variable and process status record. Less frequently set
@@ -1826,371 +1825,376 @@ buildPingMsg(uint8_t *message, size_t *responseSize)
  *
  *  These messages are outside of a session and we don't
  *  modify our shared structure, so there is no need to lock
- *  during the message write. We call ipmiMsgWriteRead directly, 
- *  instead of using the helper routine which tries to recover a 
+ *  during the message write. We call ipmiMsgWriteRead directly,
+ *  instead of using the helper routine which tries to recover a
  *  disconnected session.
  */
 
-static void
-mchPing(void *arg)
-{
-MchDev  mch     = arg;
-MchData mchData = mch->udata;
-MchSess mchSess = mchData->mchSess;
-uint8_t message[MSG_MAX_LENGTH]  = { 0 };
-uint8_t response[MSG_MAX_LENGTH] = { 0 };
-size_t  responseSize, responseLen; /* expected, actual */
-int     cos; /* change of state */
-int     inst = mchSess->instance, i = 0, j = 0;
-int     online = 0, tries = 0;
+static void mchPing(void* arg) {
+    MchDev  mch                      = arg;
+    MchData mchData                  = mch->udata;
+    MchSess mchSess                  = mchData->mchSess;
+    uint8_t message[MSG_MAX_LENGTH]  = {0};
+    uint8_t response[MSG_MAX_LENGTH] = {0};
+    size_t  responseSize, responseLen; /* expected, actual */
+    int     cos;                       /* change of state */
+    int     inst = mchSess->instance, i = 0, j = 0;
+    int     online = 0, tries = 0;
 
-	buildPingMsg( message, &responseSize );
+    buildPingMsg(message, &responseSize);
 
-	/* first we perform some initialization */
+    /* first we perform some initialization */
 
-	while ((online == 0) && ( tries < 3)) {
-		ipmiMsgWriteRead( mchSess->name, message, sizeof( RMCP_HEADER ) + sizeof( ASF_MSG ), 
-			response, &responseSize, RPLY_TIMEOUT_DEFAULT, &responseLen );
-		if (responseLen != 0){
-			online = 1;
-			break;
-		}
-		epicsThreadSleep( 1 );
-		tries++;
-	}
+    while ((online == 0) && (tries < 3)) {
+        ipmiMsgWriteRead(mchSess->name, message, sizeof(RMCP_HEADER) + sizeof(ASF_MSG), response, &responseSize,
+                         RPLY_TIMEOUT_DEFAULT, &responseLen);
+        if (responseLen != 0) {
+            online = 1;
+            break;
+        }
+        epicsThreadSleep(1);
+        tries++;
+    }
 
-	if (online == 1) {
-		mchStatSet( inst, MCH_MASK_ONLN, MCH_MASK_ONLN );
-		epicsMutexLock( mch->mutex );
-		mchCnfg( mchData, MCH_CNFG_INIT ); /* flag 1 = at init, before run-time */
-		epicsMutexUnlock( mch->mutex );
-		mchInitSuccessCounter++;
-	}
-	else {
-		/* Since device type is unknown, assume max number of FRU/MGMT devices
-		 * in order to support whichever EPICS DB is loaded for this device
-		 */
-		mchCnfgReset( mchData ); /* Initialize some data structs and values */
-		printf("No response from %s after %i tries; cannot complete initialization\n",mch->name, tries);
-		mchInitFailCounter++;
-	}
+    if (online == 1) {
+        mchStatSet(inst, MCH_MASK_ONLN, MCH_MASK_ONLN);
+        epicsMutexLock(mch->mutex);
+        mchCnfg(mchData, MCH_CNFG_INIT); /* flag 1 = at init, before run-time */
+        epicsMutexUnlock(mch->mutex);
+        mchInitSuccessCounter++;
+    } else {
+        /* Since device type is unknown, assume max number of FRU/MGMT devices
+         * in order to support whichever EPICS DB is loaded for this device
+         */
+        mchCnfgReset(mchData); /* Initialize some data structs and values */
+        printf("No response from %s after %i tries; cannot complete initialization\n", mch->name, tries);
+        mchInitFailCounter++;
+    }
 
-	/* initialization is done.  now we can go do work. */
+    /* initialization is done.  now we can go do work. */
 
-	while (1) {
+    while (1) {
 
-		epicsThreadSleep( PING_PERIOD );
+        epicsThreadSleep(PING_PERIOD);
 
-		cos = 0;
+        cos = 0;
 
-		ipmiMsgWriteRead( mchSess->name, message, sizeof( RMCP_HEADER ) + sizeof( ASF_MSG ), 
-			response, &responseSize, RPLY_TIMEOUT_DEFAULT, &responseLen );
+        ipmiMsgWriteRead(mchSess->name, message, sizeof(RMCP_HEADER) + sizeof(ASF_MSG), response, &responseSize,
+                         RPLY_TIMEOUT_DEFAULT, &responseLen);
 
-		if ( responseLen == 0 ) {
+        if (responseLen == 0) {
 
-			if ( MCH_ONLN( mchStat[inst] ) ) {
-				if ( MCH_DBG( mchStat[inst] ) )
-					printf("%s mchPing now offline\n", mchSess->name);
-				mchStatSet( inst, MCH_MASK_ONLN, 0 );
-				cos = 1;
+            if (MCH_ONLN(mchStat[inst])) {
+                if (MCH_DBG(mchStat[inst])) {
+                    printf("%s mchPing now offline\n", mchSess->name);
+                }
+                mchStatSet(inst, MCH_MASK_ONLN, 0);
+                cos = 1;
 
-				/* After MCH goes offline, perform one scan of sensor
-				 * records so that they get updated SEVR. After this,
-				 * only scan records if MCH is online.
-				 */
-				if ( drvSensorScan[inst] ) 
-					scanIoRequest( drvSensorScan[inst] );
+                /* After MCH goes offline, perform one scan of sensor
+                 * records so that they get updated SEVR. After this,
+                 * only scan records if MCH is online.
+                 */
+                if (drvSensorScan[inst]) {
+                    scanIoRequest(drvSensorScan[inst]);
+                }
+            }
+        } else {
+            if (!MCH_ONLN(mchStat[inst])) {
+                if (MCH_DBG(mchStat[inst])) {
+                    printf("%s mchPing now online\n", mchSess->name);
+                }
+                mchStatSet(inst, MCH_MASK_ONLN, MCH_MASK_ONLN);
+                cos = 1;
+            }
+            /* Every 30 seconds (while mch online), set flag to check if system configuration has changed */
+            if (i > 30 / PING_PERIOD) {
+                mchStatSet(inst, MCH_MASK_CNFG_CHK, MCH_MASK_CNFG_CHK);
+                i = 0;
+            }
+            /* Periocially (while mch online), scan sensor records */
+            if (j >= mchSensorScanPeriod / PING_PERIOD) {
+                if (drvSensorScan[inst]) {
+                    scanIoRequest(drvSensorScan[inst]);
+                }
+                j = 0;
+            }
+            i++;
+            j++;
+        }
 
-			}
-		}
-		else {
-			if ( !MCH_ONLN( mchStat[inst] ) ) {
-				if ( MCH_DBG( mchStat[inst] ) )
-					printf("%s mchPing now online\n", mchSess->name);
-				mchStatSet( inst, MCH_MASK_ONLN, MCH_MASK_ONLN );
-				cos = 1;
-			}
-			/* Every 30 seconds (while mch online), set flag to check if system configuration has changed */
-			if ( i > 30/PING_PERIOD ) {
-				mchStatSet( inst, MCH_MASK_CNFG_CHK, MCH_MASK_CNFG_CHK );
-				i = 0;
-			}
-			/* Periocially (while mch online), scan sensor records */
-			if ( j >= mchSensorScanPeriod/PING_PERIOD ) {
-				if ( drvSensorScan[inst] ) 
-					scanIoRequest( drvSensorScan[inst] );
-				j = 0;
-			}
-			i++;
-			j++;
-		}
-
-		if ( cos ) {
-       			if ( drvMchStatScan )
-       				scanIoRequest( drvMchStatScan );
-		}
-	}
+        if (cos) {
+            if (drvMchStatScan) {
+                scanIoRequest(drvMchStatScan);
+            }
+        }
+    }
 }
 
 /* Check if MCH configuration has changed or if
  * MCH is online and we have not read its configuration.
  * If either, get MCH data and store in our data structs
  */
-int
-mchCnfgChk(MchData mchData) {
-int    inst   = mchData->mchSess->instance;
+int mchCnfgChk(MchData mchData) {
+    int inst = mchData->mchSess->instance;
 
-	mchStatSet( inst, MCH_MASK_CNFG_CHK, 0 );
+    mchStatSet(inst, MCH_MASK_CNFG_CHK, 0);
 
-	if ( MCH_INIT_NOT_DONE( mchStat[inst] ) ) {
-		printf("discovered init not done, run mch cnf\n");
-		return mchCnfg( mchData, MCH_CNFG_NOT_INIT );
-	}
+    if (MCH_INIT_NOT_DONE(mchStat[inst])) {
+        printf("discovered init not done, run mch cnf\n");
+        return mchCnfg(mchData, MCH_CNFG_NOT_INIT);
+    }
 
-	else if ( MCH_INIT_DONE( mchStat[inst] ) ) { 
-		if ( mchSdrRepTsDiff( mchData ) )
-			return mchCnfg( mchData, MCH_CNFG_NOT_INIT );
-	}
+    else if (MCH_INIT_DONE(mchStat[inst])) {
+        if (mchSdrRepTsDiff(mchData)) {
+            return mchCnfg(mchData, MCH_CNFG_NOT_INIT);
+        }
+    }
 
-	return 0;
+    return 0;
 }
 
 /* Set all elements of 3D array to same integer value */
-static void
-set3DArrayVals(int a, int b, int c, int arr[a][b][c], int val) {
-int i, j, k;
+static void set3DArrayVals(int a, int b, int c, int arr[a][b][c], int val) {
+    int i, j, k;
 
-	for ( i = 0; i < a; i++ ) {
-		for ( j = 0; j < b; j++ ) {
-			for ( k = 0; k < c; k++ ) {
-				arr[i][j][k] = val;
-			}
-		}
-	}
+    for (i = 0; i < a; i++) {
+        for (j = 0; j < b; j++) {
+            for (k = 0; k < c; k++) {
+                arr[i][j][k] = val;
+            }
+        }
+    }
 }
 
 /* Set all elements of 1D array to same integer value */
-static void
-set1DArrayVals(int a, int arr[a], int val) {
-int i;
+static void set1DArrayVals(int a, int arr[a], int val) {
+    int i;
 
-	for ( i = 0; i < a; i++ ) {
-		arr[i] = val;
-	}
+    for (i = 0; i < a; i++) {
+        arr[i] = val;
+    }
 }
 
-/* 
+/*
  * Modify MCH status mask. If record-related changes
  * were made, scan associated EPICS records
  */
-void
-mchStatSet(int inst, uint32_t clear, uint32_t set) {
+void mchStatSet(int inst, uint32_t clear, uint32_t set) {
 
-	epicsMutexLock(   mchStatMtx[inst] );
-	mchStat[inst] &= ~clear;
-	mchStat[inst] |=  set;
-	epicsMutexUnlock( mchStatMtx[inst] );
+    epicsMutexLock(mchStatMtx[inst]);
+    mchStat[inst] &= ~clear;
+    mchStat[inst] |= set;
+    epicsMutexUnlock(mchStatMtx[inst]);
 
-	if ( clear == MCH_MASK_INIT) {
-		if ( drvMchInitScan )
-			scanIoRequest( drvMchInitScan );
-	}
+    if (clear == MCH_MASK_INIT) {
+        if (drvMchInitScan) {
+            scanIoRequest(drvMchInitScan);
+        }
+    }
 
-	if ( (clear == MCH_MASK_ONLN) || (set == MCH_MASK_INIT_DONE) ) {
-		if ( drvMchStatScan )
-			scanIoRequest( drvMchStatScan );
-	}
+    if ((clear == MCH_MASK_ONLN) || (set == MCH_MASK_INIT_DONE)) {
+        if (drvMchStatScan) {
+            scanIoRequest(drvMchStatScan);
+        }
+    }
 }
 
-static void
-mchSetFeatures(MchData mchData)
-{
-MchSess  mchSess  = mchData->mchSess;
-IpmiSess ipmiSess = mchData->ipmiSess;
+static void mchSetFeatures(MchData mchData) {
+    MchSess  mchSess  = mchData->mchSess;
+    IpmiSess ipmiSess = mchData->ipmiSess;
 
-	/* Optionally override default max FRU/MGMT devices */
-	if ( mchData->mchSys->mchcb->assign_sys_sizes )
-		mchData->mchSys->mchcb->assign_sys_sizes( mchData );
+    /* Optionally override default max FRU/MGMT devices */
+    if (mchData->mchSys->mchcb->assign_sys_sizes) {
+        mchData->mchSys->mchcb->assign_sys_sizes(mchData);
+    }
 
-	if ( mchSess->type == MCH_TYPE_VT )
-		mchSess->timeout = ipmiSess->timeout = RPLY_TIMEOUT_SENDMSG_RPLY;
-	else
-		mchSess->timeout = ipmiSess->timeout = RPLY_TIMEOUT_DEFAULT;
+    if (mchSess->type == MCH_TYPE_VT) {
+        mchSess->timeout = ipmiSess->timeout = RPLY_TIMEOUT_SENDMSG_RPLY;
+    } else {
+        mchSess->timeout = ipmiSess->timeout = RPLY_TIMEOUT_DEFAULT;
+    }
 
-	if ( mchSess->type == MCH_TYPE_VT )
-		ipmiSess->features |= MCH_FEAT_SENDMSG_RPLY;		
-}	
-
-static void
-*mchSetIdentity(MchData mchData, char *vendor, uint8_t vers, int type, char *cbname)
-{
-void *cb;
-
-	printf("Identified %s to be %s. IPMI V%i.%i. Initializing...\n", mchData->mchSess->name, vendor, IPMI_VER_MSD( vers ), IPMI_VER_LSD( vers ));
-	mchData->mchSess->type = type;
-	if ( !(cb = registryFind( (void *)mchCbRegistryId, cbname )) ) {
-		printf("mchIdentify: ERROR for %s: failed to find callbacks %s\n", mchData->mchSess->name, cbname);
-		return 0;
-	}
-
-	return cb;
+    if (mchSess->type == MCH_TYPE_VT) {
+        ipmiSess->features |= MCH_FEAT_SENDMSG_RPLY;
+    }
 }
 
-/* 
+static void* mchSetIdentity(MchData mchData, char* vendor, uint8_t vers, int type, char* cbname) {
+    void* cb;
+
+    printf("Identified %s to be %s. IPMI V%i.%i. Initializing...\n", mchData->mchSess->name, vendor, IPMI_VER_MSD(vers),
+           IPMI_VER_LSD(vers));
+    mchData->mchSess->type = type;
+    if (!(cb = registryFind((void*)mchCbRegistryId, cbname))) {
+        printf("mchIdentify: ERROR for %s: failed to find callbacks %s\n", mchData->mchSess->name, cbname);
+        return 0;
+    }
+
+    return cb;
+}
+
+/*
  * Use Manufacturer ID (from Get Device ID command)
  * to determine MCH type
  */
-static int
-mchIdentify(MchData mchData)
-{
-MchSess  mchSess = mchData->mchSess;
-int      i;
-uint8_t  response[MSG_MAX_LENGTH] = { 0 };
-uint8_t  tmp[4] = { 0 }, vers;
-uint32_t mf;
-void    *mchcb = 0;
+static int mchIdentify(MchData mchData) {
+    MchSess  mchSess = mchData->mchSess;
+    int      i;
+    uint8_t  response[MSG_MAX_LENGTH] = {0};
+    uint8_t  tmp[4]                   = {0}, vers;
+    uint32_t mf;
+    void*    mchcb = 0;
 
-	if ( mchMsgGetDeviceIdWrapper( mchData, response, IPMI_MSG_ADDR_BMC ) ) {
-		printf("mchIdentify: Error from Get Device ID command\n");
-		mchMsgCloseSess( mchSess, mchData->ipmiSess, response );
-		return -1;
-	}
+    if (mchMsgGetDeviceIdWrapper(mchData, response, IPMI_MSG_ADDR_BMC)) {
+        printf("mchIdentify: Error from Get Device ID command\n");
+        mchMsgCloseSess(mchSess, mchData->ipmiSess, response);
+        return -1;
+    }
 
-	/* Extract Manufacturer ID */
-	for ( i = 0; i < IPMI_RPLY_MANUF_ID_LENGTH ; i++)
-		tmp[i] = response[IPMI_RPLY_IMSG2_GET_DEVICE_ID_MANUF_ID_OFFSET + i];
+    /* Extract Manufacturer ID */
+    for (i = 0; i < IPMI_RPLY_MANUF_ID_LENGTH; i++) {
+        tmp[i] = response[IPMI_RPLY_IMSG2_GET_DEVICE_ID_MANUF_ID_OFFSET + i];
+    }
 
-       	vers = response[IPMI_RPLY_IMSG2_GET_DEVICE_ID_IPMI_VERS_OFFSET];
+    vers = response[IPMI_RPLY_IMSG2_GET_DEVICE_ID_IPMI_VERS_OFFSET];
 
-	mf  = arrayToUint32( tmp  );
-	mf  = IPMI_MANUF_ID( mf  );
+    mf = arrayToUint32(tmp);
+    mf = IPMI_MANUF_ID(mf);
 
-	switch ( mf ) {
+    switch (mf) {
 
-		default: 
-			printf("mchIdentify: Unknown type of MCH, failed to match manuf ID 0x%08x\n", mf);
-			mchSess->type = MCH_TYPE_UNKNOWN;
-			return -1;
+        default:
+            printf("mchIdentify: Unknown type of MCH, failed to match manuf ID 0x%08x\n", mf);
+            mchSess->type = MCH_TYPE_UNKNOWN;
+            return -1;
 
-		case MCH_MANUF_ID_NAT:
-			if ( 0 == (mchcb = mchSetIdentity( mchData, "N.A.T.", vers, MCH_TYPE_NAT, "drvMchMicrotcaNatCb")) )
-				return -1;
-			break;
+        case MCH_MANUF_ID_NAT:
+            if (0 == (mchcb = mchSetIdentity(mchData, "N.A.T.", vers, MCH_TYPE_NAT, "drvMchMicrotcaNatCb"))) {
+                return -1;
+            }
+            break;
 
-		case MCH_MANUF_ID_VT:
-			if ( 0 == (mchcb = mchSetIdentity( mchData, "Vadatech", vers, MCH_TYPE_VT, "drvMchMicrotcaVtCb")) )
-				return -1;
-			break;
-/*  Not yet supported     
-		case MCH_MANUF_ID_DELL:
-			mchSess->type = MCH_TYPE_DELL;
-			printf("Identified %s to be Dell. IPMI version %i.%i\n", mchSess->name, IPMI_VER_MSD( vers ), IPMI_VER_LSD( vers ));
-			break;
-*/
-		case MCH_MANUF_ID_SUPERMICRO:
-			if ( 0 == (mchcb = mchSetIdentity( mchData, "Supermicro", vers, MCH_TYPE_SUPERMICRO, "drvMchSupermicroCb")) )
-				return -1;
-			break;
+        case MCH_MANUF_ID_VT:
+            if (0 == (mchcb = mchSetIdentity(mchData, "Vadatech", vers, MCH_TYPE_VT, "drvMchMicrotcaVtCb"))) {
+                return -1;
+            }
+            break;
+            /*  Not yet supported
+                    case MCH_MANUF_ID_DELL:
+                        mchSess->type = MCH_TYPE_DELL;
+                        printf("Identified %s to be Dell. IPMI version %i.%i\n", mchSess->name, IPMI_VER_MSD( vers ),
+               IPMI_VER_LSD( vers )); break;
+            */
+        case MCH_MANUF_ID_SUPERMICRO:
+            if (0 == (mchcb = mchSetIdentity(mchData, "Supermicro", vers, MCH_TYPE_SUPERMICRO, "drvMchSupermicroCb"))) {
+                return -1;
+            }
+            break;
 
-		case MCH_MANUF_ID_ADVANTECH:
-			if ( 0 == (mchcb = mchSetIdentity( mchData, "Advantech", vers, MCH_TYPE_ADVANTECH, "drvMchAdvantechCb")) )
-				return -1;
-			break;
+        case MCH_MANUF_ID_ADVANTECH:
+            if (0 == (mchcb = mchSetIdentity(mchData, "Advantech", vers, MCH_TYPE_ADVANTECH, "drvMchAdvantechCb"))) {
+                return -1;
+            }
+            break;
 
-		case MCH_MANUF_ID_PENTAIR:
-			if ( 0 == (mchcb = mchSetIdentity( mchData, "Pentair", vers, MCH_TYPE_PENTAIR, "drvMchAtcaCb")) )
-				return -1;
-			break;
+        case MCH_MANUF_ID_PENTAIR:
+            if (0 == (mchcb = mchSetIdentity(mchData, "Pentair", vers, MCH_TYPE_PENTAIR, "drvMchAtcaCb"))) {
+                return -1;
+            }
+            break;
 
-		case MCH_MANUF_ID_ARTESYN:
-			if ( 0 == (mchcb = mchSetIdentity( mchData, "Artesyn", vers, MCH_TYPE_ARTESYN, "drvMchAtcaCb")) )
-				return -1;
-			break;
-	}
+        case MCH_MANUF_ID_ARTESYN:
+            if (0 == (mchcb = mchSetIdentity(mchData, "Artesyn", vers, MCH_TYPE_ARTESYN, "drvMchAtcaCb"))) {
+                return -1;
+            }
+            break;
+    }
 
-	/* Callbacks and init for comm with knob controller */
-	mchData->mchSys->mchcb = (MchCbRec *)mchcb;
+    /* Callbacks and init for comm with knob controller */
+    mchData->mchSys->mchcb = (MchCbRec*)mchcb;
 
-	mchSetFeatures( mchData );
-        return 0;
+    mchSetFeatures(mchData);
+    return 0;
 }
 
-static void
-mchSensorFruGetInstance(MchData mchData)
-{
-MchSys  mchSys= mchData->mchSys;
-int     s = mchSys->sensCount;
-uint8_t sensTypeInst[MAX_FRU_MGMT][MAX_SENSOR_TYPE] = { { 0 } };    /* Counts of sensor type per ID instance */
-int     j, index;
-Fru     fru  = 0;
-Mgmt    mgmt = 0;
-Sensor  sens;
+static void mchSensorFruGetInstance(MchData mchData) {
+    MchSys  mchSys                                      = mchData->mchSys;
+    int     s                                           = mchSys->sensCount;
+    uint8_t sensTypeInst[MAX_FRU_MGMT][MAX_SENSOR_TYPE] = {{0}}; /* Counts of sensor type per ID instance */
+    int     j, index;
+    Fru     fru  = 0;
+    Mgmt    mgmt = 0;
+    Sensor  sens;
 
-	/* Find FRU or management controller associated with this sensor, assign sensor an instance based on type */
-	for ( j = 0; j < s; j++ ) {
+    /* Find FRU or management controller associated with this sensor, assign sensor an instance based on type */
+    for (j = 0; j < s; j++) {
 
-		sens = &mchSys->sens[j];
+        sens = &mchSys->sens[j];
 
-		/* If sensor has not been assigned associated FRU, quit */
-		if ( -1 == (index = sens->fruIndex) )
-			continue;
+        /* If sensor has not been assigned associated FRU, quit */
+        if (-1 == (index = sens->fruIndex)) {
+            continue;
+        }
 
-		/* Skip FRU 0 for MicroTCA because it is reserved logical entity with same 
-		 * entityId and entityInst as MCH 1. This should be in callbacks
-		 */
-		if ( (mchGetFruIdFromIndex( mchData, index ) == 0) && MCH_IS_MICROTCA( mchData->mchSess->type ) )
-			continue;
+        /* Skip FRU 0 for MicroTCA because it is reserved logical entity with same
+         * entityId and entityInst as MCH 1. This should be in callbacks
+         */
+        if ((mchGetFruIdFromIndex(mchData, index) == 0) && MCH_IS_MICROTCA(mchData->mchSess->type)) {
+            continue;
+        }
 
-		if ( index < MAX_FRU ) {
+        if (index < MAX_FRU) {
 
-			fru = &mchSys->fru[index];
+            fru = &mchSys->fru[index];
 
-			/* If a real entity, assign instance */
-			if ( (mchSys->fruLkup[fru->id] != -1) ) {
+            /* If a real entity, assign instance */
+            if ((mchSys->fruLkup[fru->id] != -1)) {
 
-				sens->instance = ++sensTypeInst[index][sens->sdr.sensType];
-				if ( sens->instance > MAX_SENS_INST ) {
-					printf("WARNING: FRU %i sensor type 0x%02x instance %i exceeds allowed instance %i\n",
-					    index, sens->sdr.sensType, sens->instance, MAX_SENS_INST);
-					continue;
-				}
+                sens->instance = ++sensTypeInst[index][sens->sdr.sensType];
+                if (sens->instance > MAX_SENS_INST) {
+                    printf("WARNING: FRU %i sensor type 0x%02x instance %i exceeds allowed instance %i\n", index,
+                           sens->sdr.sensType, sens->instance, MAX_SENS_INST);
+                    continue;
+                }
 
-				if ( !sens->unavail )
-					mchSys->sensLkup[index][sens->sdr.sensType][sens->instance] = j;
-			}
-		}
-	}
+                if (!sens->unavail) {
+                    mchSys->sensLkup[index][sens->sdr.sensType][sens->instance] = j;
+                }
+            }
+        }
+    }
 
-	if ( MCH_DBG( mchStat[mchData->mchSess->instance] ) >= MCH_DBG_MED ) {
+    if (MCH_DBG(mchStat[mchData->mchSess->instance]) >= MCH_DBG_MED) {
 
-		int i;
-		printf("Sensor summary:\n");
-		for ( i = 0; i < s; i++ ) {
-			sens = &mchSys->sens[i];
-			if ( sens->fruIndex != -1 ) {
-				fru  = &mchSys->fru[sens->fruIndex];
-				printf("FRU sensor %s %i Type 0x%02x Inst %i FRUaddr 0x%02x Ent Id 0x%02x Inst 0x%02x "
-					"Sens owner 0x%02x EndId 0x%02x EndInst 0x%02x RecType %i FruId %i FruLkup %i FruIndex %i Unavail %i\n",
-					sens->sdr.str, sens->sdr.number, sens->sdr.sensType, sens->instance, fru->sdr.addr, 
-					fru->sdr.entityId, fru->sdr.entityInst, sens->sdr.owner, sens->sdr.entityId, 
-					sens->sdr.entityInst, sens->sdr.recType, fru->id, mchSys->fruLkup[fru->id], 
-					sens->fruIndex, sens->unavail);
-			}
-			else if ( sens->mgmtIndex != -1 ) {
-				mgmt  = &mchSys->mgmt[sens->mgmtIndex];
-				printf("Mgmt sensor %s %i Type 0x%02x inst %i MGMTaddr 0x%02x Ent Id 0x%02x Inst 0x%02x "
-				"Sens owner 0x%02x EntId 0x%02x EntInst 0x%02x RecType %i Unavail %i\n",
-					sens->sdr.str, sens->sdr.number, sens->sdr.sensType, sens->instance, mgmt->sdr.addr, 
-					mgmt->sdr.entityId, mgmt->sdr.entityInst, sens->sdr.owner, sens->sdr.entityId, 
-					sens->sdr.entityInst, sens->sdr.recType, sens->unavail);
-			}
-			else
-				printf("Sensor %s %i Type 0x%02x Inst %i EntId 0x%02x EntInst 0x%02x RecType %i "
-					"no corresponding FRU or MGTM unavail %i\n",
-					sens->sdr.str, sens->sdr.number, sens->sdr.sensType, sens->instance, sens->sdr.entityId, 
-					sens->sdr.entityInst, sens->sdr.recType, sens->unavail);
-		}
-	}
+        int i;
+        printf("Sensor summary:\n");
+        for (i = 0; i < s; i++) {
+            sens = &mchSys->sens[i];
+            if (sens->fruIndex != -1) {
+                fru = &mchSys->fru[sens->fruIndex];
+                printf("FRU sensor %s %i Type 0x%02x Inst %i FRUaddr 0x%02x Ent Id 0x%02x Inst 0x%02x "
+                       "Sens owner 0x%02x EndId 0x%02x EndInst 0x%02x RecType %i FruId %i FruLkup %i FruIndex %i "
+                       "Unavail %i\n",
+                       sens->sdr.str, sens->sdr.number, sens->sdr.sensType, sens->instance, fru->sdr.addr,
+                       fru->sdr.entityId, fru->sdr.entityInst, sens->sdr.owner, sens->sdr.entityId,
+                       sens->sdr.entityInst, sens->sdr.recType, fru->id, mchSys->fruLkup[fru->id], sens->fruIndex,
+                       sens->unavail);
+            } else if (sens->mgmtIndex != -1) {
+                mgmt = &mchSys->mgmt[sens->mgmtIndex];
+                printf("Mgmt sensor %s %i Type 0x%02x inst %i MGMTaddr 0x%02x Ent Id 0x%02x Inst 0x%02x "
+                       "Sens owner 0x%02x EntId 0x%02x EntInst 0x%02x RecType %i Unavail %i\n",
+                       sens->sdr.str, sens->sdr.number, sens->sdr.sensType, sens->instance, mgmt->sdr.addr,
+                       mgmt->sdr.entityId, mgmt->sdr.entityInst, sens->sdr.owner, sens->sdr.entityId,
+                       sens->sdr.entityInst, sens->sdr.recType, sens->unavail);
+            } else {
+                printf("Sensor %s %i Type 0x%02x Inst %i EntId 0x%02x EntInst 0x%02x RecType %i "
+                       "no corresponding FRU or MGTM unavail %i\n",
+                       sens->sdr.str, sens->sdr.number, sens->sdr.sensType, sens->instance, sens->sdr.entityId,
+                       sens->sdr.entityInst, sens->sdr.recType, sens->unavail);
+            }
+        }
+    }
 }
 
 /*
@@ -2198,260 +2202,255 @@ Sensor  sens;
  * Use flag to know that memory was successfully
  * allocated and later to know if it was actually
  * freed.
- * (Can't just test the pointer because even 
+ * (Can't just test the pointer because even
  *  after free, a pointer still contains the previous
  *  address even though it is no longer valid.)
  */
-static void
-freememory(void *ptr, int *flag)
-{
-        if ( *flag ) {
-                free( ptr );
-		ptr = NULL;
-                *flag = 0;
-        }
+static void freememory(void* ptr, int* flag) {
+    if (*flag) {
+        free(ptr);
+        ptr   = NULL;
+        *flag = 0;
+    }
 }
 
-static void
-mchCnfgReset(MchData mchData) {
-MchSys mchSys = mchData->mchSys;
-int i;
+static void mchCnfgReset(MchData mchData) {
+    MchSys mchSys = mchData->mchSys;
+    int    i;
 
-	if ( mchSys->fru ) { /* If FRU struct already allocated */
-		for ( i = 0; i < mchSys->fruCountMax ; i++ )
-			freememory( mchSys->fru[i].entity, &mchSys->fru[i].entityAlloc );
+    if (mchSys->fru) { /* If FRU struct already allocated */
+        for (i = 0; i < mchSys->fruCountMax; i++) {
+            freememory(mchSys->fru[i].entity, &mchSys->fru[i].entityAlloc);
+        }
 
-		memset( mchSys->fru,  0, mchSys->fruCountMax*sizeof(FruRec)   );
-	}
+        memset(mchSys->fru, 0, mchSys->fruCountMax * sizeof(FruRec));
+    }
 
-	if ( mchSys->mgmt ) { /* If Mgmt struct already allocated */
-		for ( i = 0; i < mchSys->mgmtCountMax ; i++ )
-			freememory( mchSys->mgmt[i].entity, &mchSys->mgmt[i].entityAlloc );
+    if (mchSys->mgmt) { /* If Mgmt struct already allocated */
+        for (i = 0; i < mchSys->mgmtCountMax; i++) {
+            freememory(mchSys->mgmt[i].entity, &mchSys->mgmt[i].entityAlloc);
+        }
 
-		memset( mchSys->mgmt, 0, mchSys->mgmtCountMax*sizeof(MgmtRec) );
-	}
+        memset(mchSys->mgmt, 0, mchSys->mgmtCountMax * sizeof(MgmtRec));
+    }
 
-	/* move this to reset values routine, add fruid, fuindex, etc. */
-	set3DArrayVals( MAX_FRU_MGMT, MAX_SENSOR_TYPE, MAX_SENS_INST, mchSys->sensLkup, -1 );
-	set1DArrayVals( MAX_FRU_MGMT, mchSys->fruLkup, -1 );
+    /* move this to reset values routine, add fruid, fuindex, etc. */
+    set3DArrayVals(MAX_FRU_MGMT, MAX_SENSOR_TYPE, MAX_SENS_INST, mchSys->sensLkup, -1);
+    set1DArrayVals(MAX_FRU_MGMT, mchSys->fruLkup, -1);
 
-	/* Free memory for previously allocated sensor array */
-	freememory( mchSys->sens, &mchSys->sensAlloc );
+    /* Free memory for previously allocated sensor array */
+    freememory(mchSys->sens, &mchSys->sensAlloc);
 }
 
 /* Get info about MCH, shelf, FRUs, sensors
  * Caller must perform locking
- * 
+ *
  * initFlag=1 if at init, before run-time
  */
-static int
-mchCnfg(MchData mchData, int initFlag) {
-MchSess mchSess = mchData->mchSess;
-MchSys  mchSys  = mchData->mchSys;
-int inst = mchSess->instance;
-int i;
+static int mchCnfg(MchData mchData, int initFlag) {
+    MchSess mchSess = mchData->mchSess;
+    MchSys  mchSys  = mchData->mchSys;
+    int     inst    = mchSess->instance;
+    int     i;
 
-	mchStatSet( inst, MCH_MASK_INIT, MCH_MASK_INIT_IN_PROGRESS );
+    mchStatSet(inst, MCH_MASK_INIT, MCH_MASK_INIT_IN_PROGRESS);
 
-	mchSeqInit( mchData->ipmiSess );
+    mchSeqInit(mchData->ipmiSess);
 
-	/* Turn on debug messages during initial messages with device 
-	mchStatSet( inst, MCH_MASK_DBG, MCH_DBG_SET(MCH_DBG_MED) ); */
+    /* Turn on debug messages during initial messages with device
+    mchStatSet( inst, MCH_MASK_DBG, MCH_DBG_SET(MCH_DBG_MED) ); */
 
-	/* Initiate communication session with MCH */
-	if ( mchCommStart( mchSess, mchData->ipmiSess ) ) {
-		printf("Error initiating session with %s; cannot complete initialization\n",mchSess->name);
-		goto bail;
-	}
+    /* Initiate communication session with MCH */
+    if (mchCommStart(mchSess, mchData->ipmiSess)) {
+        printf("Error initiating session with %s; cannot complete initialization\n", mchSess->name);
+        goto bail;
+    }
 
-        /* Determine MCH type */
-        if ( mchIdentify( mchData ) ) {
-	       	printf("Failed to identify %s MCH type; cannot complete initialization\n",mchSess->name);	
-		goto bail;
-	}
+    /* Determine MCH type */
+    if (mchIdentify(mchData)) {
+        printf("Failed to identify %s MCH type; cannot complete initialization\n", mchSess->name);
+        goto bail;
+    }
 
-	/* If first time executing this routine, perform some startup-only tasks */
-	if ( initFlag == MCH_CNFG_INIT ) {
-		if ( !(mchSys->fru = calloc( 1, mchSys->fruCountMax*sizeof(FruRec) )) )
-			cantProceed("FATAL ERROR: No memory for FRU data for %s\n", mchData->mchSess->name);
+    /* If first time executing this routine, perform some startup-only tasks */
+    if (initFlag == MCH_CNFG_INIT) {
+        if (!(mchSys->fru = calloc(1, mchSys->fruCountMax * sizeof(FruRec)))) {
+            cantProceed("FATAL ERROR: No memory for FRU data for %s\n", mchData->mchSess->name);
+        }
 
-		if ( !(mchSys->mgmt = calloc( 1, mchSys->mgmtCountMax*sizeof(MgmtRec) )) )
-			cantProceed("FATAL ERROR: No memory for Management Controller data for %s\n", mchData->mchSess->name);
+        if (!(mchSys->mgmt = calloc(1, mchSys->mgmtCountMax * sizeof(MgmtRec)))) {
+            cantProceed("FATAL ERROR: No memory for Management Controller data for %s\n", mchData->mchSess->name);
+        }
 
-		for ( i = 0; i < mchSys->fruCountMax ; i++ ) {
-			mchSys->fru[i].entityAlloc  = 0; /* Indicates memory has not been allocated for fru entity array;  this supports alloc/free scheme */
-		}
-		for ( i = 0; i < mchSys->mgmtCountMax ; i++ ) {
-			mchSys->mgmt[i].entityAlloc = 0; /* Indicates memory has not been allocated for mgmt entity array; this supports alloc/free scheme */
-		}
+        for (i = 0; i < mchSys->fruCountMax; i++) {
+            mchSys->fru[i].entityAlloc =
+                0; /* Indicates memory has not been allocated for fru entity array;  this supports alloc/free scheme */
+        }
+        for (i = 0; i < mchSys->mgmtCountMax; i++) {
+            mchSys->mgmt[i].entityAlloc =
+                0; /* Indicates memory has not been allocated for mgmt entity array; this supports alloc/free scheme */
+        }
+    }
 
-	}
+    /* Moved to after mchIdentify so that max fru/mgmt counts are defined */
+    mchCnfgReset(mchData);
 
-	/* Moved to after mchIdentify so that max fru/mgmt counts are defined */
-	mchCnfgReset( mchData );
+    /* Intialize sensor and device counts to 0 */
+    mchSys->sdrCount = mchSys->sensCount = mchSys->fruCount = mchSys->mgmtCount = 0;
 
-	/* Intialize sensor and device counts to 0 */
-	mchSys->sdrCount = mchSys->sensCount = mchSys->fruCount = mchSys->mgmtCount = 0;
+    /* Get SDR data */
+    if (mchSdrGetDataAll(mchData)) {
+        printf("Failed to read %s SDR; cannot complete initialization\n", mchSess->name);
+        goto bail;
+    }
 
-       	/* Get SDR data */
-       	if ( mchSdrGetDataAll( mchData ) ) {
-       		printf("Failed to read %s SDR; cannot complete initialization\n",mchSess->name);
-		goto bail;
-       	}
+    /* Get FRU data; errors are not fatal, but could cause missing FRU data */
+    mchFruGetDataAll(mchData);
 
-	/* Get FRU data; errors are not fatal, but could cause missing FRU data */
-	mchFruGetDataAll( mchData );
- 
-		/* Comment this out for now; it always happens at the end of initialization and it is confusing
-		printf("Warning: errors getting %s FRU data; some data may be missing\n",mchSess->name);
-		*/
+    /* Comment this out for now; it always happens at the end of initialization and it is confusing
+    printf("Warning: errors getting %s FRU data; some data may be missing\n",mchSess->name);
+    */
 
-	/* Get Sensor/FRU association */
-	for ( i = 0; i < mchSys->sensCount; i++ )
-		mchSensorGetFru( mchData, i );
+    /* Get Sensor/FRU association */
+    for (i = 0; i < mchSys->sensCount; i++) {
+        mchSensorGetFru(mchData, i);
+    }
 
-	mchSensorFruGetInstance( mchData );
+    mchSensorFruGetInstance(mchData);
 
-	mchStatSet( inst, MCH_MASK_INIT, MCH_MASK_INIT_DONE );
+    mchStatSet(inst, MCH_MASK_INIT, MCH_MASK_INIT_DONE);
 
-	if ( drvMchFruScan )
-		scanIoRequest( drvMchFruScan );
+    if (drvMchFruScan) {
+        scanIoRequest(drvMchFruScan);
+    }
 
-	mchStatSet( inst, MCH_MASK_DBG, MCH_DBG_SET(MCH_DBG_OFF) );
+    mchStatSet(inst, MCH_MASK_DBG, MCH_DBG_SET(MCH_DBG_OFF));
 
-	printf("%s Initialization complete\n", mchSess->name);
+    printf("%s Initialization complete\n", mchSess->name);
 
-	return 0;
+    return 0;
 
 bail:
-	mchStatSet( inst, MCH_MASK_INIT, MCH_MASK_INIT_NOT_DONE );
-	return -1;
+    mchStatSet(inst, MCH_MASK_INIT, MCH_MASK_INIT_NOT_DONE);
+    return -1;
 }
 
+// !! need to make sure initial values do not lead to records sending messages i.e. assume not initialized if cannot
+// establish session
 
-// !! need to make sure initial values do not lead to records sending messages i.e. assume not initialized if cannot establish session
-
-/* 
+/*
  * MCH initialization. Called before iocInit.
  *
  * Initial release requires MCH/shelf to be on-line
- * and populated and creates new epics records script.  
+ * and populated and creates new epics records script.
  * Later release should derive info from previously
  * created script.
  */
-static void
-mchInit(const char *name)
-{
-MchDev   mch     = 0; /* Device support data structure */
-MchData  mchData = 0; /* MCH-specific info */
-MchSess  mchSess = 0;
-IpmiSess ipmiSess = 0;
-MchSys   mchSys  = 0;
-char     taskName[MAX_NAME_LENGTH+10];
-int      inst;
+static void mchInit(const char* name) {
+    MchDev   mch      = 0; /* Device support data structure */
+    MchData  mchData  = 0; /* MCH-specific info */
+    MchSess  mchSess  = 0;
+    IpmiSess ipmiSess = 0;
+    MchSys   mchSys   = 0;
+    char     taskName[MAX_NAME_LENGTH + 10];
+    int      inst;
 
-	if (postIocStart) {
-		printf("Error: calling mchInit() too late\n");
-		return;
-	}
+    if (postIocStart) {
+        printf("Error: calling mchInit() too late\n");
+        return;
+    }
 
-	/* Allocate memory for MCH data structures */
-	if ( ! (mchData = calloc( 1, sizeof( *mchData ))) )
-		cantProceed("FATAL ERROR: No memory for MchData structure for %s\n", name);
+    /* Allocate memory for MCH data structures */
+    if (!(mchData = calloc(1, sizeof(*mchData)))) {
+        cantProceed("FATAL ERROR: No memory for MchData structure for %s\n", name);
+    }
 
-	if ( ! (mchSess = calloc( 1, sizeof( *mchSess ))) )
-		cantProceed("FATAL ERROR: No memory for MchSess structure for %s\n", name);
+    if (!(mchSess = calloc(1, sizeof(*mchSess)))) {
+        cantProceed("FATAL ERROR: No memory for MchSess structure for %s\n", name);
+    }
 
-	if ( ! (ipmiSess = calloc( 1, sizeof( *ipmiSess ))) )
-		cantProceed("FATAL ERROR: No memory for IpmiSess structure for %s\n", name);
+    if (!(ipmiSess = calloc(1, sizeof(*ipmiSess)))) {
+        cantProceed("FATAL ERROR: No memory for IpmiSess structure for %s\n", name);
+    }
 
-	if ( ! (mchSys = calloc( 1, sizeof( *mchSys ))) )
-		cantProceed("FATAL ERROR: No memory for MchSys structure for %s\n", name);
+    if (!(mchSys = calloc(1, sizeof(*mchSys)))) {
+        cantProceed("FATAL ERROR: No memory for MchSys structure for %s\n", name);
+    }
 
-	ipmiSess->wrf = (IpmiWriteReadHelper)mchMsgWriteReadHelper;
+    ipmiSess->wrf = (IpmiWriteReadHelper)mchMsgWriteReadHelper;
 
-	inst = mchSess->instance = mchCounter++;
+    inst = mchSess->instance = mchCounter++;
 
-	mchStatMtx[inst] = epicsMutexMustCreate(); /* Used for global mchStat mask */
+    mchStatMtx[inst] = epicsMutexMustCreate(); /* Used for global mchStat mask */
 
-	/* Allocate and initialize memory for MCH device support structure */
-	if ( ! (mch = devMchRegister( name )) )
-		printf("FATAL ERROR: Unable to register MCH %s with device support\n", name);
+    /* Allocate and initialize memory for MCH device support structure */
+    if (!(mch = devMchRegister(name))) {
+        printf("FATAL ERROR: Unable to register MCH %s with device support\n", name);
+    }
 
-	mchData->ipmiSess = ipmiSess;
-	mchData->mchSess = mchSess;
-	mchData->mchSys  = mchSys;
+    mchData->ipmiSess = ipmiSess;
+    mchData->mchSess  = mchSess;
+    mchData->mchSys   = mchSys;
 
-	strncpy( mchSess->name, mch->name, MAX_NAME_LENGTH );
-	strncpy( mchSys->name,  mch->name, MAX_NAME_LENGTH ); // okay to remove this and from drvMch.h?
-	mch->udata = mchData;
+    strncpy(mchSess->name, mch->name, MAX_NAME_LENGTH);
+    strncpy(mchSys->name, mch->name, MAX_NAME_LENGTH); // okay to remove this and from drvMch.h?
+    mch->udata = mchData;
 
-	/* Set default maximum counts (for this device) for FRU/MGMT to max
-	 * Individual device types can override this in callbacks
-	 */
-	mchSys->fruCountMax  = MAX_FRU;
-	mchSys->mgmtCountMax = MAX_MGMT;
-	mchSys->sensAlloc = 0; /* Indicates memory has not been allocated for sensor struct; this supports alloc/free scheme */
+    /* Set default maximum counts (for this device) for FRU/MGMT to max
+     * Individual device types can override this in callbacks
+     */
+    mchSys->fruCountMax  = MAX_FRU;
+    mchSys->mgmtCountMax = MAX_MGMT;
+    mchSys->sensAlloc =
+        0; /* Indicates memory has not been allocated for sensor struct; this supports alloc/free scheme */
 
-	mchSess->timeout = ipmiSess->timeout = RPLY_TIMEOUT_SENDMSG_RPLY; /* Default, until determine type */
-	mchSess->session = 1;   /* Default: enable session with MCH */
+    mchSess->timeout = ipmiSess->timeout = RPLY_TIMEOUT_SENDMSG_RPLY; /* Default, until determine type */
+    mchSess->session                     = 1;                         /* Default: enable session with MCH */
 
-	/* For sensor record scanning */
-	scanIoInit( &drvSensorScan[inst] );
+    /* For sensor record scanning */
+    scanIoInit(&drvSensorScan[inst]);
 
-	/* Start task to continue initialization and periodically ping MCH */
-	sprintf( taskName, "%s-PING", mch->name ); 
-	mchSess->pingThreadId = epicsThreadMustCreate( taskName, epicsThreadPriorityMedium, epicsThreadGetStackSize(epicsThreadStackMedium), mchPing, mch );
+    /* Start task to continue initialization and periodically ping MCH */
+    sprintf(taskName, "%s-PING", mch->name);
+    mchSess->pingThreadId = epicsThreadMustCreate(taskName, epicsThreadPriorityMedium,
+                                                  epicsThreadGetStackSize(epicsThreadStackMedium), mchPing, mch);
 }
 
-static long
-drvMchReport(int level)
-{
-	printf("IPMI communication driver support\n");
-	return 0;
+static long drvMchReport(int level) {
+    printf("IPMI communication driver support\n");
+    return 0;
 }
 
-static long
-drvMchInit(void)
-{
-	return 0;
+static long drvMchInit(void) {
+    return 0;
 }
 
 static struct {
-	long number;
-	DRVSUPFUN report;
-	DRVSUPFUN init;
-} drvMch={
-	2,
-	(DRVSUPFUN)drvMchReport,
-	drvMchInit
-};
+    long      number;
+    DRVSUPFUN report;
+    DRVSUPFUN init;
+} drvMch = {2, (DRVSUPFUN)drvMchReport, drvMchInit};
 
-epicsExportAddress(drvet,drvMch);
+epicsExportAddress(drvet, drvMch);
 
-
-/* 
+/*
  * IOC shell command registration
  */
-static const iocshArg mchInitArg0        = { "port name",iocshArgString};
-static const iocshArg *mchInitArgs[1]    = { &mchInitArg0 };
-static const iocshFuncDef mchInitFuncDef = { "mchInit", 1, mchInitArgs };
+static const iocshArg     mchInitArg0    = {"port name", iocshArgString};
+static const iocshArg*    mchInitArgs[1] = {&mchInitArg0};
+static const iocshFuncDef mchInitFuncDef = {"mchInit", 1, mchInitArgs};
 
-static void 
-mchInitCallFunc(const iocshArgBuf *args)
-{
-	mchInit(args[0].sval);
+static void mchInitCallFunc(const iocshArgBuf* args) {
+    mchInit(args[0].sval);
 }
 
-static void
-drvMchRegisterCommands(void)
-{
-	static int firstTime = 1;
-	if ( firstTime ) {
-		initHookRegister(mchInitHook);
-		iocshRegister(&mchInitFuncDef, mchInitCallFunc);
-		firstTime = 0;
-	}
+static void drvMchRegisterCommands(void) {
+    static int firstTime = 1;
+    if (firstTime) {
+        initHookRegister(mchInitHook);
+        iocshRegister(&mchInitFuncDef, mchInitCallFunc);
+        firstTime = 0;
+    }
 }
 
 epicsExportRegistrar(drvMchRegisterCommands);

--- a/src/drvMch.h
+++ b/src/drvMch.h
@@ -1,10 +1,10 @@
 //////////////////////////////////////////////////////////////////////////////
 // This file is part of 'ipmiComm'.
-// It is subject to the license terms in the LICENSE.txt file found in the 
-// top-level directory of this distribution and at: 
-//    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
-// No part of 'ipmiComm', including this file, 
-// may be copied, modified, propagated, or distributed except according to 
+// It is subject to the license terms in the LICENSE.txt file found in the
+// top-level directory of this distribution and at:
+//    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+// No part of 'ipmiComm', including this file,
+// may be copied, modified, propagated, or distributed except according to
 // the terms contained in the LICENSE.txt file.
 //////////////////////////////////////////////////////////////////////////////
 #ifndef DRV_MCH_H
@@ -14,11 +14,11 @@
 #include <devMch.h>
 #include <ipmiDef.h>
 
-#define MAX_FRU             255   // 0xFF reserved, according to IPMI 2.0 spec
-#define MAX_MGMT            32    // management controller device, arbitrary limit, may need adjusting
-#define MAX_FRU_MGMT        MAX_FRU + MAX_MGMT
-#define MAX_MCH             255
-#define MAX_SENS_INST       32    /* Max instances of one sensor type on one FRU or Management Controller entity */
+#define MAX_FRU       255 // 0xFF reserved, according to IPMI 2.0 spec
+#define MAX_MGMT      32  // management controller device, arbitrary limit, may need adjusting
+#define MAX_FRU_MGMT  MAX_FRU + MAX_MGMT
+#define MAX_MCH       255
+#define MAX_SENS_INST 32 /* Max instances of one sensor type on one FRU or Management Controller entity */
 
 extern uint32_t mchStat[MAX_MCH];
 
@@ -31,210 +31,221 @@ extern epicsMutexId mchStatMtx[MAX_MCH];
 extern IOSCANPVT drvSensorScan[MAX_MCH];
 
 /* Vadatech typically sends 2 replies; NAT sends 1 */
-#define RPLY_TIMEOUT_SENDMSG_RPLY    0.50
-#define RPLY_TIMEOUT_DEFAULT         0.25
+#define RPLY_TIMEOUT_SENDMSG_RPLY 0.50
+#define RPLY_TIMEOUT_DEFAULT      0.25
 
 /* Mask of MCH status
- * INIT uses 2 lowest bits: 
+ * INIT uses 2 lowest bits:
  * must AND stat with MCH_MASK_INIT and
  * then test for value, for example:
- * if ( (mchStat & MCH_MASK_INIT) == MCH_MASK_INIT_DONE ) 
+ * if ( (mchStat & MCH_MASK_INIT) == MCH_MASK_INIT_DONE )
  * Similarly for DBG
  */
-#define MCH_MASK_INIT            (0x3) 
+#define MCH_MASK_INIT             (0x3)
 #define MCH_MASK_INIT_NOT_DONE    0
 #define MCH_MASK_INIT_IN_PROGRESS 1
 #define MCH_MASK_INIT_DONE        2
 #define MCH_MASK_INIT_FAILED      3
-#define MCH_MASK_ONLN            (1<<2) /* 1 = MCH responds to pings */
-#define MCH_MASK_CNFG_CHK        (1<<3) /* 1 = time to check config up-to-date */
-#define MCH_MASK_DBG             (0x30) 
-#define MCH_INIT_DONE(x)         ((x & MCH_MASK_INIT) == MCH_MASK_INIT_DONE)
-#define MCH_INIT_NOT_DONE(x)     ((x & MCH_MASK_INIT) == MCH_MASK_INIT_NOT_DONE)
-#define MCH_ONLN(x)              ((x & MCH_MASK_ONLN) >> 2)
-#define MCH_CNFG_CHK(x)          ((x & MCH_MASK_CNFG_CHK) >> 3)
-#define MCH_DBG(x)               ((x & MCH_MASK_DBG) >> 4)
-#define MCH_DBG_SET(x)           (x<<4) /* Select debug bits in mask */
+#define MCH_MASK_ONLN             (1 << 2) /* 1 = MCH responds to pings */
+#define MCH_MASK_CNFG_CHK         (1 << 3) /* 1 = time to check config up-to-date */
+#define MCH_MASK_DBG              (0x30)
+#define MCH_INIT_DONE(x)          ((x & MCH_MASK_INIT) == MCH_MASK_INIT_DONE)
+#define MCH_INIT_NOT_DONE(x)      ((x & MCH_MASK_INIT) == MCH_MASK_INIT_NOT_DONE)
+#define MCH_ONLN(x)               ((x & MCH_MASK_ONLN) >> 2)
+#define MCH_CNFG_CHK(x)           ((x & MCH_MASK_CNFG_CHK) >> 3)
+#define MCH_DBG(x)                ((x & MCH_MASK_DBG) >> 4)
+#define MCH_DBG_SET(x)            (x << 4) /* Select debug bits in mask */
 
-#define MCH_DBG_OFF   0
-#define MCH_DBG_LOW   1
-#define MCH_DBG_MED   2
-#define MCH_DBG_HIGH  3
+#define MCH_DBG_OFF  0
+#define MCH_DBG_LOW  1
+#define MCH_DBG_MED  2
+#define MCH_DBG_HIGH 3
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-typedef struct MchCbRec_ MchCbRec;
+    typedef struct MchCbRec_ MchCbRec;
 
-typedef struct EntAssocRec_ {
-	SdrEntAssocRec   sdr;
-} EntAssocRec, *EntAssoc;
+    typedef struct EntAssocRec_ {
+        SdrEntAssocRec sdr;
+    } EntAssocRec, *EntAssoc;
 
-typedef struct DevEntAssocRec_ {
-	SdrDevEntAssocRec   sdr;
-	uint8_t             ownerAddr; /* Slave address of owner */
-	uint8_t             ownerChan; /* Channel of owner */
-} DevEntAssocRec, *DevEntAssoc;
+    typedef struct DevEntAssocRec_ {
+        SdrDevEntAssocRec sdr;
+        uint8_t           ownerAddr; /* Slave address of owner */
+        uint8_t           ownerChan; /* Channel of owner */
+    } DevEntAssocRec, *DevEntAssoc;
 
-/* Data structure to uniquely identify an entity */
-typedef struct EntityRec_ {
-	uint8_t entityId;
-	uint8_t entityInst;
-/* Following only used for device-relative entities */
-       	uint8_t addr; /* For device-relative, this is set to the owner's address if the container address is not defined in the entity assoc record */
-	uint8_t chan; /* For device-relative, this is set to the owner's chan if the container chan is not defined in the entity assoc record */
-} EntityRec, *Entity;
+    /* Data structure to uniquely identify an entity */
+    typedef struct EntityRec_ {
+        uint8_t entityId;
+        uint8_t entityInst;
+        /* Following only used for device-relative entities */
+        uint8_t addr; /* For device-relative, this is set to the owner's address if the container address is not defined
+                         in the entity assoc record */
+        uint8_t chan; /* For device-relative, this is set to the owner's chan if the container chan is not defined in
+                         the entity assoc record */
+    } EntityRec, *Entity;
 
-/* Handle for each Management Controller Device
- * Management controllers that also provide FRU data will
- * additionally have an associated FRU data structure
- */
-typedef struct MgmtRec_ {
-	uint8_t      instance;      /* Instance of management controller set in drvMch.c - needed? */
-	SdrMgmtRec   sdr;
-	SdrRepRec    sdrRep;
-	EntityRec    *entity;       /* Array of associated entities that should be considered subsets of this management controller */
-	int          entityAlloc;   /* Flag indicating entity array memory has been allocated and can be freed during configuration update*/
-	int          entityCount;   /* Count of entities contained by this management controller */
-} MgmtRec, *Mgmt;
+    /* Handle for each Management Controller Device
+     * Management controllers that also provide FRU data will
+     * additionally have an associated FRU data structure
+     */
+    typedef struct MgmtRec_ {
+        uint8_t    instance; /* Instance of management controller set in drvMch.c - needed? */
+        SdrMgmtRec sdr;
+        SdrRepRec  sdrRep;
+        EntityRec*
+            entity; /* Array of associated entities that should be considered subsets of this management controller */
+        int entityAlloc; /* Flag indicating entity array memory has been allocated and can be freed during configuration
+                            update*/
+        int entityCount; /* Count of entities contained by this management controller */
+    } MgmtRec, *Mgmt;
 
-/* Handle for each FRU and Management Controller that provides FRU data */
-typedef struct FruRec_ {
-	uint8_t      id;            /* FRU ID: for MicroTCA matches FRU index and defined by MicroTCA spec;
-				     * for ATCA set to chosen values to identify associated hardware*/
-	uint8_t      type;          /* FRU type */
-	uint8_t      instance;      /* Instance of this FRU type, set in drvMch.c - still in use? */
-	uint8_t      size[2];       /* FRU Inventory Area size, LS byte stored first */	
-	uint8_t      access;        /* Access FRU data by words or bytes */
-	uint8_t      readOffset[2];  
-	uint16_t     read;          /* Read number */
-	FruChassisRec chassis;
-	FruBoardRec  board;
-	FruProdRec   prod;
-	SdrFruRec    sdr;
-	char         parm[10];      /* Describes FRU type, used to load EPICS records */
-	uint8_t      pwrDyn;        /* 1 if FRU supports dynamic reconfiguration of power, otherwise 0 */
-	uint8_t      pwrDly;        /* Delay to stable power */
-/* Next section used only by cooling unit FRUs */
-        uint8_t      fanMin;        /* Fan minimum level */          
-        uint8_t      fanMax;        /* Fan maximum level */          
-        uint8_t      fanNom;        /* Fan nominal level */   
-        uint8_t      fanProp;       /* [7] 1 if fan try supports automatic fan speed adjustment */
-	int          mgmtIndex;     /* If associated with management controller, index into Mgmt array; else -1 */
-	EntityRec    *entity;       /* Array of associated entities that should be considered subsets of this FRU */
-	int          entityAlloc;   /* Flag indicating entity array memory has been allocated and can be freed during configuration update*/
-	int          entityCount;   /* Count of entities contained by this FRU */
-/* Next section used only for PICMG systems */
-	uint8_t      siteNumber;    /* Maps to physical location, slot number */
-	uint8_t      siteType;      /* Maps to physical location, slot number */
-} FruRec, *Fru;
+    /* Handle for each FRU and Management Controller that provides FRU data */
+    typedef struct FruRec_ {
+        uint8_t id;             /* FRU ID: for MicroTCA matches FRU index and defined by MicroTCA spec;
+                                 * for ATCA set to chosen values to identify associated hardware*/
+        uint8_t       type;     /* FRU type */
+        uint8_t       instance; /* Instance of this FRU type, set in drvMch.c - still in use? */
+        uint8_t       size[2];  /* FRU Inventory Area size, LS byte stored first */
+        uint8_t       access;   /* Access FRU data by words or bytes */
+        uint8_t       readOffset[2];
+        uint16_t      read; /* Read number */
+        FruChassisRec chassis;
+        FruBoardRec   board;
+        FruProdRec    prod;
+        SdrFruRec     sdr;
+        char          parm[10]; /* Describes FRU type, used to load EPICS records */
+        uint8_t       pwrDyn;   /* 1 if FRU supports dynamic reconfiguration of power, otherwise 0 */
+        uint8_t       pwrDly;   /* Delay to stable power */
+                                /* Next section used only by cooling unit FRUs */
+        uint8_t    fanMin;      /* Fan minimum level */
+        uint8_t    fanMax;      /* Fan maximum level */
+        uint8_t    fanNom;      /* Fan nominal level */
+        uint8_t    fanProp;     /* [7] 1 if fan try supports automatic fan speed adjustment */
+        int        mgmtIndex;   /* If associated with management controller, index into Mgmt array; else -1 */
+        EntityRec* entity;      /* Array of associated entities that should be considered subsets of this FRU */
+        int entityAlloc; /* Flag indicating entity array memory has been allocated and can be freed during configuration
+                            update*/
+        int entityCount; /* Count of entities contained by this FRU */
+                         /* Next section used only for PICMG systems */
+        uint8_t siteNumber; /* Maps to physical location, slot number */
+        uint8_t siteType;   /* Maps to physical location, slot number */
+    } FruRec, *Fru;
 
-/* Handle for each SDR */
-typedef struct SensorRec_ {
-	SdrFullRec    sdr;          /* Full Sensor SDR */
-        uint8_t       val;          /* Most recent sensor reading */
-	int           fruId;        /* FRU ID for associated FRU ( -1 if no associated FRU ) */
-	int           fruIndex;     /* Index into FRU array for associated FRU ( -1 if no associated FRU ) */
-	int           mgmtIndex;    /* Index into Mgmt array for associated Management Controller ( -1 if no associated MGMT ) */
-	uint8_t       instance;     /* Instance of this sensor type on this entity (usually a FRU) */
-	int           unavail;      /* 1 if sensor reading returns 'Requested Sensor, data, or record not present' */
-	char          parm[10];     /* Describes signal type, used by device support */
-	size_t        readMsgLength;/* Get Sensor Reading message response length */
-	int           cnfg;         /* 0 if needs record fields need to be updated */
-	uint8_t       tmask;        /* Mask of which thresholds are readable */
-	uint8_t       tlnc;         /* Threshold lower non-critical */
-	uint8_t       tlc;          /* Threshold lower critical */
-	uint8_t       tlnr;         /* Threshold lower non-recoverable */
-	uint8_t       tunc;         /* Threshold upper non-critical */
-	uint8_t       tuc;          /* Threshold upper critical */
-	uint8_t       tunr;         /* Threshold upper non-recoverable */
-} SensorRec, *Sensor;
+    /* Handle for each SDR */
+    typedef struct SensorRec_ {
+        SdrFullRec sdr;      /* Full Sensor SDR */
+        uint8_t    val;      /* Most recent sensor reading */
+        int        fruId;    /* FRU ID for associated FRU ( -1 if no associated FRU ) */
+        int        fruIndex; /* Index into FRU array for associated FRU ( -1 if no associated FRU ) */
+        int     mgmtIndex; /* Index into Mgmt array for associated Management Controller ( -1 if no associated MGMT ) */
+        uint8_t instance;  /* Instance of this sensor type on this entity (usually a FRU) */
+        int     unavail;   /* 1 if sensor reading returns 'Requested Sensor, data, or record not present' */
+        char    parm[10];  /* Describes signal type, used by device support */
+        size_t  readMsgLength; /* Get Sensor Reading message response length */
+        int     cnfg;          /* 0 if needs record fields need to be updated */
+        uint8_t tmask;         /* Mask of which thresholds are readable */
+        uint8_t tlnc;          /* Threshold lower non-critical */
+        uint8_t tlc;           /* Threshold lower critical */
+        uint8_t tlnr;          /* Threshold lower non-recoverable */
+        uint8_t tunc;          /* Threshold upper non-critical */
+        uint8_t tuc;           /* Threshold upper critical */
+        uint8_t tunr;          /* Threshold upper non-recoverable */
+    } SensorRec, *Sensor;
 
-/* Struct for MCH session information */
-typedef struct MchSessRec_ {
-	char    name[MAX_NAME_LENGTH];  /* MCH port name used by asyn */
-	int           instance;      /* MCH instance number; assigned at init */
-	epicsThreadId pingThreadId;  /* Thread ID for task that periodically pings MCH */
-	double        timeout;       /* Asyn read timeout */
-	int           session;       /* Enable session with MCH */
-	int           err;           /* Count of sequential message errors */         
-	int           type;          /* MCH vendor, Vadatech, NAT, etc. - need to clean this up, perhaps merge with vendor and/or add 'features' */
-} MchSessRec, *MchSess;
+    /* Struct for MCH session information */
+    typedef struct MchSessRec_ {
+        char          name[MAX_NAME_LENGTH]; /* MCH port name used by asyn */
+        int           instance;              /* MCH instance number; assigned at init */
+        epicsThreadId pingThreadId;          /* Thread ID for task that periodically pings MCH */
+        double        timeout;               /* Asyn read timeout */
+        int           session;               /* Enable session with MCH */
+        int           err;                   /* Count of sequential message errors */
+        int type; /* MCH vendor, Vadatech, NAT, etc. - need to clean this up, perhaps merge with vendor and/or add
+                     'features' */
+    } MchSessRec, *MchSess;
 
-/* Struct for MCH system information */
-typedef struct MchSysRec_ {
-	char    name[MAX_NAME_LENGTH]; /* MCH port name used by asyn */
-	SdrRepRec     sdrRep;
-	uint32_t      sdrCount;
-	uint8_t       fruCount;      /* FRU device count */
-	size_t        fruCountMax;   /* Max number of supported FRUs. Architecture-dependent. Implemented to reduce memory usage */
-	size_t        mgmtCountMax;  /* Max number of supported MGMTs. Architecture-dependent. Implemented to reduce memory usage */
-	size_t        sensCountMax;  /* Max number of supported sensors. Architecture-dependent. Implemented to reduce memory usage */
-	FruRec       *fru;           /* Array of FRUs (size of MAX_FRU) */
-	int           fruLkup[MAX_FRU_MGMT];/* Element values of fruLkup are indices into data arrays for FRUs (and Management Controllers that provide FRU data)
-                                             * Indices of fruLkup are 'ids' of FRU/MGMT, which may be chosen arbitrarily for each platform
-					     * in order to provide consistent IDs in device support addresses
-                                             * 0-MAX_FRU used for FRUs, higher indices used for Management Controllers;
-					     * value of -1 if not used 
-					     */
-	int           sensLkup[MAX_FRU_MGMT][MAX_SENSOR_TYPE][MAX_SENS_INST]; /* Index into sens struct array, used by devsup, -1 if not used */
-				     /* First index is FRU index (not FRU ID) */
-	int           sensCount;     /* Sensor count, data type must be larger than MAX_FRU_MGMT*MAX_SENSOR_TYPE*MAX_SENS_INST */
-	SensorRec    *sens;          /* Array of sensors (size of sensCount) */
-	int           sensAlloc;     /* Flag indicating sensor array memory has been allocated and can be freed during configuration update*/
-	uint8_t       mgmtCount;     /* Management controller device count */
-	MgmtRec      *mgmt;          /* Array of management controller devices (size of mgmtCount) */	
-	MchCbRec     *mchcb;         /* Callbacks for architecture-specific functionality */
-	EntAssocRec entAssoc[10];
-	int            entAssocCount;
-	DevEntAssocRec devEntAssoc[10];
-	int            devEntAssocCount;
-} MchSysRec, *MchSys;
+    /* Struct for MCH system information */
+    typedef struct MchSysRec_ {
+        char      name[MAX_NAME_LENGTH]; /* MCH port name used by asyn */
+        SdrRepRec sdrRep;
+        uint32_t  sdrCount;
+        uint8_t   fruCount; /* FRU device count */
+        size_t
+            fruCountMax; /* Max number of supported FRUs. Architecture-dependent. Implemented to reduce memory usage */
+        size_t mgmtCountMax; /* Max number of supported MGMTs. Architecture-dependent. Implemented to reduce memory
+                                usage */
+        size_t sensCountMax; /* Max number of supported sensors. Architecture-dependent. Implemented to reduce memory
+                                usage */
+        FruRec* fru;         /* Array of FRUs (size of MAX_FRU) */
+        int fruLkup[MAX_FRU_MGMT]; /* Element values of fruLkup are indices into data arrays for FRUs (and Management
+                                    * Controllers that provide FRU data) Indices of fruLkup are 'ids' of FRU/MGMT, which
+                                    * may be chosen arbitrarily for each platform in order to provide consistent IDs in
+                                    * device support addresses 0-MAX_FRU used for FRUs, higher indices used for
+                                    * Management Controllers; value of -1 if not used
+                                    */
+        int sensLkup[MAX_FRU_MGMT][MAX_SENSOR_TYPE]
+                    [MAX_SENS_INST]; /* Index into sens struct array, used by devsup, -1 if not used */
+                                     /* First index is FRU index (not FRU ID) */
+        int sensCount;   /* Sensor count, data type must be larger than MAX_FRU_MGMT*MAX_SENSOR_TYPE*MAX_SENS_INST */
+        SensorRec* sens; /* Array of sensors (size of sensCount) */
+        int sensAlloc;   /* Flag indicating sensor array memory has been allocated and can be freed during configuration
+                            update*/
+        uint8_t        mgmtCount; /* Management controller device count */
+        MgmtRec*       mgmt;      /* Array of management controller devices (size of mgmtCount) */
+        MchCbRec*      mchcb;     /* Callbacks for architecture-specific functionality */
+        EntAssocRec    entAssoc[10];
+        int            entAssocCount;
+        DevEntAssocRec devEntAssoc[10];
+        int            devEntAssocCount;
+    } MchSysRec, *MchSys;
+    /* Struct for MCH system information */
+    typedef struct MchDataRec_ {
+        IpmiSess ipmiSess; /* IPMI session information; defined in ipmiDef.h */
+        MchSess  mchSess;  /* Additional MCH session info */
+        MchSys   mchSys;   /* MCH system info */
+    } MchDataRec, *MchData;
 
-/* Struct for MCH system information */
-typedef struct MchDataRec_ {
-	IpmiSess   ipmiSess;       /* IPMI session information; defined in ipmiDef.h */
-	MchSess    mchSess;        /* Additional MCH session info */
-	MchSys     mchSys;         /* MCH system info */
-} MchDataRec, *MchData;
+    /*extern MchSys mchSysData[MAX_MCH];*/
 
-/*extern MchSys mchSysData[MAX_MCH];*/
+    int  mchCnfgChk(MchData mchData);
+    void mchStatSet(int inst, uint32_t clear, uint32_t set);
+    int  mchNewSession(MchSess mchSess, IpmiSess ipmiSess);
+    int  mchGetSensorReadingStat(MchData mchData, uint8_t* response, Sensor sens);
+    int  mchGetFruIdFromIndex(MchData mchData, int index);
 
-int  mchCnfgChk(MchData mchData);
-void mchStatSet(int inst, uint32_t clear, uint32_t set);
-int  mchNewSession(MchSess mchSess, IpmiSess ipmiSess);
-int  mchGetSensorReadingStat(MchData mchData, uint8_t *response, Sensor sens);
-int  mchGetFruIdFromIndex(MchData mchData, int index);
-
-#define IPMI_RPLY_CLOSE_SESSION_LENGTH_VT        22
+#define IPMI_RPLY_CLOSE_SESSION_LENGTH_VT 22
 
 /* IPMI device types */
-#define MCH_TYPE_MAX           10 /* Number possible MCH types; increase as needed */
-#define MCH_TYPE_UNKNOWN        0
-#define MCH_TYPE_VT             1
-#define MCH_TYPE_NAT            2
-#define MCH_TYPE_SUPERMICRO     3
-#define MCH_TYPE_PENTAIR        4
-#define MCH_TYPE_ARTESYN        5
-#define MCH_TYPE_ADVANTECH      6
+#define MCH_TYPE_MAX         10 /* Number possible MCH types; increase as needed */
+#define MCH_TYPE_UNKNOWN     0
+#define MCH_TYPE_VT          1
+#define MCH_TYPE_NAT         2
+#define MCH_TYPE_SUPERMICRO  3
+#define MCH_TYPE_PENTAIR     4
+#define MCH_TYPE_ARTESYN     5
+#define MCH_TYPE_ADVANTECH   6
 #define MCH_IS_VT(x)         (x == MCH_TYPE_VT)
 #define MCH_IS_NAT(x)        (x == MCH_TYPE_NAT)
 #define MCH_IS_SUPERMICRO(x) (x == MCH_TYPE_SUPERMICRO)
 #define MCH_IS_ADVANTECH(x)  (x == MCH_TYPE_ADVANTECH)
-#define MCH_IS_MICROTCA(x)   ((x==MCH_TYPE_NAT)||(x==MCH_TYPE_VT))
-#define MCH_IS_ATCA(x)       ((x==MCH_TYPE_PENTAIR) || (x==MCH_TYPE_ARTESYN))
+#define MCH_IS_MICROTCA(x)   ((x == MCH_TYPE_NAT) || (x == MCH_TYPE_VT))
+#define MCH_IS_ATCA(x)       ((x == MCH_TYPE_PENTAIR) || (x == MCH_TYPE_ARTESYN))
 #define MCH_IS_PICMG(x)      (MCH_IS_MICROTCA(x) || MCH_IS_ATCA(x))
 
-/* Dell not yet supported 
-#define MCH_TYPE_DELL           
-#define MCH_IS_DELL(x)       (x == MCH_TYPE_DELL)
-#define MCH_MANUF_ID_DELL       0x02A2
-#define MCH_PROD_ID_DELL  0x0100
-*/
+    /* Dell not yet supported
+    #define MCH_TYPE_DELL
+    #define MCH_IS_DELL(x)       (x == MCH_TYPE_DELL)
+    #define MCH_MANUF_ID_DELL       0x02A2
+    #define MCH_PROD_ID_DELL  0x0100
+    */
 
 #define MCH_DESC_MAX_LENGTH 40
-extern char mchDescString[MCH_TYPE_MAX][MCH_DESC_MAX_LENGTH]; /* Defined in drvMch.c */
+    extern char mchDescString[MCH_TYPE_MAX][MCH_DESC_MAX_LENGTH]; /* Defined in drvMch.c */
 
 /* Manufacturer ID */
 #define MCH_MANUF_ID_VT         0x5D32
@@ -245,27 +256,27 @@ extern char mchDescString[MCH_TYPE_MAX][MCH_DESC_MAX_LENGTH]; /* Defined in drvM
 #define MCH_MANUF_ID_ADVANTECH  0x2839 /* Advantech PC */
 
 /* Vadatech */
-#define VT_ENTITY_ID_MCH      0xC2 
-#define VT_ENTITY_ID_AMC      0xC1
-#define VT_ENTITY_ID_CU       0x1E
-#define VT_ENTITY_ID_PM       0x0A
-#define VT_ENTITY_ID_RTM      0xC0  /* asked Vivek to verify */
+#define VT_ENTITY_ID_MCH 0xC2
+#define VT_ENTITY_ID_AMC 0xC1
+#define VT_ENTITY_ID_CU  0x1E
+#define VT_ENTITY_ID_PM  0x0A
+#define VT_ENTITY_ID_RTM 0xC0 /* asked Vivek to verify */
 
-extern const void *mchCbRegistryId;
-extern struct MchCbRec_ {
-    void   (*assign_sys_sizes)   (MchData mchData);
-    void   (*assign_site_info)   (MchData mchData);
-    void   (*assign_fru_lkup)    (MchData mchData);    
-    int    (*fru_data_suppl)     (MchData mchData, int index);
-    void   (*sensor_get_fru)     (MchData mchData, Sensor sens);
-    int    (*get_chassis_status) (MchData mchData, uint8_t *data);
-/* Following are PICMG only */
-    int    (*set_fru_act)        (MchData mchData, uint8_t *data, uint8_t fruIndex, uint8_t parm);
-    int    (*get_fan_prop)       (MchData mchData, uint8_t *data, uint8_t fruIndex);
-    int    (*get_fan_level)      (MchData mchData, uint8_t *data, uint8_t fruIndex, uint8_t *level);
-    int    (*set_fan_level)      (MchData mchData, uint8_t *data, uint8_t fruIndex, uint8_t level);
-    int    (*get_power_level)    (MchData mchData, uint8_t *data, uint8_t fruIndex, uint8_t parm);
-} *MchCb;
+    extern const void* mchCbRegistryId;
+    extern struct MchCbRec_ {
+        void (*assign_sys_sizes)(MchData mchData);
+        void (*assign_site_info)(MchData mchData);
+        void (*assign_fru_lkup)(MchData mchData);
+        int (*fru_data_suppl)(MchData mchData, int index);
+        void (*sensor_get_fru)(MchData mchData, Sensor sens);
+        int (*get_chassis_status)(MchData mchData, uint8_t* data);
+        /* Following are PICMG only */
+        int (*set_fru_act)(MchData mchData, uint8_t* data, uint8_t fruIndex, uint8_t parm);
+        int (*get_fan_prop)(MchData mchData, uint8_t* data, uint8_t fruIndex);
+        int (*get_fan_level)(MchData mchData, uint8_t* data, uint8_t fruIndex, uint8_t* level);
+        int (*set_fan_level)(MchData mchData, uint8_t* data, uint8_t fruIndex, uint8_t level);
+        int (*get_power_level)(MchData mchData, uint8_t* data, uint8_t fruIndex, uint8_t parm);
+    }* MchCb;
 
 #ifdef __cplusplus
 };

--- a/src/drvMchMsg.c
+++ b/src/drvMchMsg.c
@@ -1,10 +1,10 @@
 //////////////////////////////////////////////////////////////////////////////
 // This file is part of 'ipmiComm'.
-// It is subject to the license terms in the LICENSE.txt file found in the 
-// top-level directory of this distribution and at: 
-//    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
-// No part of 'ipmiComm', including this file, 
-// may be copied, modified, propagated, or distributed except according to 
+// It is subject to the license terms in the LICENSE.txt file found in the
+// top-level directory of this distribution and at:
+//    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+// No part of 'ipmiComm', including this file,
+// may be copied, modified, propagated, or distributed except according to
 // the terms contained in the LICENSE.txt file.
 //////////////////////////////////////////////////////////////////////////////
 #include <errlog.h>
@@ -20,13 +20,12 @@
 #include <picmgDef.h>
 #include <drvMchMsg.h>
 
-
 /* change this to be callback mchWriteRead, move to drvMch.c
  *
- * Call ipmiMsgWriteRead. 
+ * Call ipmiMsgWriteRead.
  * If error, increment error count. Else, set error count back to zero.
  * If MCH is alive, but there is no response or error count reaches 10,
- * start a new session and return error. 
+ * start a new session and return error.
  * Check message sequence, session sequence, completion code.
  *
  *   RETURNS: 0 if error-free response
@@ -44,188 +43,196 @@
  *                codeOffs     - Additional offset used to read completion code
  *                outSess      - 1 if outside a session; 0 if in a session
  */
-int
-mchMsgWriteReadHelper(MchSess mchSess, IpmiSess ipmiSess, uint8_t *message, size_t messageSize, uint8_t *response, size_t *responseSize, uint8_t cmd, uint8_t netfn, int codeOffs, int outSess)
-{
-int      i, status, inst = mchSess->instance;
-uint8_t  ipmiSeq = 0, code;
-int      ipmiSeqOffs;
-uint8_t  seq[4];
-uint32_t seqInt, seqRplyInt, seqDiff;
-size_t   responseLen;
+int mchMsgWriteReadHelper(MchSess mchSess, IpmiSess ipmiSess, uint8_t* message, size_t messageSize, uint8_t* response,
+                          size_t* responseSize, uint8_t cmd, uint8_t netfn, int codeOffs, int outSess) {
+    int      i, status, inst = mchSess->instance;
+    uint8_t  ipmiSeq = 0, code;
+    int      ipmiSeqOffs;
+    uint8_t  seq[4];
+    uint32_t seqInt, seqRplyInt, seqDiff;
+    size_t   responseLen;
 
-	ipmiSeqOffs = ( IPMI_MSG_AUTH_TYPE_NONE == message[RMCP_MSG_HEADER_LENGTH+IPMI_WRAPPER_AUTH_TYPE_OFFSET] ) ?
-		RMCP_MSG_HEADER_LENGTH + IPMI_WRAPPER_LENGTH + IPMI_MSG1_LENGTH + IPMI_MSG2_SEQLUN_OFFSET          :
-		RMCP_MSG_HEADER_LENGTH + IPMI_WRAPPER_AUTH_LENGTH + IPMI_MSG1_LENGTH + IPMI_MSG2_SEQLUN_OFFSET;
+    ipmiSeqOffs = (IPMI_MSG_AUTH_TYPE_NONE == message[RMCP_MSG_HEADER_LENGTH + IPMI_WRAPPER_AUTH_TYPE_OFFSET])
+                      ? RMCP_MSG_HEADER_LENGTH + IPMI_WRAPPER_LENGTH + IPMI_MSG1_LENGTH + IPMI_MSG2_SEQLUN_OFFSET
+                      : RMCP_MSG_HEADER_LENGTH + IPMI_WRAPPER_AUTH_LENGTH + IPMI_MSG1_LENGTH + IPMI_MSG2_SEQLUN_OFFSET;
 
-	/* seems we check this twice for sensor reads -- look into this */       	
-	if ( !MCH_ONLN( mchStat[inst] ) )
-		return -1;
+    /* seems we check this twice for sensor reads -- look into this */
+    if (!MCH_ONLN(mchStat[inst])) {
+        return -1;
+    }
 
-       	status = ipmiMsgWriteRead( mchSess->name, message, messageSize, response, responseSize, mchSess->timeout, &responseLen );
+    status =
+        ipmiMsgWriteRead(mchSess->name, message, messageSize, response, responseSize, mchSess->timeout, &responseLen);
 
-	if ( MCH_DBG( mchStat[inst] ) >= MCH_DBG_MED ) {
+    if (MCH_DBG(mchStat[inst]) >= MCH_DBG_MED) {
 
-		if ( MCH_DBG( mchStat[inst] ) >= MCH_DBG_HIGH ) {
-			printf("%s Message status %i, received %i, expected %i, raw data:\n", mchSess->name, status, (int)responseLen, *(int *)responseSize );
-			for ( i = 0; i < responseLen; i++ )
-				printf("%02x ", response[i]);
-			printf("\n");
-		}
-		else if ( status )
-			printf("%s Message status %i, received %i, expected %i\n", mchSess->name, status, (int)responseLen, *(int *)responseSize);
-	}
+        if (MCH_DBG(mchStat[inst]) >= MCH_DBG_HIGH) {
+            printf("%s Message status %i, received %i, expected %i, raw data:\n", mchSess->name, status,
+                   (int)responseLen, *(int*)responseSize);
+            for (i = 0; i < responseLen; i++) {
+                printf("%02x ", response[i]);
+            }
+            printf("\n");
+        } else if (status) {
+            printf("%s Message status %i, received %i, expected %i\n", mchSess->name, status, (int)responseLen,
+                   *(int*)responseSize);
+        }
+    }
 
-	*responseSize = responseLen; /* Pass actual response length back to caller */
+    *responseSize = responseLen; /* Pass actual response length back to caller */
 
-	if ( outSess ) {
-		if ( status )
-			return status;
+    if (outSess) {
+        if (status) {
+            return status;
+        }
 
-		if ( (code = response[codeOffs]) && MCH_DBG( mchStat[inst] ) )
-			ipmiCompletionCode( mchSess->name, code, cmd, netfn );
-	       	return code;
-	}
+        if ((code = response[codeOffs]) && MCH_DBG(mchStat[inst])) {
+            ipmiCompletionCode(mchSess->name, code, cmd, netfn);
+        }
+        return code;
+    }
 
-       	if ( mchSess->err > 9 ) {
-       		if ( MCH_DBG( mchStat[inst] ) )
-       			printf("%s start new session; err count is %i\n", mchSess->name, mchSess->err);
+    if (mchSess->err > 9) {
+        if (MCH_DBG(mchStat[inst])) {
+            printf("%s start new session; err count is %i\n", mchSess->name, mchSess->err);
+        }
 
-       		/* Reset error count to 0 */
-       		mchSess->err = 0;
+        /* Reset error count to 0 */
+        mchSess->err = 0;
 
-       		/* Close current session, start new one, and return error */
-       		mchMsgCloseSess( mchSess, ipmiSess, response );
-       		mchNewSession( mchSess, ipmiSess );
-       	       	return -1;
-       	}
+        /* Close current session, start new one, and return error */
+        mchMsgCloseSess(mchSess, ipmiSess, response);
+        mchNewSession(mchSess, ipmiSess);
+        return -1;
+    }
 
-	if ( responseLen == 0 ) {
-		mchSess->err++;
-		return -1;
-	}
+    if (responseLen == 0) {
+        mchSess->err++;
+        return -1;
+    }
 
-       	/* Verify IPMI message sequence number. If incorrect, increment error count and return error */
-       	ipmiSeq = IPMI_SEQLUN_EXTRACT_SEQ(response[ipmiSeqOffs]);
-       	if ( ipmiSeq != ipmiSess->seq ) {
-	       	if ( MCH_DBG( mchStat[inst] ) )
-	       		printf("%s Incorrect IPMI sequence; got %i but expected %i\n", mchSess->name, ipmiSeq, ipmiSess->seq );
-	       	mchSess->err++;
-	       	return -1;
-       	}
+    /* Verify IPMI message sequence number. If incorrect, increment error count and return error */
+    ipmiSeq = IPMI_SEQLUN_EXTRACT_SEQ(response[ipmiSeqOffs]);
+    if (ipmiSeq != ipmiSess->seq) {
+        if (MCH_DBG(mchStat[inst])) {
+            printf("%s Incorrect IPMI sequence; got %i but expected %i\n", mchSess->name, ipmiSeq, ipmiSess->seq);
+        }
+        mchSess->err++;
+        return -1;
+    }
 
-	/* Extract session sequence number from reply */
-	for ( i = 0; i < IPMI_RPLY_SEQ_LENGTH ; i++)
-       	       	seq[i] = response[RMCP_MSG_HEADER_LENGTH + IPMI_WRAPPER_SEQ_OFFSET + i]; /* bridged offset ? */
-	       
-	seqInt     = arrayToUint32( seq );
-	seqRplyInt = arrayToUint32( ipmiSess->seqRply );
-	seqDiff    = seqInt - seqRplyInt;
+    /* Extract session sequence number from reply */
+    for (i = 0; i < IPMI_RPLY_SEQ_LENGTH; i++) {
+        seq[i] = response[RMCP_MSG_HEADER_LENGTH + IPMI_WRAPPER_SEQ_OFFSET + i]; /* bridged offset ? */
+    }
 
-	if ( MCH_DBG( mchStat[inst] ) >= MCH_DBG_HIGH )
-       		printf("%s new sequence number %i, stored %i\n", mchSess->name, seqInt, seqRplyInt);
+    seqInt     = arrayToUint32(seq);
+    seqRplyInt = arrayToUint32(ipmiSess->seqRply);
+    seqDiff    = seqInt - seqRplyInt;
 
-	/* Check session sequence number. If it is not increasing or more than 
-	 * 7 counts higher than last time, discard message and set error.
-	 * If it is more than 7 counts higher, store new sequence number.
-	 *
-	 * If neither above errors are encountered, sotre new sequence number
-	 *
-	 * If seq number error or completion code non-zero, increment error count and return error.
-         * Else reset error count to 0 and return success.
-	 */
-	if ( (seqInt <= seqRplyInt) || (seqDiff > 7) ) {
-		if ( MCH_DBG( mchStat[inst] ) >= MCH_DBG_MED )
-	       		printf("%s sequence number %i, previous %i\n", mchSess->name, seqInt, seqRplyInt);
-		if ( (seqDiff > 7) ) {
-			for ( i = 0; i < IPMI_RPLY_SEQ_LENGTH; i++ )
-				ipmiSess->seqRply[i] = seq[i];
-		}
-		else
-			incr4Uint8Array( ipmiSess->seqRply, 1 );
+    if (MCH_DBG(mchStat[inst]) >= MCH_DBG_HIGH) {
+        printf("%s new sequence number %i, stored %i\n", mchSess->name, seqInt, seqRplyInt);
+    }
 
-		/* Dumb workaround for Advantech non-increasing numbers */
-		if ( !(mchSess->type == MCH_TYPE_ADVANTECH) ) {
-			mchSess->err++;
-			return -1;
-		}
-       	}
-       	else {
-		for ( i = 0; i < IPMI_RPLY_SEQ_LENGTH; i++ )
-			ipmiSess->seqRply[i] = seq[i];
+    /* Check session sequence number. If it is not increasing or more than
+     * 7 counts higher than last time, discard message and set error.
+     * If it is more than 7 counts higher, store new sequence number.
+     *
+     * If neither above errors are encountered, sotre new sequence number
+     *
+     * If seq number error or completion code non-zero, increment error count and return error.
+     * Else reset error count to 0 and return success.
+     */
+    if ((seqInt <= seqRplyInt) || (seqDiff > 7)) {
+        if (MCH_DBG(mchStat[inst]) >= MCH_DBG_MED) {
+            printf("%s sequence number %i, previous %i\n", mchSess->name, seqInt, seqRplyInt);
+        }
+        if ((seqDiff > 7)) {
+            for (i = 0; i < IPMI_RPLY_SEQ_LENGTH; i++) {
+                ipmiSess->seqRply[i] = seq[i];
+            }
+        } else {
+            incr4Uint8Array(ipmiSess->seqRply, 1);
+        }
 
-		if ( (code = response[codeOffs] ) ) {
-			if ( MCH_DBG( mchStat[inst] ) )
-				ipmiCompletionCode( mchSess->name, code, cmd, netfn );
-			//mchSess->err++; // only increment error count for some errors ? --not parameter out of range, for example
-			return code;
-		}
-	}
+        /* Dumb workaround for Advantech non-increasing numbers */
+        if (!(mchSess->type == MCH_TYPE_ADVANTECH)) {
+            mchSess->err++;
+            return -1;
+        }
+    } else {
+        for (i = 0; i < IPMI_RPLY_SEQ_LENGTH; i++) {
+            ipmiSess->seqRply[i] = seq[i];
+        }
 
-	mchSess->err = 0;
-	return 0;
+        if ((code = response[codeOffs])) {
+            if (MCH_DBG(mchStat[inst])) {
+                ipmiCompletionCode(mchSess->name, code, cmd, netfn);
+            }
+            // mchSess->err++; // only increment error count for some errors ? --not parameter out of range, for example
+            return code;
+        }
+    }
+
+    mchSess->err = 0;
+    return 0;
 }
 
-/* Only relevant for messages in a session. Do not call for messages preceding a session. Do this so we can use authReq to determine auth type. 
- * Some devices do both bridged/non-bridged messages, so cannot use ipmiSess->features alone to determine this. For now,
- * also check *bridged, which should be set to non-zero value for a bridged message. Also this is only for once-bridged messages.
- * Twice-bridged messages handled separately
+/* Only relevant for messages in a session. Do not call for messages preceding a session. Do this so we can use authReq
+ * to determine auth type. Some devices do both bridged/non-bridged messages, so cannot use ipmiSess->features alone to
+ * determine this. For now, also check *bridged, which should be set to non-zero value for a bridged message. Also this
+ * is only for once-bridged messages. Twice-bridged messages handled separately
  */
-void
-mchSetSizeOffs(IpmiSess ipmiSess, size_t payloadSize, size_t *roffs, size_t *responseSize, int *bridged, uint8_t *rsAddr, uint8_t *rqAddr)
-{
-int authOffs, offs;
+void mchSetSizeOffs(IpmiSess ipmiSess, size_t payloadSize, size_t* roffs, size_t* responseSize, int* bridged,
+                    uint8_t* rsAddr, uint8_t* rqAddr) {
+    int authOffs, offs;
 
-	/* This section needs to be completely figured out (Vadatech) */
-	if ( ipmiSess->features & MCH_FEAT_SENDMSG_RPLY ) {
-		// note that we used to only check comp code of send msg reply (not payload reply) which is different than other devices; may need to revert to that
-		offs = IPMI_RPLY_BRIDGED_2REPLY_OFFSET;
-		*responseSize += IPMI_RPLY_HEADER_LENGTH + offs;
-		*bridged = 1;
-		*rsAddr = IPMI_MSG_ADDR_CM;
-		*rqAddr = IPMI_MSG_ADDR_BMC;
-	}
-	else if ( *bridged ) {
-		offs = IPMI_RPLY_BRIDGED_2REPLY_OFFSET;
-		*responseSize += IPMI_RPLY_HEADER_LENGTH + offs;
-		*rqAddr = IPMI_MSG_ADDR_BMC;
-	}
-	else {
-		offs = 0;
-		*responseSize += IPMI_RPLY_HEADER_LENGTH;
-		*bridged = 0;
-		*rqAddr  = IPMI_MSG_ADDR_SW;
-	}
+    /* This section needs to be completely figured out (Vadatech) */
+    if (ipmiSess->features & MCH_FEAT_SENDMSG_RPLY) {
+        // note that we used to only check comp code of send msg reply (not payload reply) which is different than other
+        // devices; may need to revert to that
+        offs = IPMI_RPLY_BRIDGED_2REPLY_OFFSET;
+        *responseSize += IPMI_RPLY_HEADER_LENGTH + offs;
+        *bridged = 1;
+        *rsAddr  = IPMI_MSG_ADDR_CM;
+        *rqAddr  = IPMI_MSG_ADDR_BMC;
+    } else if (*bridged) {
+        offs = IPMI_RPLY_BRIDGED_2REPLY_OFFSET;
+        *responseSize += IPMI_RPLY_HEADER_LENGTH + offs;
+        *rqAddr = IPMI_MSG_ADDR_BMC;
+    } else {
+        offs = 0;
+        *responseSize += IPMI_RPLY_HEADER_LENGTH;
+        *bridged = 0;
+        *rqAddr  = IPMI_MSG_ADDR_SW;
+    }
 
+    if (ipmiSess->authReq != IPMI_MSG_AUTH_TYPE_NONE) {
+        authOffs = sizeof(IPMI_WRAPPER_PWD_KEY) - sizeof(IPMI_WRAPPER);
+        offs += authOffs;
+        *responseSize += authOffs;
+    }
 
-	if ( ipmiSess->authReq != IPMI_MSG_AUTH_TYPE_NONE ) {
-		authOffs = sizeof( IPMI_WRAPPER_PWD_KEY ) - sizeof( IPMI_WRAPPER );
-		offs += authOffs;
-		*responseSize += authOffs;
-	}
+    *roffs = *responseSize; /* Offset into packet our section of interest */
+    /* If payloadSize is 0, it means the response length is variable or unknown;
+     * Set responseSize to 0 to indicate this to write/read function */
+    *responseSize += payloadSize + FOOTER_LENGTH;
 
-	*roffs = *responseSize;  /* Offset into packet our section of interest */
-	/* If payloadSize is 0, it means the response length is variable or unknown;
-         * Set responseSize to 0 to indicate this to write/read function */         
-	*responseSize += payloadSize + FOOTER_LENGTH;
-
-	return;
+    return;
 }
 
-int
-mchMsgCheckSizes(size_t destSize, int offset, size_t srcSize)
-{
-	if ( 0 >= (int)srcSize ) {
-		/* printf("mchMsgCheckSizes: message size %i less than zero\n", (int)srcSize); */
-		return -1;
-	}
-	else if ( (offset + (int)srcSize) > (int)destSize ) {
-		/* printf("mchMsgCheckSizes: copy size %i larger than destination %i \n", offset+(int)srcSize, (int)destSize); */
-		return -1;
-	}
-	
-	return 0;
-}	
+int mchMsgCheckSizes(size_t destSize, int offset, size_t srcSize) {
+    if (0 >= (int)srcSize) {
+        /* printf("mchMsgCheckSizes: message size %i less than zero\n", (int)srcSize); */
+        return -1;
+    } else if ((offset + (int)srcSize) > (int)destSize) {
+        /* printf("mchMsgCheckSizes: copy size %i larger than destination %i \n", offset+(int)srcSize, (int)destSize);
+         */
+        return -1;
+    }
+
+    return 0;
+}
 
 /* Somewhere need to state that all calls that pass in message buffer must use buffer size of MSG_MAX_LENGTH
 -- or just make caller specify buffer size? */
@@ -236,71 +243,69 @@ mchMsgCheckSizes(size_t destSize, int offset, size_t srcSize)
  *            0 on success
  *            non-zero for error
  */
-int
-mchMsgGetChanAuth(MchSess mchSess, IpmiSess ipmiSess, uint8_t *data)
-{
-uint8_t  response[MSG_MAX_LENGTH] = { 0 }; 
-size_t   roffs, responseSize, payloadSize = IPMI_RPLY_IMSG2_GET_CHAN_AUTH_LENGTH; 
-int      rval;
+int mchMsgGetChanAuth(MchSess mchSess, IpmiSess ipmiSess, uint8_t* data) {
+    uint8_t response[MSG_MAX_LENGTH] = {0};
+    size_t  roffs, responseSize, payloadSize = IPMI_RPLY_IMSG2_GET_CHAN_AUTH_LENGTH;
+    int     rval;
 
-	roffs = IPMI_RPLY_HEADER_LENGTH;
-	responseSize = (payloadSize==0) ? 0 : roffs + payloadSize + FOOTER_LENGTH;
+    roffs        = IPMI_RPLY_HEADER_LENGTH;
+    responseSize = (payloadSize == 0) ? 0 : roffs + payloadSize + FOOTER_LENGTH;
 
-	if ( (rval = ipmiMsgGetChanAuth( mchSess, ipmiSess, response, &responseSize, roffs )) )
-		goto bail;
+    if ((rval = ipmiMsgGetChanAuth(mchSess, ipmiSess, response, &responseSize, roffs))) {
+        goto bail;
+    }
 
-	if ( (rval = mchMsgCheckSizes( sizeof( response ), roffs, payloadSize )) ) {
-		printf("mchMsgGetChanAuth size error\n");
-		goto bail;
-	}
+    if ((rval = mchMsgCheckSizes(sizeof(response), roffs, payloadSize))) {
+        printf("mchMsgGetChanAuth size error\n");
+        goto bail;
+    }
 
-	memcpy( data, response + roffs, payloadSize );
+    memcpy(data, response + roffs, payloadSize);
 
 bail:
-	return rval;
+    return rval;
 }
 
 /* Temporary workaround for using different usernames across different devices */
-int
-mchMsgGetSess(MchSess mchSess, IpmiSess ipmiSess, uint8_t *data)
-{
-uint8_t response[MSG_MAX_LENGTH] = { 0 }; 
-size_t  size = sizeof( GET_SESS_MSG );
-uint8_t msg[size]; 
-size_t  roffs, responseSize, payloadSize = IPMI_RPLY_IMSG2_GET_SESSION_CHALLENGE_LENGTH; 
-int     rval;
+int mchMsgGetSess(MchSess mchSess, IpmiSess ipmiSess, uint8_t* data) {
+    uint8_t response[MSG_MAX_LENGTH] = {0};
+    size_t  size                     = sizeof(GET_SESS_MSG);
+    uint8_t msg[size];
+    size_t  roffs, responseSize, payloadSize = IPMI_RPLY_IMSG2_GET_SESSION_CHALLENGE_LENGTH;
+    int     rval;
 
-	roffs = IPMI_RPLY_HEADER_LENGTH;
-	/* If payloadSize is 0, it means the response length is variable or unknown;
-         * Set responseSize to 0 to indicate this to write/read function */         
-	responseSize = (payloadSize==0) ? 0 : roffs + payloadSize + FOOTER_LENGTH;
+    roffs        = IPMI_RPLY_HEADER_LENGTH;
+    /* If payloadSize is 0, it means the response length is variable or unknown;
+     * Set responseSize to 0 to indicate this to write/read function */
+    responseSize = (payloadSize == 0) ? 0 : roffs + payloadSize + FOOTER_LENGTH;
 
-	switch ( ipmiSess->authReq ) {
+    switch (ipmiSess->authReq) {
 
-		default:
-			printf("mchMsgGetSess: unsupported authentication type %i\n", ipmiSess->authReq );
-			return 0;
+        default:
+            printf("mchMsgGetSess: unsupported authentication type %i\n", ipmiSess->authReq);
+            return 0;
 
-		case IPMI_MSG_AUTH_TYPE_NONE:
-			memcpy( msg, GET_SESS_MSG, sizeof( GET_SESS_MSG ) );
-			break;
+        case IPMI_MSG_AUTH_TYPE_NONE:
+            memcpy(msg, GET_SESS_MSG, sizeof(GET_SESS_MSG));
+            break;
 
-		case IPMI_MSG_AUTH_TYPE_PWD_KEY:
-			memcpy( msg, GET_SESS_MSG_PWD_KEY, sizeof( GET_SESS_MSG_PWD_KEY )  );
-			break;
-	}
+        case IPMI_MSG_AUTH_TYPE_PWD_KEY:
+            memcpy(msg, GET_SESS_MSG_PWD_KEY, sizeof(GET_SESS_MSG_PWD_KEY));
+            break;
+    }
 
-	if ( (rval = ipmiMsgGetSess( mchSess, ipmiSess, response, &responseSize, msg, roffs )) )
-		goto bail;
+    if ((rval = ipmiMsgGetSess(mchSess, ipmiSess, response, &responseSize, msg, roffs))) {
+        goto bail;
+    }
 
-	if ( (rval = mchMsgCheckSizes( sizeof( response ), roffs, payloadSize )) ) {
-		printf("mchMsgGetSess size error\n");
-		goto bail;
-	}
-	memcpy( data, response + roffs, payloadSize );
+    if ((rval = mchMsgCheckSizes(sizeof(response), roffs, payloadSize))) {
+        printf("mchMsgGetSess size error\n");
+        goto bail;
+    }
+    memcpy(data, response + roffs, payloadSize);
 
 bail:
-	return rval;
+    return rval;
 }
 
 /* Activate Session
@@ -309,27 +314,26 @@ bail:
  *            0 on success
  *            non-zero for error
  */
-int
-mchMsgActSess(MchSess mchSess, IpmiSess ipmiSess, uint8_t *data)
-{
-uint8_t  response[MSG_MAX_LENGTH] = { 0 }; 
-size_t   roffs, responseSize = 0, payloadSize = IPMI_RPLY_IMSG2_ACTIVATE_SESSION_LENGTH; 
-int      rval, bridged = 0;
-uint8_t  rsAddr = IPMI_MSG_ADDR_BMC, rqAddr;
+int mchMsgActSess(MchSess mchSess, IpmiSess ipmiSess, uint8_t* data) {
+    uint8_t response[MSG_MAX_LENGTH] = {0};
+    size_t  roffs, responseSize = 0, payloadSize = IPMI_RPLY_IMSG2_ACTIVATE_SESSION_LENGTH;
+    int     rval, bridged = 0;
+    uint8_t rsAddr = IPMI_MSG_ADDR_BMC, rqAddr;
 
-	mchSetSizeOffs( ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr );
+    mchSetSizeOffs(ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr);
 
-	if ( (rval = ipmiMsgActSess( mchSess, ipmiSess, response, &responseSize, roffs )) )
-		goto bail;
+    if ((rval = ipmiMsgActSess(mchSess, ipmiSess, response, &responseSize, roffs))) {
+        goto bail;
+    }
 
-	if ( (rval = mchMsgCheckSizes( sizeof( response ), roffs, payloadSize )) ) {
-		printf("mchMsgActSess size error\n");
-		goto bail;
-	}
-	memcpy( data, response + roffs, payloadSize );
+    if ((rval = mchMsgCheckSizes(sizeof(response), roffs, payloadSize))) {
+        printf("mchMsgActSess size error\n");
+        goto bail;
+    }
+    memcpy(data, response + roffs, payloadSize);
 
 bail:
-	return rval;
+    return rval;
 }
 
 /* Set Session Privilege level
@@ -338,27 +342,26 @@ bail:
  *            0 on success
  *            non-zero for error
  */
-int
-mchMsgSetPriv(MchSess mchSess, IpmiSess ipmiSess, uint8_t *data, uint8_t level)
-{
-uint8_t  response[MSG_MAX_LENGTH] = { 0 }; 
-size_t   roffs, responseSize = 0, payloadSize = IPMI_RPLY_IMSG2_SET_PRIV_LEVEL_LENGTH; 
-int      rval, bridged = 0;
-uint8_t  rsAddr = IPMI_MSG_ADDR_BMC, rqAddr;
+int mchMsgSetPriv(MchSess mchSess, IpmiSess ipmiSess, uint8_t* data, uint8_t level) {
+    uint8_t response[MSG_MAX_LENGTH] = {0};
+    size_t  roffs, responseSize = 0, payloadSize = IPMI_RPLY_IMSG2_SET_PRIV_LEVEL_LENGTH;
+    int     rval, bridged = 0;
+    uint8_t rsAddr = IPMI_MSG_ADDR_BMC, rqAddr;
 
-	mchSetSizeOffs( ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr );
+    mchSetSizeOffs(ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr);
 
-	if ( (rval = ipmiMsgSetPriv( mchSess, ipmiSess, response, &responseSize, level, roffs )) )
-		goto bail;
+    if ((rval = ipmiMsgSetPriv(mchSess, ipmiSess, response, &responseSize, level, roffs))) {
+        goto bail;
+    }
 
-	if ( (rval = mchMsgCheckSizes( sizeof( response ), roffs, payloadSize )) ) {
-		printf("mchMsgSetPriv size error\n");
-		goto bail;
-	}
-	memcpy( data, response + roffs, payloadSize );
+    if ((rval = mchMsgCheckSizes(sizeof(response), roffs, payloadSize))) {
+        printf("mchMsgSetPriv size error\n");
+        goto bail;
+    }
+    memcpy(data, response + roffs, payloadSize);
 
 bail:
-	return rval;
+    return rval;
 }
 
 /* Get Device ID -- this is called before we know device type -- need to update this
@@ -367,102 +370,106 @@ bail:
  *            0 on success
  *            non-zero for error
  */
-static int
-mchMsgGetDeviceId(MchData mchData, uint8_t *data, int bridged, uint8_t rsAddr) // change this to either never be bridged or to implement device checking and offsets; handle rqAddr too
+static int mchMsgGetDeviceId(MchData mchData, uint8_t* data, int bridged,
+                             uint8_t rsAddr) // change this to either never be bridged or to implement device checking
+                                             // and offsets; handle rqAddr too
 {
-uint8_t  response[MSG_MAX_LENGTH] = { 0 }; 
-size_t   roffs, responseSize = 0, payloadSize = IPMI_RPLY_IMSG2_GET_DEVICE_ID_LENGTH; 
-int      rval;
-uint8_t  rqAddr;
+    uint8_t response[MSG_MAX_LENGTH] = {0};
+    size_t  roffs, responseSize = 0, payloadSize = IPMI_RPLY_IMSG2_GET_DEVICE_ID_LENGTH;
+    int     rval;
+    uint8_t rqAddr;
 
-	mchSetSizeOffs( mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr);
+    mchSetSizeOffs(mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr);
 
-	if ( (rval = ipmiMsgGetDeviceId( mchData->mchSess, mchData->ipmiSess, response, bridged, rsAddr, rqAddr, &responseSize, roffs )) )
-		goto bail;
+    if ((rval = ipmiMsgGetDeviceId(mchData->mchSess, mchData->ipmiSess, response, bridged, rsAddr, rqAddr,
+                                   &responseSize, roffs))) {
+        goto bail;
+    }
 
-	if ( (rval = mchMsgCheckSizes( sizeof( response ), roffs, payloadSize )) ) {
-		printf("mchMsgGetDeviceId size error\n");
-		goto bail;
-	}
-	memcpy( data, response + roffs, payloadSize );
+    if ((rval = mchMsgCheckSizes(sizeof(response), roffs, payloadSize))) {
+        printf("mchMsgGetDeviceId size error\n");
+        goto bail;
+    }
+    memcpy(data, response + roffs, payloadSize);
 
 bail:
-	return rval;
+    return rval;
 }
 
-int 
-mchMsgGetDeviceIdWrapper(MchData mchData, uint8_t *data, uint8_t rsAddr) {
-int bridged = 0;
+int mchMsgGetDeviceIdWrapper(MchData mchData, uint8_t* data, uint8_t rsAddr) {
+    int bridged = 0;
 
-	if ( rsAddr != IPMI_MSG_ADDR_BMC )
-		bridged = 1;
-	return mchMsgGetDeviceId( mchData, data, bridged, rsAddr );
+    if (rsAddr != IPMI_MSG_ADDR_BMC) {
+        bridged = 1;
+    }
+    return mchMsgGetDeviceId(mchData, data, bridged, rsAddr);
 }
 
- /* Broadcast Get Device ID -- this is called before we know device type -- need to update this
-  *
-  *   RETURNS: status from mchMsgWriteReadHelper
-  *            0 on success
-  *            non-zero for error
-  */
- int
- mchMsgBroadcastGetDeviceId(MchData mchData, uint8_t *data, int tmp, uint8_t tmp1 ) //int bridged, uint8_t rsAddr) // change this $
- {
- uint8_t  response[MSG_MAX_LENGTH] = { 0 };
- size_t   roffs, responseSize = 0, payloadSize = IPMI_RPLY_IMSG2_GET_DEVICE_ID_LENGTH;
- int      rval, bridged = 0;
- uint8_t  rsAddr = IPMI_MSG_ADDR_BMC, rqAddr;
+/* Broadcast Get Device ID -- this is called before we know device type -- need to update this
+ *
+ *   RETURNS: status from mchMsgWriteReadHelper
+ *            0 on success
+ *            non-zero for error
+ */
+int mchMsgBroadcastGetDeviceId(MchData mchData, uint8_t* data, int tmp,
+                               uint8_t tmp1) // int bridged, uint8_t rsAddr) // change this $
+{
+    uint8_t response[MSG_MAX_LENGTH] = {0};
+    size_t  roffs, responseSize = 0, payloadSize = IPMI_RPLY_IMSG2_GET_DEVICE_ID_LENGTH;
+    int     rval, bridged = 0;
+    uint8_t rsAddr = IPMI_MSG_ADDR_BMC, rqAddr;
 
-       mchSetSizeOffs( mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr);
- 
-       if ( (rval = ipmiMsgBroadcastGetDeviceId( mchData->mchSess, mchData->ipmiSess, response, bridged, rsAddr, rqAddr, &responseSize, roffs )) )
-               goto bail;
-  
-       if ( (rval = mchMsgCheckSizes( sizeof( response ), roffs, payloadSize )) ) {
-               printf("mchMsgBroadcastGetDeviceId size error\n");
-               goto bail;
-       }
-       memcpy( data, response + roffs, payloadSize );
+    mchSetSizeOffs(mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr);
+
+    if ((rval = ipmiMsgBroadcastGetDeviceId(mchData->mchSess, mchData->ipmiSess, response, bridged, rsAddr, rqAddr,
+                                            &responseSize, roffs))) {
+        goto bail;
+    }
+
+    if ((rval = mchMsgCheckSizes(sizeof(response), roffs, payloadSize))) {
+        printf("mchMsgBroadcastGetDeviceId size error\n");
+        goto bail;
+    }
+    memcpy(data, response + roffs, payloadSize);
 bail:
-      return rval;
+    return rval;
 }
 
 /* Close Session - test for NAT and determine reply offset*/
-int
-mchMsgCloseSess(MchSess mchSess, IpmiSess ipmiSess, uint8_t *data)
-{
-size_t responseSize = MCH_IS_NAT( mchSess->type ) ? IPMI_RPLY_CLOSE_SESSION_LENGTH_NAT : IPMI_RPLY_CLOSE_SESSION_LENGTH_VT;
+int mchMsgCloseSess(MchSess mchSess, IpmiSess ipmiSess, uint8_t* data) {
+    size_t responseSize =
+        MCH_IS_NAT(mchSess->type) ? IPMI_RPLY_CLOSE_SESSION_LENGTH_NAT : IPMI_RPLY_CLOSE_SESSION_LENGTH_VT;
 
-	return ipmiMsgCloseSess( mchSess, ipmiSess, data, &responseSize /* need to add roffs */ );
+    return ipmiMsgCloseSess(mchSess, ipmiSess, data, &responseSize /* need to add roffs */);
 }
 
-/* Chassis Control 
+/* Chassis Control
  *
  *   RETURNS: status from ipmiMsgChassisControl
  *            0 on success
  *            non-zero for error
  */
-int
-mchMsgChassisControl(MchData mchData, uint8_t *data, uint8_t parm)
-{
-uint8_t  response[MSG_MAX_LENGTH] = { 0 }; 
-size_t   roffs, responseSize = 0, payloadSize = IPMI_RPLY_IMSG2_CHAS_CTRL_LENGTH; 
-int      rval, bridged = 0;
-uint8_t  rsAddr = IPMI_MSG_ADDR_BMC, rqAddr;
+int mchMsgChassisControl(MchData mchData, uint8_t* data, uint8_t parm) {
+    uint8_t response[MSG_MAX_LENGTH] = {0};
+    size_t  roffs, responseSize = 0, payloadSize = IPMI_RPLY_IMSG2_CHAS_CTRL_LENGTH;
+    int     rval, bridged = 0;
+    uint8_t rsAddr = IPMI_MSG_ADDR_BMC, rqAddr;
 
-	mchSetSizeOffs( mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr );
+    mchSetSizeOffs(mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr);
 
-	if ( (rval = ipmiMsgChassisControl( mchData->mchSess, mchData->ipmiSess, response, bridged, rsAddr, rqAddr, parm, &responseSize, roffs )) )
-		goto bail;
+    if ((rval = ipmiMsgChassisControl(mchData->mchSess, mchData->ipmiSess, response, bridged, rsAddr, rqAddr, parm,
+                                      &responseSize, roffs))) {
+        goto bail;
+    }
 
-	if ( (rval = mchMsgCheckSizes( sizeof( response ), roffs, payloadSize )) ) {
-		printf("mchMsgChassisControl size error\n");
-		goto bail;
-	}
-	memcpy( data, response + roffs, payloadSize );
+    if ((rval = mchMsgCheckSizes(sizeof(response), roffs, payloadSize))) {
+        printf("mchMsgChassisControl size error\n");
+        goto bail;
+    }
+    memcpy(data, response + roffs, payloadSize);
 
 bail:
-	return rval;
+    return rval;
 }
 
 /* Get Chassis Status, supported by Supermicro and ATCA systems
@@ -471,27 +478,27 @@ bail:
  *            0 on success
  *            non-zero for error
  */
-int
-mchMsgGetChassisStatus(MchData mchData, uint8_t *data)
-{
-uint8_t  response[MSG_MAX_LENGTH] = { 0 }; 
-size_t   roffs, responseSize = 0, payloadSize = IPMI_RPLY_IMSG2_GET_CHAS_STATUS_LENGTH; 
-int      rval, bridged = 0;
-uint8_t  rsAddr = IPMI_MSG_ADDR_BMC, rqAddr;
+int mchMsgGetChassisStatus(MchData mchData, uint8_t* data) {
+    uint8_t response[MSG_MAX_LENGTH] = {0};
+    size_t  roffs, responseSize = 0, payloadSize = IPMI_RPLY_IMSG2_GET_CHAS_STATUS_LENGTH;
+    int     rval, bridged = 0;
+    uint8_t rsAddr = IPMI_MSG_ADDR_BMC, rqAddr;
 
-	mchSetSizeOffs( mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr );
+    mchSetSizeOffs(mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr);
 
-	if ( (rval = ipmiMsgGetChassisStatus( mchData->mchSess, mchData->ipmiSess, response, bridged, rsAddr, rqAddr, &responseSize, roffs )) )
-		goto bail;
+    if ((rval = ipmiMsgGetChassisStatus(mchData->mchSess, mchData->ipmiSess, response, bridged, rsAddr, rqAddr,
+                                        &responseSize, roffs))) {
+        goto bail;
+    }
 
-	if ( (rval = mchMsgCheckSizes( sizeof( response ), roffs, payloadSize )) ) {
-		printf("mchMsgGetChassisStatus size error\n");
-		goto bail;
-	}
-	memcpy( data, response + roffs, payloadSize );
+    if ((rval = mchMsgCheckSizes(sizeof(response), roffs, payloadSize))) {
+        printf("mchMsgGetChassisStatus size error\n");
+        goto bail;
+    }
+    memcpy(data, response + roffs, payloadSize);
 
 bail:
-	return rval;
+    return rval;
 }
 
 /* Get FRU Inventory Info, optionally bridged message. If not bridged, caller should set bridged arg to 0.
@@ -500,126 +507,126 @@ bail:
  *            0 on success
  *            non-zero for error
  */
-static int
-mchMsgGetFruInvInfo(MchData mchData, uint8_t *data, uint8_t id, int bridged, uint8_t rsAddr)
-{
-uint8_t  response[MSG_MAX_LENGTH] = { 0 }; 
-size_t   roffs, responseSize = 0, payloadSize = IPMI_RPLY_IMSG2_GET_FRU_INV_INFO_LENGTH; 
-int      rval;
-uint8_t  rqAddr;
+static int mchMsgGetFruInvInfo(MchData mchData, uint8_t* data, uint8_t id, int bridged, uint8_t rsAddr) {
+    uint8_t response[MSG_MAX_LENGTH] = {0};
+    size_t  roffs, responseSize = 0, payloadSize = IPMI_RPLY_IMSG2_GET_FRU_INV_INFO_LENGTH;
+    int     rval;
+    uint8_t rqAddr;
 
-	mchSetSizeOffs( mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr );
+    mchSetSizeOffs(mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr);
 
-	if ( (rval = ipmiMsgGetFruInvInfo( mchData->mchSess, mchData->ipmiSess, response, bridged, rsAddr, rqAddr, id, &responseSize, roffs )) )
-		goto bail;
+    if ((rval = ipmiMsgGetFruInvInfo(mchData->mchSess, mchData->ipmiSess, response, bridged, rsAddr, rqAddr, id,
+                                     &responseSize, roffs))) {
+        goto bail;
+    }
 
-	if ( (rval = mchMsgCheckSizes( sizeof( response ), roffs, payloadSize )) ) {
-		printf("mchMsgGetFruInvInfo size error\n");
-		goto bail;
-	}
+    if ((rval = mchMsgCheckSizes(sizeof(response), roffs, payloadSize))) {
+        printf("mchMsgGetFruInvInfo size error\n");
+        goto bail;
+    }
 
-	memcpy( data, response + roffs, payloadSize );
+    memcpy(data, response + roffs, payloadSize);
 
 bail:
-	return rval;
+    return rval;
 }
 
-int
-mchMsgGetFruInvInfoWrapper(MchData mchData, uint8_t *data, Fru fru)
-{
-int bridged = 0;
-uint8_t rsAddr = fru->sdr.addr;
+int mchMsgGetFruInvInfoWrapper(MchData mchData, uint8_t* data, Fru fru) {
+    int     bridged = 0;
+    uint8_t rsAddr  = fru->sdr.addr;
 
-	if ( rsAddr != IPMI_MSG_ADDR_BMC )
-		bridged = 1;
-	return mchMsgGetFruInvInfo( mchData, data, fru->sdr.fruId, bridged, rsAddr );
+    if (rsAddr != IPMI_MSG_ADDR_BMC) {
+        bridged = 1;
+    }
+    return mchMsgGetFruInvInfo(mchData, data, fru->sdr.fruId, bridged, rsAddr);
 }
 
-/* Read FRU data 
+/* Read FRU data
  *
  *   RETURNS: status from mchMsgWriteReadHelper
  *            0 on success
  *            non-zero for error
  */
-static int
-mchMsgReadFru(MchData mchData, uint8_t *data, uint8_t id, uint8_t *readOffset, uint8_t readSize, int bridged, uint8_t rsAddr)
-{
-uint8_t  response[MSG_MAX_LENGTH] = { 0 }; 
-size_t   roffs, responseSize = 0, payloadSize = IPMI_RPLY_IMSG2_READ_FRU_DATA_BASE_LENGTH + readSize; 
-int      rval;
-uint8_t  rqAddr;
+static int mchMsgReadFru(MchData mchData, uint8_t* data, uint8_t id, uint8_t* readOffset, uint8_t readSize, int bridged,
+                         uint8_t rsAddr) {
+    uint8_t response[MSG_MAX_LENGTH] = {0};
+    size_t  roffs, responseSize = 0, payloadSize = IPMI_RPLY_IMSG2_READ_FRU_DATA_BASE_LENGTH + readSize;
+    int     rval;
+    uint8_t rqAddr;
 
-	mchSetSizeOffs( mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr );
+    mchSetSizeOffs(mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr);
 
-	if ( (rval = ipmiMsgReadFru( mchData->mchSess, mchData->ipmiSess, response, bridged, rsAddr, rqAddr, id, readOffset, readSize, &responseSize, roffs )) )
-		goto bail;
+    if ((rval = ipmiMsgReadFru(mchData->mchSess, mchData->ipmiSess, response, bridged, rsAddr, rqAddr, id, readOffset,
+                               readSize, &responseSize, roffs))) {
+        goto bail;
+    }
 
-	if ( (rval = mchMsgCheckSizes( sizeof( response ), roffs, payloadSize )) ) {
-		printf("mchMsgReadFru size error\n");
-		goto bail;
-	}
+    if ((rval = mchMsgCheckSizes(sizeof(response), roffs, payloadSize))) {
+        printf("mchMsgReadFru size error\n");
+        goto bail;
+    }
 
-	memcpy( data, response + roffs, payloadSize );
+    memcpy(data, response + roffs, payloadSize);
 
 bail:
-	return rval;
+    return rval;
 }
 
-int
-mchMsgReadFruWrapper(MchData mchData, uint8_t *data, Fru fru, uint8_t *readOffset, uint8_t readSize)
-{
-int bridged = 0;
-uint8_t rsAddr = fru->sdr.addr;
+int mchMsgReadFruWrapper(MchData mchData, uint8_t* data, Fru fru, uint8_t* readOffset, uint8_t readSize) {
+    int     bridged = 0;
+    uint8_t rsAddr  = fru->sdr.addr;
 
-	if ( rsAddr != IPMI_MSG_ADDR_BMC )
-		bridged = 1;
-	return mchMsgReadFru( mchData, data, fru->sdr.fruId, readOffset, readSize, bridged, rsAddr );
+    if (rsAddr != IPMI_MSG_ADDR_BMC) {
+        bridged = 1;
+    }
+    return mchMsgReadFru(mchData, data, fru->sdr.fruId, readOffset, readSize, bridged, rsAddr);
 }
 
-/* Get SDR (Sensor Data Record) Repository Info 
+/* Get SDR (Sensor Data Record) Repository Info
  *
  *   RETURNS: status from mchMsgWriteReadHelper
  *            0 on success
  *            non-zero for error
  */
-static int
-mchMsgGetSdrRepInfo(MchData mchData, uint8_t *data, uint8_t parm, int bridged, uint8_t rsAddr)
-{
-uint8_t  response[MSG_MAX_LENGTH] = { 0 }; 
-size_t   roffs, responseSize = 0; 
-size_t   payloadSize = (parm==IPMI_SDRREP_PARM_GET_DEV_SDR) ? IPMI_RPLY_IMSG2_GET_DEV_SDR_INFO_LENGTH : IPMI_RPLY_IMSG2_GET_SDRREP_INFO_LENGTH; 
-int      rval;
-uint8_t  rqAddr;
+static int mchMsgGetSdrRepInfo(MchData mchData, uint8_t* data, uint8_t parm, int bridged, uint8_t rsAddr) {
+    uint8_t response[MSG_MAX_LENGTH] = {0};
+    size_t  roffs, responseSize = 0;
+    size_t  payloadSize = (parm == IPMI_SDRREP_PARM_GET_DEV_SDR) ? IPMI_RPLY_IMSG2_GET_DEV_SDR_INFO_LENGTH
+                                                                 : IPMI_RPLY_IMSG2_GET_SDRREP_INFO_LENGTH;
+    int     rval;
+    uint8_t rqAddr;
 
-	mchSetSizeOffs( mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr );
+    mchSetSizeOffs(mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr);
 
-/* Set channel ? */
-	if ( (rval = ipmiMsgGetSdrRepInfo( mchData->mchSess, mchData->ipmiSess, response, bridged, rsAddr, rqAddr, &responseSize, roffs, parm )) )
-		goto bail;
+    /* Set channel ? */
+    if ((rval = ipmiMsgGetSdrRepInfo(mchData->mchSess, mchData->ipmiSess, response, bridged, rsAddr, rqAddr,
+                                     &responseSize, roffs, parm))) {
+        goto bail;
+    }
 
-	if ( (rval = mchMsgCheckSizes( sizeof( response ), roffs, payloadSize )) ) {
-		printf("mchMsgGetSdrRepInfo size error roffs %i payloadSize %i responseSize %i\n", (int)roffs, (int)payloadSize, (int)responseSize);
-		goto bail;
-	}
+    if ((rval = mchMsgCheckSizes(sizeof(response), roffs, payloadSize))) {
+        printf("mchMsgGetSdrRepInfo size error roffs %i payloadSize %i responseSize %i\n", (int)roffs, (int)payloadSize,
+               (int)responseSize);
+        goto bail;
+    }
 
-	memcpy( data, response + roffs, payloadSize );
+    memcpy(data, response + roffs, payloadSize);
 
 bail:
-	return rval;
+    return rval;
 }
 
-int
-mchMsgGetSdrRepInfoWrapper(MchData mchData, uint8_t *data, uint8_t parm, uint8_t rsAddr)
-{
-int bridged = 0;
+int mchMsgGetSdrRepInfoWrapper(MchData mchData, uint8_t* data, uint8_t parm, uint8_t rsAddr) {
+    int bridged = 0;
 
-	if ( rsAddr != IPMI_MSG_ADDR_BMC )
-		bridged = 1;
+    if (rsAddr != IPMI_MSG_ADDR_BMC) {
+        bridged = 1;
+    }
 
-	return mchMsgGetSdrRepInfo( mchData, data, parm, bridged, rsAddr );
+    return mchMsgGetSdrRepInfo(mchData, data, parm, bridged, rsAddr);
 }
 
-/* Get Device Sensor Data Record (SDR) Info 
+/* Get Device Sensor Data Record (SDR) Info
  *
  *   RETURNS: status from mchMsgWriteReadHelper
  *            0 on success
@@ -628,25 +635,25 @@ int bridged = 0;
 int
 mchMsgGetDevSdrInfo(MchData mchData, uint8_t *data, int bridged, uint8_t rsAddr, uint8_t parm)
 {
-uint8_t  response[MSG_MAX_LENGTH] = { 0 }; 
-size_t   roffs, responseSize = 0, payloadSize = IPMI_RPLY_IMSG2_GET_DEV_SDR_INFO_LENGTH; 
+uint8_t  response[MSG_MAX_LENGTH] = { 0 };
+size_t   roffs, responseSize = 0, payloadSize = IPMI_RPLY_IMSG2_GET_DEV_SDR_INFO_LENGTH;
 int      rval;
 uint8_t  rqAddr;
 
-	mchSetSizeOffs( mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr );
+    mchSetSizeOffs( mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr );
 
-	if ( (rval = ipmiMsgGetDevSdrInfo( mchData->mchSess, mchData->ipmiSess, response, bridged, rsAddr, rqAddr, parm, &responseSize, roffs )) )
-		goto bail;
+    if ( (rval = ipmiMsgGetDevSdrInfo( mchData->mchSess, mchData->ipmiSess, response, bridged, rsAddr, rqAddr, parm,
+&responseSize, roffs )) ) goto bail;
 
-	if ( (rval = mchMsgCheckSizes( sizeof( response ), roffs, payloadSize )) ) {
-		printf("mchMsgGetDevSdrInfo size error\n");
-		goto bail;
-	}
+    if ( (rval = mchMsgCheckSizes( sizeof( response ), roffs, payloadSize )) ) {
+        printf("mchMsgGetDevSdrInfo size error\n");
+        goto bail;
+    }
 
-	memcpy( data, response + roffs, payloadSize );
+    memcpy( data, response + roffs, payloadSize );
 
 bail:
-	return rval;
+    return rval;
 }
 */
 
@@ -656,164 +663,165 @@ bail:
  *            0 on success
  *            non-zero for error
  */
-static int
-mchMsgReserveSdrRep(MchData mchData, uint8_t *data, uint8_t parm, int bridged, uint8_t rsAddr)
-{
-uint8_t  response[MSG_MAX_LENGTH] = { 0 }; 
-size_t   roffs, responseSize = 0, payloadSize = IPMI_RPLY_IMSG2_RESERVE_SDRREP_LENGTH; 
-int      rval;
-uint8_t  rqAddr;
+static int mchMsgReserveSdrRep(MchData mchData, uint8_t* data, uint8_t parm, int bridged, uint8_t rsAddr) {
+    uint8_t response[MSG_MAX_LENGTH] = {0};
+    size_t  roffs, responseSize = 0, payloadSize = IPMI_RPLY_IMSG2_RESERVE_SDRREP_LENGTH;
+    int     rval;
+    uint8_t rqAddr;
 
-	mchSetSizeOffs( mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr );
+    mchSetSizeOffs(mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr);
 
-	if ( (rval = ipmiMsgReserveSdrRep( mchData->mchSess, mchData->ipmiSess, response, bridged, rsAddr, rqAddr, &responseSize, roffs, parm )) )
-		goto bail;
+    if ((rval = ipmiMsgReserveSdrRep(mchData->mchSess, mchData->ipmiSess, response, bridged, rsAddr, rqAddr,
+                                     &responseSize, roffs, parm))) {
+        goto bail;
+    }
 
-	if ( (rval = mchMsgCheckSizes( sizeof( response ), roffs, payloadSize )) ) {
-		printf("mchMsgReserveSdrRep size error\n");
-		goto bail;
-	}
+    if ((rval = mchMsgCheckSizes(sizeof(response), roffs, payloadSize))) {
+        printf("mchMsgReserveSdrRep size error\n");
+        goto bail;
+    }
 
-	memcpy( data, response + roffs, payloadSize );
+    memcpy(data, response + roffs, payloadSize);
 
 bail:
-	return rval;
+    return rval;
 }
 
-int
-mchMsgReserveSdrRepWrapper(MchData mchData, uint8_t *data, uint8_t parm, uint8_t rsAddr)
-{
-int bridged = 0;
+int mchMsgReserveSdrRepWrapper(MchData mchData, uint8_t* data, uint8_t parm, uint8_t rsAddr) {
+    int bridged = 0;
 
-	if ( rsAddr != IPMI_MSG_ADDR_BMC )
-		bridged = 1;
-	return mchMsgReserveSdrRep( mchData, data, parm, bridged, rsAddr );
+    if (rsAddr != IPMI_MSG_ADDR_BMC) {
+        bridged = 1;
+    }
+    return mchMsgReserveSdrRep(mchData, data, parm, bridged, rsAddr);
 }
 
-/* 
+/*
  * Get SDR (Sensor Data Record)
- * 
- * Offset and reservation ID are 0 unless doing partial read that begins at an 
+ *
+ * Offset and reservation ID are 0 unless doing partial read that begins at an
  * offset into the SDR other than 0.
  *
- * Used for both Get SDR (parm = 0) and Get Device SDR (parm = 1). 
+ * Used for both Get SDR (parm = 0) and Get Device SDR (parm = 1).
  * Only differences in the message are the network function and command code.
  *
  *   RETURNS: status from mchMsgWriteReadHelper
  *            0 on success
  *            non-zero for error
  */
-static int
-mchMsgGetSdr(MchData mchData, uint8_t *data, uint8_t *id, uint8_t *res, uint8_t offset, uint8_t readSize, uint8_t parm, int bridged, uint8_t rsAddr)
-{
-uint8_t  response[MSG_MAX_LENGTH] = { 0 }; 
-uint8_t  sdrDataSize = ( readSize == 0xFF ) ? SDR_MAX_LENGTH : readSize;
-size_t   roffs, responseSize = 0, payloadSize = IPMI_RPLY_IMSG2_GET_SDR_BASE_LENGTH + sdrDataSize; 
-int      rval;
-uint8_t  rqAddr;
-    
-	mchSetSizeOffs( mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr );
+static int mchMsgGetSdr(MchData mchData, uint8_t* data, uint8_t* id, uint8_t* res, uint8_t offset, uint8_t readSize,
+                        uint8_t parm, int bridged, uint8_t rsAddr) {
+    uint8_t response[MSG_MAX_LENGTH] = {0};
+    uint8_t sdrDataSize              = (readSize == 0xFF) ? SDR_MAX_LENGTH : readSize;
+    size_t  roffs, responseSize = 0, payloadSize = IPMI_RPLY_IMSG2_GET_SDR_BASE_LENGTH + sdrDataSize;
+    int     rval;
+    uint8_t rqAddr;
 
-	if ( (rval = ipmiMsgGetSdr( mchData->mchSess, mchData->ipmiSess, response, bridged, rsAddr, rqAddr, id, res, offset, readSize, &responseSize, roffs, parm )) )
-		goto bail;
+    mchSetSizeOffs(mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr);
 
-	if ( (rval = mchMsgCheckSizes( sizeof( response ), roffs, payloadSize )) ) {
-		printf("mchMsgGetSdr size error\n");
-		goto bail;
-	}
- 
-	memcpy( data, response + roffs, payloadSize );
+    if ((rval = ipmiMsgGetSdr(mchData->mchSess, mchData->ipmiSess, response, bridged, rsAddr, rqAddr, id, res, offset,
+                              readSize, &responseSize, roffs, parm))) {
+        goto bail;
+    }
+
+    if ((rval = mchMsgCheckSizes(sizeof(response), roffs, payloadSize))) {
+        printf("mchMsgGetSdr size error\n");
+        goto bail;
+    }
+
+    memcpy(data, response + roffs, payloadSize);
 
 bail:
-	return rval;
+    return rval;
 }
 
-int
-mchMsgGetSdrWrapper(MchData mchData, uint8_t *data,  uint8_t *id, uint8_t *res, uint8_t offset, uint8_t readSize, uint8_t parm, uint8_t rsAddr)
-{
-int bridged = 0;
+int mchMsgGetSdrWrapper(MchData mchData, uint8_t* data, uint8_t* id, uint8_t* res, uint8_t offset, uint8_t readSize,
+                        uint8_t parm, uint8_t rsAddr) {
+    int bridged = 0;
 
-	if ( rsAddr != IPMI_MSG_ADDR_BMC )
-		bridged = 1;
-	return mchMsgGetSdr( mchData, data, id, res, offset, readSize, parm, bridged, rsAddr );
+    if (rsAddr != IPMI_MSG_ADDR_BMC) {
+        bridged = 1;
+    }
+    return mchMsgGetSdr(mchData, data, id, res, offset, readSize, parm, bridged, rsAddr);
 }
 
-/* Get Sensor Reading. Caller specifies expected message response length. 
+/* Get Sensor Reading. Caller specifies expected message response length.
  *
  *   RETURNS: status from mchMsgWriteReadHelper
  *            0 on success
  *            non-zero for error
  */
-int
-mchMsgReadSensor(MchData mchData, uint8_t *data, uint8_t sens, uint8_t lun, size_t *sensReadMsgSize, int bridged, uint8_t rsAddr)
-{
-uint8_t  response[MSG_MAX_LENGTH] = { 0 }; 
-size_t   roffs, responseSize = 0, payloadSize = *sensReadMsgSize; 
-int      rval;
-uint8_t  rqAddr;
+int mchMsgReadSensor(MchData mchData, uint8_t* data, uint8_t sens, uint8_t lun, size_t* sensReadMsgSize, int bridged,
+                     uint8_t rsAddr) {
+    uint8_t response[MSG_MAX_LENGTH] = {0};
+    size_t  roffs, responseSize = 0, payloadSize = *sensReadMsgSize;
+    int     rval;
+    uint8_t rqAddr;
 
-	mchSetSizeOffs( mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr );
+    mchSetSizeOffs(mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr);
 
-	if ( (rval = ipmiMsgReadSensor( mchData->mchSess, mchData->ipmiSess, response, bridged, rsAddr, rqAddr, sens, lun, &responseSize, roffs )) )
-		goto bail;
+    if ((rval = ipmiMsgReadSensor(mchData->mchSess, mchData->ipmiSess, response, bridged, rsAddr, rqAddr, sens, lun,
+                                  &responseSize, roffs))) {
+        goto bail;
+    }
 
-	payloadSize = *sensReadMsgSize = responseSize - roffs - FOOTER_LENGTH;
-	if ( (rval = mchMsgCheckSizes( sizeof( response ), roffs, payloadSize )) ) {
-		/* printf("mchMsgReadSensor size error\n"); */
-		goto bail;
-	}
+    payloadSize = *sensReadMsgSize = responseSize - roffs - FOOTER_LENGTH;
+    if ((rval = mchMsgCheckSizes(sizeof(response), roffs, payloadSize))) {
+        /* printf("mchMsgReadSensor size error\n"); */
+        goto bail;
+    }
 
-//printf("mchMsgReadSensor: responseSize %i roffs %i response+roffs %i payloadSize %i\n", (int)responseSize, (int)roffs, (int)(response + roffs), (int)payloadSize);
+    // printf("mchMsgReadSensor: responseSize %i roffs %i response+roffs %i payloadSize %i\n", (int)responseSize,
+    // (int)roffs, (int)(response + roffs), (int)payloadSize);
 
-	memcpy( data, response + roffs, payloadSize );
-
-bail:
-	return rval;
-}
-
-int
-mchMsgReadSensorWrapper(MchData mchData, uint8_t *data, Sensor sens, size_t *sensReadMsgSize)
-{
-int bridged = 0;
-uint8_t rsAddr = sens->sdr.owner;
-
-	if ( rsAddr != IPMI_MSG_ADDR_BMC )
-		bridged = 1;
-	return mchMsgReadSensor( mchData, data, sens->sdr.number, (sens->sdr.lun & 0x3), sensReadMsgSize, bridged, rsAddr );
-}
-
-static int
-mchMsgGetSensorThresholds(MchData mchData, uint8_t *data, uint8_t sens, uint8_t lun, int bridged, uint8_t rsAddr)
-{
-uint8_t  response[MSG_MAX_LENGTH] = { 0 }; 
-size_t   roffs, responseSize = 0, payloadSize = IPMI_RPLY_IMSG2_GET_SENSOR_THRESH_LENGTH; 
-int      rval;
-uint8_t  rqAddr;
-
-	mchSetSizeOffs( mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr);
-
-	if ( (rval = ipmiMsgGetSensorThresholds( mchData->mchSess, mchData->ipmiSess, response, bridged, rsAddr, rqAddr, sens, lun, &responseSize, roffs )) )
-		goto bail;
-
-	if ( (rval = mchMsgCheckSizes( sizeof( response ), roffs, payloadSize )) ) {
-		printf("mchMsgGetSensorThresholds size error\n");
-		goto bail;
-	}
-
-	memcpy( data, response + roffs, payloadSize );
+    memcpy(data, response + roffs, payloadSize);
 
 bail:
-	return rval;
+    return rval;
 }
 
-int
-mchMsgGetSensorThresholdsWrapper(MchData mchData, uint8_t *data, Sensor sens){
+int mchMsgReadSensorWrapper(MchData mchData, uint8_t* data, Sensor sens, size_t* sensReadMsgSize) {
+    int     bridged = 0;
+    uint8_t rsAddr  = sens->sdr.owner;
 
-int bridged = 0;
-uint8_t rsAddr = sens->sdr.owner;
-
-	if ( rsAddr != IPMI_MSG_ADDR_BMC )
-		bridged = 1;
-	return mchMsgGetSensorThresholds( mchData, data, sens->sdr.number, (sens->sdr.lun & 0x3), bridged, rsAddr );
+    if (rsAddr != IPMI_MSG_ADDR_BMC) {
+        bridged = 1;
+    }
+    return mchMsgReadSensor(mchData, data, sens->sdr.number, (sens->sdr.lun & 0x3), sensReadMsgSize, bridged, rsAddr);
 }
 
+static int mchMsgGetSensorThresholds(MchData mchData, uint8_t* data, uint8_t sens, uint8_t lun, int bridged,
+                                     uint8_t rsAddr) {
+    uint8_t response[MSG_MAX_LENGTH] = {0};
+    size_t  roffs, responseSize = 0, payloadSize = IPMI_RPLY_IMSG2_GET_SENSOR_THRESH_LENGTH;
+    int     rval;
+    uint8_t rqAddr;
+
+    mchSetSizeOffs(mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr);
+
+    if ((rval = ipmiMsgGetSensorThresholds(mchData->mchSess, mchData->ipmiSess, response, bridged, rsAddr, rqAddr, sens,
+                                           lun, &responseSize, roffs))) {
+        goto bail;
+    }
+
+    if ((rval = mchMsgCheckSizes(sizeof(response), roffs, payloadSize))) {
+        printf("mchMsgGetSensorThresholds size error\n");
+        goto bail;
+    }
+
+    memcpy(data, response + roffs, payloadSize);
+
+bail:
+    return rval;
+}
+
+int mchMsgGetSensorThresholdsWrapper(MchData mchData, uint8_t* data, Sensor sens) {
+
+    int     bridged = 0;
+    uint8_t rsAddr  = sens->sdr.owner;
+
+    if (rsAddr != IPMI_MSG_ADDR_BMC) {
+        bridged = 1;
+    }
+    return mchMsgGetSensorThresholds(mchData, data, sens->sdr.number, (sens->sdr.lun & 0x3), bridged, rsAddr);
+}

--- a/src/drvMchMsg.h
+++ b/src/drvMchMsg.h
@@ -1,10 +1,10 @@
 //////////////////////////////////////////////////////////////////////////////
 // This file is part of 'ipmiComm'.
-// It is subject to the license terms in the LICENSE.txt file found in the 
-// top-level directory of this distribution and at: 
-//    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
-// No part of 'ipmiComm', including this file, 
-// may be copied, modified, propagated, or distributed except according to 
+// It is subject to the license terms in the LICENSE.txt file found in the
+// top-level directory of this distribution and at:
+//    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+// No part of 'ipmiComm', including this file,
+// may be copied, modified, propagated, or distributed except according to
 // the terms contained in the LICENSE.txt file.
 //////////////////////////////////////////////////////////////////////////////
 #ifndef DRV_MCH_MSG_H
@@ -13,48 +13,53 @@
 #include <ipmiDef.h>
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-/* IMPORTANT: For all routines below, caller must perform locking */
+    /* IMPORTANT: For all routines below, caller must perform locking */
 
-void mchSetSizeOffs(IpmiSess ipmiSess, size_t payloadSize, size_t *roffs, size_t *responseSize, int *bridged, uint8_t *rsAddr, uint8_t *rqAddr);
+    void mchSetSizeOffs(IpmiSess ipmiSess, size_t payloadSize, size_t* roffs, size_t* responseSize, int* bridged,
+                        uint8_t* rsAddr, uint8_t* rqAddr);
 
-int mchMsgCheckSizes(size_t destSize, int offset, size_t srcSize);
+    int mchMsgCheckSizes(size_t destSize, int offset, size_t srcSize);
 
-int mchMsgGetChanAuth(MchSess mchSess, IpmiSess ipmiSess, uint8_t *response);
+    int mchMsgGetChanAuth(MchSess mchSess, IpmiSess ipmiSess, uint8_t* response);
 
-int mchMsgGetSess(MchSess mchSess, IpmiSess ipmiSess, uint8_t *response);
+    int mchMsgGetSess(MchSess mchSess, IpmiSess ipmiSess, uint8_t* response);
 
-int mchMsgActSess(MchSess mchSess, IpmiSess ipmiSess, uint8_t *response);
+    int mchMsgActSess(MchSess mchSess, IpmiSess ipmiSess, uint8_t* response);
 
-int mchMsgSetPriv(MchSess mchSess, IpmiSess ipmiSess, uint8_t *response, uint8_t level);
+    int mchMsgSetPriv(MchSess mchSess, IpmiSess ipmiSess, uint8_t* response, uint8_t level);
 
-int mchMsgWriteReadHelper(MchSess mchSess, IpmiSess ipmiSess, uint8_t *message, size_t messageSize, uint8_t *response, size_t *responseSize, uint8_t cmd, uint8_t netfn, int codeOffs, int outSess);
+    int mchMsgWriteReadHelper(MchSess mchSess, IpmiSess ipmiSess, uint8_t* message, size_t messageSize,
+                              uint8_t* response, size_t* responseSize, uint8_t cmd, uint8_t netfn, int codeOffs,
+                              int outSess);
 
-int mchMsgCloseSess(MchSess mchSess, IpmiSess ipmiSess, uint8_t *data);
+    int mchMsgCloseSess(MchSess mchSess, IpmiSess ipmiSess, uint8_t* data);
 
-int mchMsgChassisControl(MchData mchData, uint8_t *data, uint8_t parm);
+    int mchMsgChassisControl(MchData mchData, uint8_t* data, uint8_t parm);
 
-int mchMsgGetChassisStatus(MchData mchData, uint8_t *data);
+    int mchMsgGetChassisStatus(MchData mchData, uint8_t* data);
 
-int mchMsgGetFruInvInfoWrapper(MchData mchData, uint8_t *data, Fru fru);
+    int mchMsgGetFruInvInfoWrapper(MchData mchData, uint8_t* data, Fru fru);
 
-int mchMsgReadFruWrapper(MchData mchData, uint8_t *data, Fru fru, uint8_t *readOffset, uint8_t readSize);
+    int mchMsgReadFruWrapper(MchData mchData, uint8_t* data, Fru fru, uint8_t* readOffset, uint8_t readSize);
 
-int mchMsgGetSdrRepInfoWrapper(MchData mchData, uint8_t *data, uint8_t parm, uint8_t addr);
+    int mchMsgGetSdrRepInfoWrapper(MchData mchData, uint8_t* data, uint8_t parm, uint8_t addr);
 
-int mchMsgReserveSdrRepWrapper(MchData mchData, uint8_t *data, uint8_t parm, uint8_t addr);
+    int mchMsgReserveSdrRepWrapper(MchData mchData, uint8_t* data, uint8_t parm, uint8_t addr);
 
-int mchMsgGetSdrWrapper(MchData mchData, uint8_t *data,  uint8_t *id, uint8_t *res, uint8_t offset, uint8_t readSize, uint8_t parm, uint8_t rsAddr);
+    int mchMsgGetSdrWrapper(MchData mchData, uint8_t* data, uint8_t* id, uint8_t* res, uint8_t offset, uint8_t readSize,
+                            uint8_t parm, uint8_t rsAddr);
 
-//int mchMsgGetDevSdrInfo(MchData mchData, uint8_t *data, int bridged, uint8_t rsAddr, uint8_t parm);
-				
-int mchMsgReadSensorWrapper(MchData mchData, uint8_t *data, Sensor sens, size_t *sensReadMsgSize);
+    // int mchMsgGetDevSdrInfo(MchData mchData, uint8_t *data, int bridged, uint8_t rsAddr, uint8_t parm);
 
-int mchMsgGetSensorThresholdsWrapper(MchData mchData, uint8_t *data, Sensor sens);
+    int mchMsgReadSensorWrapper(MchData mchData, uint8_t* data, Sensor sens, size_t* sensReadMsgSize);
 
-int mchMsgGetDeviceIdWrapper(MchData mchData, uint8_t *data, uint8_t rsAddr);
+    int mchMsgGetSensorThresholdsWrapper(MchData mchData, uint8_t* data, Sensor sens);
+
+    int mchMsgGetDeviceIdWrapper(MchData mchData, uint8_t* data, uint8_t rsAddr);
 
 #ifdef __cplusplus
 };

--- a/src/drvMchPicmg.c
+++ b/src/drvMchPicmg.c
@@ -1,17 +1,17 @@
 //////////////////////////////////////////////////////////////////////////////
 // This file is part of 'ipmiComm'.
-// It is subject to the license terms in the LICENSE.txt file found in the 
-// top-level directory of this distribution and at: 
-//    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
-// No part of 'ipmiComm', including this file, 
-// may be copied, modified, propagated, or distributed except according to 
+// It is subject to the license terms in the LICENSE.txt file found in the
+// top-level directory of this distribution and at:
+//    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+// No part of 'ipmiComm', including this file,
+// may be copied, modified, propagated, or distributed except according to
 // the terms contained in the LICENSE.txt file.
 //////////////////////////////////////////////////////////////////////////////
 #include <stdint.h>
-#include <stdio.h>   /* fopen, etc. */
+#include <stdio.h> /* fopen, etc. */
 #include <string.h>
-#include <math.h>    /* floor, pow */
-#include <ctype.h>   /* toupper */
+#include <math.h>  /* floor, pow */
+#include <ctype.h> /* toupper */
 
 #include <errlog.h>
 #include <epicsExport.h>
@@ -31,7 +31,7 @@
 static int MAX_MGMT_ATCA = 15;
 static int MAX_FRU_ATCA  = 25;
 
-/* Get Address Info - this is version that attempts to get physical location 
+/* Get Address Info - this is version that attempts to get physical location
  *                    information for a specific device using IPMB-0 address
  *
  *
@@ -39,32 +39,31 @@ static int MAX_FRU_ATCA  = 25;
  *            0 on success
  *            non-zero for error
  */
-int
-mchMsgGetAddressInfoIpmb0(MchData mchData, uint8_t *data, uint8_t fruId, uint8_t key)
-{
-uint8_t  response[MSG_MAX_LENGTH] = { 0 }; 
-size_t   roffs, responseSize = 0, payloadSize = PICMG_RPLY_GET_ADDR_INFO_LENGTH;
-int      rval, bridged = 0;
-uint8_t  rsAddr = IPMI_MSG_ADDR_BMC, rqAddr;
+int mchMsgGetAddressInfoIpmb0(MchData mchData, uint8_t* data, uint8_t fruId, uint8_t key) {
+    uint8_t response[MSG_MAX_LENGTH] = {0};
+    size_t  roffs, responseSize = 0, payloadSize = PICMG_RPLY_GET_ADDR_INFO_LENGTH;
+    int     rval, bridged = 0;
+    uint8_t rsAddr = IPMI_MSG_ADDR_BMC, rqAddr;
 
-	mchSetSizeOffs( mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr );
+    mchSetSizeOffs(mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr);
 
-	if ( (rval = ipmiMsgGetAddressInfoIpmb0( mchData->mchSess, mchData->ipmiSess, response, bridged, rsAddr, rqAddr, &responseSize, roffs, 
-						     fruId, key)) )
-		goto bail;
+    if ((rval = ipmiMsgGetAddressInfoIpmb0(mchData->mchSess, mchData->ipmiSess, response, bridged, rsAddr, rqAddr,
+                                           &responseSize, roffs, fruId, key))) {
+        goto bail;
+    }
 
-	if ( (rval = mchMsgCheckSizes( sizeof( response ), roffs, payloadSize )) ) {
-		printf("mchMsgGetAddressInfoIpmb0 size error\n");
-		goto bail;
-	}
+    if ((rval = mchMsgCheckSizes(sizeof(response), roffs, payloadSize))) {
+        printf("mchMsgGetAddressInfoIpmb0 size error\n");
+        goto bail;
+    }
 
-	memcpy( data, response + roffs, payloadSize );
+    memcpy(data, response + roffs, payloadSize);
 
 bail:
-	return rval;
+    return rval;
 }
 
-/* Get Address Info - this is version that attempts to get physical location 
+/* Get Address Info - this is version that attempts to get physical location
  *                    information for a specific device
  * needs updating
  *
@@ -72,29 +71,29 @@ bail:
  *            0 on success
  *            non-zero for error
  */
-int
-mchMsgGetAddressInfoHwAddr(MchData mchData, uint8_t *data, uint8_t fru, uint8_t keytype, uint8_t key, uint8_t sitetype)
-{
-uint8_t  response[MSG_MAX_LENGTH] = { 0 }; 
-size_t   roffs, responseSize = 0, payloadSize = PICMG_RPLY_GET_ADDR_INFO_LENGTH;
-int      rval, bridged = 0;
-uint8_t  rsAddr = IPMI_MSG_ADDR_BMC, rqAddr;
+int mchMsgGetAddressInfoHwAddr(MchData mchData, uint8_t* data, uint8_t fru, uint8_t keytype, uint8_t key,
+                               uint8_t sitetype) {
+    uint8_t response[MSG_MAX_LENGTH] = {0};
+    size_t  roffs, responseSize = 0, payloadSize = PICMG_RPLY_GET_ADDR_INFO_LENGTH;
+    int     rval, bridged = 0;
+    uint8_t rsAddr = IPMI_MSG_ADDR_BMC, rqAddr;
 
-	mchSetSizeOffs( mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr );
+    mchSetSizeOffs(mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr);
 
-	if ( (rval = ipmiMsgGetAddressInfoHwAddr( mchData->mchSess, mchData->ipmiSess, response, bridged, rsAddr, rqAddr, &responseSize, roffs, 
-						     fru, keytype, key, sitetype )) )
-		goto bail;
+    if ((rval = ipmiMsgGetAddressInfoHwAddr(mchData->mchSess, mchData->ipmiSess, response, bridged, rsAddr, rqAddr,
+                                            &responseSize, roffs, fru, keytype, key, sitetype))) {
+        goto bail;
+    }
 
-	if ( (rval = mchMsgCheckSizes( sizeof( response ), roffs, payloadSize )) ) {
-		printf("mchMsgGetAddressInfoHwAddr size error\n");
-		goto bail;
-	}
+    if ((rval = mchMsgCheckSizes(sizeof(response), roffs, payloadSize))) {
+        printf("mchMsgGetAddressInfoHwAddr size error\n");
+        goto bail;
+    }
 
-	memcpy( data, response + roffs, payloadSize );
+    memcpy(data, response + roffs, payloadSize);
 
 bail:
-	return rval;
+    return rval;
 }
 
 /* Get Address Info - this is version that does not seek information
@@ -106,113 +105,110 @@ bail:
  *            0 on success
  *            non-zero for error
  */
-int
-mchMsgGetAddressInfoIpmc(MchData mchData, uint8_t *data)
-{
-uint8_t  response[MSG_MAX_LENGTH] = { 0 }; 
-size_t   roffs, responseSize = 0, payloadSize = IPMI_RPLY_IMSG2_GET_PICMG_PROP_LENGTH; 
-int      rval, bridged = 0;
-uint8_t  rsAddr = IPMI_MSG_ADDR_BMC, rqAddr;
+int mchMsgGetAddressInfoIpmc(MchData mchData, uint8_t* data) {
+    uint8_t response[MSG_MAX_LENGTH] = {0};
+    size_t  roffs, responseSize = 0, payloadSize = IPMI_RPLY_IMSG2_GET_PICMG_PROP_LENGTH;
+    int     rval, bridged = 0;
+    uint8_t rsAddr = IPMI_MSG_ADDR_BMC, rqAddr;
 
-	mchSetSizeOffs( mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr );
+    mchSetSizeOffs(mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr);
 
-	if ( (rval = ipmiMsgGetAddressInfoIpmc( mchData->mchSess, mchData->ipmiSess, response, bridged, rsAddr, rqAddr, &responseSize, roffs )) )
-		goto bail;
+    if ((rval = ipmiMsgGetAddressInfoIpmc(mchData->mchSess, mchData->ipmiSess, response, bridged, rsAddr, rqAddr,
+                                          &responseSize, roffs))) {
+        goto bail;
+    }
 
-	if ( (rval = mchMsgCheckSizes( sizeof( response ), roffs, payloadSize )) ) {
-		printf("mchMsgGetAddressInfoIpmc size error\n");
-		goto bail;
-	}
+    if ((rval = mchMsgCheckSizes(sizeof(response), roffs, payloadSize))) {
+        printf("mchMsgGetAddressInfoIpmc size error\n");
+        goto bail;
+    }
 
-	memcpy( data, response + roffs, payloadSize );
+    memcpy(data, response + roffs, payloadSize);
 
 bail:
-	return rval;
+    return rval;
 }
 
-static void
-mchPicmgFruGetFbAddressInfo(MchData mchData)
-{
-MchSys  mchSys  = mchData->mchSys;
-uint8_t response[MSG_MAX_LENGTH] = { 0 };
-uint8_t i;
-Fru fru;
-int dbg = MCH_DBG( mchStat[mchData->mchSess->instance] );
+static void mchPicmgFruGetFbAddressInfo(MchData mchData) {
+    MchSys  mchSys                   = mchData->mchSys;
+    uint8_t response[MSG_MAX_LENGTH] = {0};
+    uint8_t i;
+    Fru     fru;
+    int     dbg = MCH_DBG(mchStat[mchData->mchSess->instance]);
 
-	for ( i = 0; i < mchSys->fruCount; i++ ) {
+    for (i = 0; i < mchSys->fruCount; i++) {
 
-      		fru = &mchSys->fru[i];
+        fru = &mchSys->fru[i];
 
-		/* move this to data reset routine for pre-config reset: */
-		fru->siteNumber = -1; fru->siteType = -1;
+        /* move this to data reset routine for pre-config reset: */
+        fru->siteNumber = -1;
+        fru->siteType   = -1;
 
-		if ( fru->sdr.entityId == ENTITY_ID_PICMG_FRONT_BOARD || 
-		     fru->sdr.entityId == ENTITY_ID_COOLING_UNIT ) {
+        if (fru->sdr.entityId == ENTITY_ID_PICMG_FRONT_BOARD || fru->sdr.entityId == ENTITY_ID_COOLING_UNIT) {
 
-			if ( dbg >= MCH_DBG_MED )
-				printf("mchPicmgFruGetFbAddressInfo: Found FB or CU FRU index %i addr 0x%02x\n", i, fru->sdr.addr);
+            if (dbg >= MCH_DBG_MED) {
+                printf("mchPicmgFruGetFbAddressInfo: Found FB or CU FRU index %i addr 0x%02x\n", i, fru->sdr.addr);
+            }
 
-			if ( mchMsgGetAddressInfoIpmb0( mchData, response, 0, fru->sdr.addr ) )
-				continue;
+            if (mchMsgGetAddressInfoIpmb0(mchData, response, 0, fru->sdr.addr)) {
+                continue;
+            }
 
-			fru->siteNumber = response[PICMG_RPLY_IMSG2_GET_ADDR_INFO_SITE_NUMBER_OFFSET];
-			fru->siteType   = response[PICMG_RPLY_IMSG2_GET_ADDR_INFO_SITE_TYPE_OFFSET];
+            fru->siteNumber = response[PICMG_RPLY_IMSG2_GET_ADDR_INFO_SITE_NUMBER_OFFSET];
+            fru->siteType   = response[PICMG_RPLY_IMSG2_GET_ADDR_INFO_SITE_TYPE_OFFSET];
 
-			if ( dbg >= MCH_DBG_MED ) {
-				printf("mchPicmgFruGetFbAddressInfo: Got FRU %i entityId 0x%02x entityInst 0x%02x "
-				    "addr 0x%02x phys loc info sitenumber %i, sitetype 0x%02x\n", 
-					i, fru->sdr.entityId, fru->sdr.entityInst, fru->sdr.addr, fru->siteNumber, fru->siteType );
-			}
-		}
-	}
+            if (dbg >= MCH_DBG_MED) {
+                printf("mchPicmgFruGetFbAddressInfo: Got FRU %i entityId 0x%02x entityInst 0x%02x "
+                       "addr 0x%02x phys loc info sitenumber %i, sitetype 0x%02x\n",
+                       i, fru->sdr.entityId, fru->sdr.entityInst, fru->sdr.addr, fru->siteNumber, fru->siteType);
+            }
+        }
+    }
 }
 
-static void
-mchPicmgFruGetRtmAddressInfo(MchData mchData)
-{
-MchSys  mchSys  = mchData->mchSys;
-Fru fru, fruFb;
-int i, j;
-int dbg = MCH_DBG( mchStat[mchData->mchSess->instance] );
+static void mchPicmgFruGetRtmAddressInfo(MchData mchData) {
+    MchSys mchSys = mchData->mchSys;
+    Fru    fru, fruFb;
+    int    i, j;
+    int    dbg = MCH_DBG(mchStat[mchData->mchSess->instance]);
 
-	for ( i = 0; i < mchSys->fruCount; i++ ) {
+    for (i = 0; i < mchSys->fruCount; i++) {
 
-      		fru = &mchSys->fru[i];
+        fru = &mchSys->fru[i];
 
-		if ( fru->sdr.entityId == ENTITY_ID_PICMG_RTM ) {
+        if (fru->sdr.entityId == ENTITY_ID_PICMG_RTM) {
 
-			for ( j = 0; j < mchSys->fruCount; j++ ) {
+            for (j = 0; j < mchSys->fruCount; j++) {
 
-				fruFb = &mchSys->fru[j];
-				if ( (fru->sdr.addr == fruFb->sdr.addr) && (fru->sdr.chan == fruFb->sdr.chan) && 
-				    ( fruFb->sdr.entityId == ENTITY_ID_PICMG_FRONT_BOARD) ) {
-					fru->siteNumber = fruFb->siteNumber;
-					fru->siteType   = PICMG_SITE_TYPE_RTM;
+                fruFb = &mchSys->fru[j];
+                if ((fru->sdr.addr == fruFb->sdr.addr) && (fru->sdr.chan == fruFb->sdr.chan) &&
+                    (fruFb->sdr.entityId == ENTITY_ID_PICMG_FRONT_BOARD)) {
+                    fru->siteNumber = fruFb->siteNumber;
+                    fru->siteType   = PICMG_SITE_TYPE_RTM;
 
-					if ( dbg >= MCH_DBG_MED ) {
-						printf("mchPicmgFruGetRtmAddressInfo: Matched RTM FRU %i to "
-						    "FB FRU %i siteNumber %i siteType %i\n", i, j , fru->siteNumber, fru->siteType);
-					}
-					break;
-				}
-			}
-		}
-	}
+                    if (dbg >= MCH_DBG_MED) {
+                        printf("mchPicmgFruGetRtmAddressInfo: Matched RTM FRU %i to "
+                               "FB FRU %i siteNumber %i siteType %i\n",
+                               i, j, fru->siteNumber, fru->siteType);
+                    }
+                    break;
+                }
+            }
+        }
+    }
 }
 
-static void
-assign_sys_sizes_atca(MchData mchData)
-{
-	mchData->mchSys->fruCountMax  = MAX_FRU_ATCA;
-	mchData->mchSys->mgmtCountMax = MAX_MGMT_ATCA;
+static void assign_sys_sizes_atca(MchData mchData) {
+    mchData->mchSys->fruCountMax  = MAX_FRU_ATCA;
+    mchData->mchSys->mgmtCountMax = MAX_MGMT_ATCA;
 }
 
-/* 
+/*
  * For ATCA systems:
  *   -For Front Board FRUs (use entityId to determine),
  *    use HWADDR and FRU 'ID' of 0 to query site number/type
  *    This 'ID' is actually just the order of FRUs associated with
- *    this device. So the 'first' FRU is always 
+ *    this device. So the 'first' FRU is always
  *    addressed by 0 in this message
  *
  *   -For RTMs, can infer the slot number from matching it
@@ -225,263 +221,254 @@ assign_sys_sizes_atca(MchData mchData)
  * then we don't have to catalog the different sub-FRU device info
  *
  */
-static void
-assign_site_info_atca(MchData mchData) 
-{
-	
-	mchPicmgFruGetFbAddressInfo(  mchData );
-	mchPicmgFruGetRtmAddressInfo( mchData );
+static void assign_site_info_atca(MchData mchData) {
+
+    mchPicmgFruGetFbAddressInfo(mchData);
+    mchPicmgFruGetRtmAddressInfo(mchData);
 }
 
-static void
-assign_fru_lkup_atca(MchData mchData) 
-{
-MchSys  mchSys  = mchData->mchSys;
-uint8_t i;
-Fru fru;
-int cuCnt = 0, shfCnt = 0, pmCnt = 0, shmCnt = 0;
-int dbg = MCH_DBG( mchStat[mchData->mchSess->instance] );
+static void assign_fru_lkup_atca(MchData mchData) {
+    MchSys  mchSys = mchData->mchSys;
+    uint8_t i;
+    Fru     fru;
+    int     cuCnt = 0, shfCnt = 0, pmCnt = 0, shmCnt = 0;
+    int     dbg = MCH_DBG(mchStat[mchData->mchSess->instance]);
 
-	for ( i = 0; i < mchSys->fruCount; i++ ) {
+    for (i = 0; i < mchSys->fruCount; i++) {
 
-      		fru = &mchSys->fru[i];
+        fru = &mchSys->fru[i];
 
-		if ( fru->siteType == PICMG_SITE_TYPE_FRONT_BOARD ) {
-			fru->id = UTCA_FRU_TYPE_AMC_MIN + fru->siteNumber - 1;
-			mchSys->fruLkup[fru->id] = i;
-			if ( dbg >= MCH_DBG_MED ) {
-				printf("assign_fru_lkup_atca: Found front board, "
-				    "index in FRU array %i, index in lkup array (aka id) %i\n", 
-				    i,fru->id); 
-			}
-		}
-		else if ( fru->siteType == PICMG_SITE_TYPE_RTM ) {
-			fru->id = UTCA_FRU_TYPE_RTM_MIN + fru->siteNumber - 1;
-			mchSys->fruLkup[fru->id] = i;
-			if ( dbg >= MCH_DBG_MED ) {
-				printf("assign_fru_lkup_atca: Found RTM, index in FRU array %i, "
-				    "index in lkup array (aka id) %i\n", 
-				    i, fru->id);
-			}
-		}
-		else if ( fru->sdr.entityId == ENTITY_ID_PICMG_SHMC ) {
-			if ( (PICMG_FRU_TYPE_SHMC_MIN + shmCnt) > PICMG_FRU_TYPE_SHMC_MAX )
-				continue;
-			fru->id = PICMG_FRU_TYPE_SHMC_MAX - shmCnt;
-			mchSys->fruLkup[fru->id] = i;
-			if ( dbg >= MCH_DBG_MED ) {
-				printf("assign_fru_lkup_atca: Found SHMC, index in FRU array %i, "
-				    "index in lkup array (aka id) %i\n", 
-				    i, fru->id); 
-			}
-			shmCnt++;
-		}
-		else if ( fru->sdr.entityId == ENTITY_ID_PICMG_SHELF_FRU_INFO ) {
-			if ( (UTCA_FRU_TYPE_SHELF_MIN + shfCnt) > UTCA_FRU_TYPE_SHELF_MAX )
-				continue;
-			fru->id = UTCA_FRU_TYPE_SHELF_MIN + shfCnt;
-			mchSys->fruLkup[fru->id] = i;
-			if ( dbg >= MCH_DBG_MED ) {
-				printf("assign_fru_lkup_atca: Found shelf fru info, "
-				    "fru index %i, index in lkup array (aka id) %i\n", 
-				    i,fru->id); 
-			}
-			shfCnt++;
-		}
-		else if ( fru->sdr.entityId == ENTITY_ID_COOLING_UNIT) {
-			fru->id = UTCA_FRU_TYPE_CU_MIN + cuCnt;
-			mchSys->fruLkup[fru->id] = i;
-			cuCnt++;
-			if ( dbg >= MCH_DBG_MED ) {
-				printf("assign_fru_lkup_atca: Found CU, index in FRU array %i, "
-				    "index in lkup array (aka id) %i\n", 
-				    i, fru->id);
-			}
-		}
-		else if ( fru->sdr.entityId == ENTITY_ID_POWER_MODULE ) {
-			if ( (UTCA_FRU_TYPE_PM_MIN + pmCnt) > UTCA_FRU_TYPE_PM_MAX )
-				continue;
-			fru->id = UTCA_FRU_TYPE_PM_MIN + pmCnt;
-			mchSys->fruLkup[fru->id] = i;
-			pmCnt++;
-			if ( dbg >= MCH_DBG_MED ) {
-				printf("assign_fru_lkup_atca: Found PM, index in FRU array %i, "
-				    "index in lkup array (aka id) %i\n", 
-				    i, fru->id);
-			}
-		}
-	}
+        if (fru->siteType == PICMG_SITE_TYPE_FRONT_BOARD) {
+            fru->id                  = UTCA_FRU_TYPE_AMC_MIN + fru->siteNumber - 1;
+            mchSys->fruLkup[fru->id] = i;
+            if (dbg >= MCH_DBG_MED) {
+                printf("assign_fru_lkup_atca: Found front board, "
+                       "index in FRU array %i, index in lkup array (aka id) %i\n",
+                       i, fru->id);
+            }
+        } else if (fru->siteType == PICMG_SITE_TYPE_RTM) {
+            fru->id                  = UTCA_FRU_TYPE_RTM_MIN + fru->siteNumber - 1;
+            mchSys->fruLkup[fru->id] = i;
+            if (dbg >= MCH_DBG_MED) {
+                printf("assign_fru_lkup_atca: Found RTM, index in FRU array %i, "
+                       "index in lkup array (aka id) %i\n",
+                       i, fru->id);
+            }
+        } else if (fru->sdr.entityId == ENTITY_ID_PICMG_SHMC) {
+            if ((PICMG_FRU_TYPE_SHMC_MIN + shmCnt) > PICMG_FRU_TYPE_SHMC_MAX) {
+                continue;
+            }
+            fru->id                  = PICMG_FRU_TYPE_SHMC_MAX - shmCnt;
+            mchSys->fruLkup[fru->id] = i;
+            if (dbg >= MCH_DBG_MED) {
+                printf("assign_fru_lkup_atca: Found SHMC, index in FRU array %i, "
+                       "index in lkup array (aka id) %i\n",
+                       i, fru->id);
+            }
+            shmCnt++;
+        } else if (fru->sdr.entityId == ENTITY_ID_PICMG_SHELF_FRU_INFO) {
+            if ((UTCA_FRU_TYPE_SHELF_MIN + shfCnt) > UTCA_FRU_TYPE_SHELF_MAX) {
+                continue;
+            }
+            fru->id                  = UTCA_FRU_TYPE_SHELF_MIN + shfCnt;
+            mchSys->fruLkup[fru->id] = i;
+            if (dbg >= MCH_DBG_MED) {
+                printf("assign_fru_lkup_atca: Found shelf fru info, "
+                       "fru index %i, index in lkup array (aka id) %i\n",
+                       i, fru->id);
+            }
+            shfCnt++;
+        } else if (fru->sdr.entityId == ENTITY_ID_COOLING_UNIT) {
+            fru->id                  = UTCA_FRU_TYPE_CU_MIN + cuCnt;
+            mchSys->fruLkup[fru->id] = i;
+            cuCnt++;
+            if (dbg >= MCH_DBG_MED) {
+                printf("assign_fru_lkup_atca: Found CU, index in FRU array %i, "
+                       "index in lkup array (aka id) %i\n",
+                       i, fru->id);
+            }
+        } else if (fru->sdr.entityId == ENTITY_ID_POWER_MODULE) {
+            if ((UTCA_FRU_TYPE_PM_MIN + pmCnt) > UTCA_FRU_TYPE_PM_MAX) {
+                continue;
+            }
+            fru->id                  = UTCA_FRU_TYPE_PM_MIN + pmCnt;
+            mchSys->fruLkup[fru->id] = i;
+            pmCnt++;
+            if (dbg >= MCH_DBG_MED) {
+                printf("assign_fru_lkup_atca: Found PM, index in FRU array %i, "
+                       "index in lkup array (aka id) %i\n",
+                       i, fru->id);
+            }
+        }
+    }
 }
 
 /* MicroTCA uses pre-defined unique FRU IDs
  * Assign FRU lookup ID to these same values
  */
-static void
-assign_fru_lkup_microtca(MchData mchData) 
-{
-int i;
-MchSys mchSys = mchData->mchSys;
-Fru    fru;
+static void assign_fru_lkup_microtca(MchData mchData) {
+    int    i;
+    MchSys mchSys = mchData->mchSys;
+    Fru    fru;
 
-	for ( i = 0; i < mchSys->fruCount ; i++ ) {
+    for (i = 0; i < mchSys->fruCount; i++) {
 
-	       	fru = &mchSys->fru[i];
+        fru = &mchSys->fru[i];
 
-		if ( fru->sdr.recType ) { /* If real entity */
+        if (fru->sdr.recType) { /* If real entity */
 
-			fru->id = fru->sdr.fruId;
-			mchSys->fruLkup[fru->id] = i;
-		}
-	}
+            fru->id                  = fru->sdr.fruId;
+            mchSys->fruLkup[fru->id] = i;
+        }
+    }
 }
 
-int
-fru_data_suppl_picmg(MchData mchData, int index)
-{
-int id, rval = 0;
-uint8_t response[MSG_MAX_LENGTH] = { 0 };
-Fru fru;
-int dbg = MCH_DBG( mchStat[mchData->mchSess->instance] );
+int fru_data_suppl_picmg(MchData mchData, int index) {
+    int     id, rval = 0;
+    uint8_t response[MSG_MAX_LENGTH] = {0};
+    Fru     fru;
+    int     dbg = MCH_DBG(mchStat[mchData->mchSess->instance]);
 
-       	fru = &mchData->mchSys->fru[index];
-	id = fru->id;
+    fru = &mchData->mchSys->fru[index];
+    id  = fru->id;
 
-	if ( -1 == (index = mchData->mchSys->fruLkup[id]) ) /* Was not assigned FRU-lookup ID */
-		return rval;
+    if (-1 == (index = mchData->mchSys->fruLkup[id])) { /* Was not assigned FRU-lookup ID */
+        return rval;
+    }
 
-	if ( (id >= UTCA_FRU_TYPE_CU_MIN) && (id <= UTCA_FRU_TYPE_CU_MAX) ) {
+    if ((id >= UTCA_FRU_TYPE_CU_MIN) && (id <= UTCA_FRU_TYPE_CU_MAX)) {
 
-		if ( mchData->mchSys->mchcb->get_fan_prop ) {
-			if ( mchData->mchSys->mchcb->get_fan_prop( mchData, response, index ) ) {
-				/* For now, set fan properties to all zeros to indicate not read */
-				fru->fanMin = fru->fanMax = fru->fanNom = fru->fanProp = 0;
-				rval = -1;
-			}
-		}		
-		else
-			return rval;
+        if (mchData->mchSys->mchcb->get_fan_prop) {
+            if (mchData->mchSys->mchcb->get_fan_prop(mchData, response, index)) {
+                /* For now, set fan properties to all zeros to indicate not read */
+                fru->fanMin = fru->fanMax = fru->fanNom = fru->fanProp = 0;
+                rval                                                   = -1;
+            }
+        } else {
+            return rval;
+        }
 
-		fru->fanMin  = response[IPMI_RPLY_IMSG2_GET_FAN_PROP_MIN_OFFSET];
-		fru->fanMax  = response[IPMI_RPLY_IMSG2_GET_FAN_PROP_MAX_OFFSET];
-		fru->fanNom  = response[IPMI_RPLY_IMSG2_GET_FAN_PROP_NOM_OFFSET];
-		fru->fanProp = response[IPMI_RPLY_IMSG2_GET_FAN_PROP_PROP_OFFSET];
+        fru->fanMin  = response[IPMI_RPLY_IMSG2_GET_FAN_PROP_MIN_OFFSET];
+        fru->fanMax  = response[IPMI_RPLY_IMSG2_GET_FAN_PROP_MAX_OFFSET];
+        fru->fanNom  = response[IPMI_RPLY_IMSG2_GET_FAN_PROP_NOM_OFFSET];
+        fru->fanProp = response[IPMI_RPLY_IMSG2_GET_FAN_PROP_PROP_OFFSET];
 
-		if ( dbg >= MCH_DBG_MED )
-			printf("fru_data_suppl_picmg: FRU index %i id %i fan properties "
-			    "min %i max %i nom %i prop 0x%02x\n", 
-			    index, id, fru->fanMin, fru->fanMax, fru->fanNom, fru->fanProp);
-	}
-	return rval;
+        if (dbg >= MCH_DBG_MED) {
+            printf("fru_data_suppl_picmg: FRU index %i id %i fan properties "
+                   "min %i max %i nom %i prop 0x%02x\n",
+                   index, id, fru->fanMin, fru->fanMax, fru->fanNom, fru->fanProp);
+        }
+    }
+    return rval;
 }
 
-static void
-sensor_get_fru_atca(MchData mchData, Sensor sens)
-{
-MchSys  mchSys = mchData->mchSys;
-Fru     fru;
-Mgmt    mgmt;
-int i, j;
+static void sensor_get_fru_atca(MchData mchData, Sensor sens) {
+    MchSys mchSys = mchData->mchSys;
+    Fru    fru;
+    Mgmt   mgmt;
+    int    i, j;
 
-	for ( i = 0; i < mchSys->fruCount; i++ ) {
-	
-		fru = &mchSys->fru[i];
-		if ( (sens->sdr.owner == fru->sdr.addr) && (sens->sdr.entityId == fru->sdr.entityId ) &&
-			(sens->sdr.entityInst == fru->sdr.entityInst ) ) {
-			sens->fruIndex = i; /* FRU index for associated FRU */
-			return;
-		}
-		for ( j = 0; j < fru->entityCount; j++ ) {
-			if ( (sens->sdr.owner == fru->entity[j].addr) && (sens->sdr.entityId == fru->entity[j].entityId ) &&
-				(sens->sdr.entityInst == fru->entity[j].entityInst ) ) {
-				sens->fruIndex = i; /* FRU index for associated FRU */
-				return;
-			}			
-		}
-/* If AMC entity & owner is same as existing front-board FRU, can associate sensor with that front board
- * In future, this may be sufficient information to create indepdendent AMC entities */
-		if ( (sens->sdr.entityId == ENTITY_ID_PICMG_AMC) && (fru->sdr.entityId == ENTITY_ID_PICMG_FRONT_BOARD) && (sens->sdr.owner == fru->sdr.addr) ) {
-			sens->fruIndex = i;
-			return;
-		}
-	}
+    for (i = 0; i < mchSys->fruCount; i++) {
 
-	for ( i = 0; i < mchSys->mgmtCount; i++ ) {
+        fru = &mchSys->fru[i];
+        if ((sens->sdr.owner == fru->sdr.addr) && (sens->sdr.entityId == fru->sdr.entityId) &&
+            (sens->sdr.entityInst == fru->sdr.entityInst)) {
+            sens->fruIndex = i; /* FRU index for associated FRU */
+            return;
+        }
+        for (j = 0; j < fru->entityCount; j++) {
+            if ((sens->sdr.owner == fru->entity[j].addr) && (sens->sdr.entityId == fru->entity[j].entityId) &&
+                (sens->sdr.entityInst == fru->entity[j].entityInst)) {
+                sens->fruIndex = i; /* FRU index for associated FRU */
+                return;
+            }
+        }
+        /* If AMC entity & owner is same as existing front-board FRU, can associate sensor with that front board
+         * In future, this may be sufficient information to create indepdendent AMC entities */
+        if ((sens->sdr.entityId == ENTITY_ID_PICMG_AMC) && (fru->sdr.entityId == ENTITY_ID_PICMG_FRONT_BOARD) &&
+            (sens->sdr.owner == fru->sdr.addr)) {
+            sens->fruIndex = i;
+            return;
+        }
+    }
 
-		mgmt = &mchSys->mgmt[i];
-		if ( (sens->sdr.owner == mchSys->mgmt[i].sdr.addr) ) {
-			sens->mgmtIndex = i;
-			return;
-		}
-		for ( j = 0; j < mgmt->entityCount; j++ ) {
-			if ( (sens->sdr.owner == mgmt->entity[j].addr) && (sens->sdr.entityId == mgmt->entity[j].entityId ) &&
-				(sens->sdr.entityInst == mgmt->entity[j].entityInst ) ) {
-				sens->mgmtIndex = i; /* MGMT ID for associated MGMT */
-				return;
-			}			
-		}
+    for (i = 0; i < mchSys->mgmtCount; i++) {
 
-	}		
+        mgmt = &mchSys->mgmt[i];
+        if ((sens->sdr.owner == mchSys->mgmt[i].sdr.addr)) {
+            sens->mgmtIndex = i;
+            return;
+        }
+        for (j = 0; j < mgmt->entityCount; j++) {
+            if ((sens->sdr.owner == mgmt->entity[j].addr) && (sens->sdr.entityId == mgmt->entity[j].entityId) &&
+                (sens->sdr.entityInst == mgmt->entity[j].entityInst)) {
+                sens->mgmtIndex = i; /* MGMT ID for associated MGMT */
+                return;
+            }
+        }
+    }
 
-	return; /* Did not find match */
+    return; /* Did not find match */
 }
 
-static void
-sensor_get_fru_microtca(MchData mchData, Sensor sens)
-{
-MchSys  mchSys = mchData->mchSys;
-SdrFull sdr = &sens->sdr;
-char buff[9];
-int i, natid, id;
+static void sensor_get_fru_microtca(MchData mchData, Sensor sens) {
+    MchSys  mchSys = mchData->mchSys;
+    SdrFull sdr    = &sens->sdr;
+    char    buff[9];
+    int     i, natid, id;
 
-	/* NAT associates hotswap aka M-state sensors with carrier manager but
-         * Vadatech associates them with the actual FRU described by the sensor.
-	 * For NAT, parse sensor description to get associated FRU number
-         */
-	if ( MCH_IS_NAT( mchData->mchSess->type ) && (sdr->sensType == SENSOR_TYPE_HOTSWAP) ) {
-		if ( 2 != sscanf( (const char *)(sdr->str), "HS %d %s", &natid, buff ) )
-			return;
-		sens->fruIndex = mchSys->fruLkup[natid];
-	}
+    /* NAT associates hotswap aka M-state sensors with carrier manager but
+     * Vadatech associates them with the actual FRU described by the sensor.
+     * For NAT, parse sensor description to get associated FRU number
+     */
+    if (MCH_IS_NAT(mchData->mchSess->type) && (sdr->sensType == SENSOR_TYPE_HOTSWAP)) {
+        if (2 != sscanf((const char*)(sdr->str), "HS %d %s", &natid, buff)) {
+            return;
+        }
+        sens->fruIndex = mchSys->fruLkup[natid];
+    }
 
-	/* Loop through FRUs and Management Controllers
-	 * Start at 1 for MicroTCA because FRU 0 is reserved logical 
-	 * entity with same entityId and entityInst as MCH 1 
-	 */
-	for ( i = 0; i < mchSys->fruCount; i++ ) {
+    /* Loop through FRUs and Management Controllers
+     * Start at 1 for MicroTCA because FRU 0 is reserved logical
+     * entity with same entityId and entityInst as MCH 1
+     */
+    for (i = 0; i < mchSys->fruCount; i++) {
 
-		if ( mchSys->fru[i].sdr.fruId == 0 ) { /* Does fruId need to be reset to 0 on each config ? */
-			continue;
-		}
-		if ( (sens->sdr.entityId == mchSys->fru[i].sdr.entityId) && (sens->sdr.entityInst == mchSys->fru[i].sdr.entityInst ) ) {
-			sens->fruIndex = i; /* FRU index for associated FRU */
-			return;
-		}
-	}
-	for ( i = 0; i < mchSys->mgmtCount; i++ ) {
-		if ( (sens->sdr.entityId == mchSys->mgmt[i].sdr.entityId) && (sens->sdr.entityInst == mchSys->mgmt[i].sdr.entityInst) ) {
-			sens->mgmtIndex = i;
-			return;
-		}
-	}
+        if (mchSys->fru[i].sdr.fruId == 0) { /* Does fruId need to be reset to 0 on each config ? */
+            continue;
+        }
+        if ((sens->sdr.entityId == mchSys->fru[i].sdr.entityId) &&
+            (sens->sdr.entityInst == mchSys->fru[i].sdr.entityInst)) {
+            sens->fruIndex = i; /* FRU index for associated FRU */
+            return;
+        }
+    }
+    for (i = 0; i < mchSys->mgmtCount; i++) {
+        if ((sens->sdr.entityId == mchSys->mgmt[i].sdr.entityId) &&
+            (sens->sdr.entityInst == mchSys->mgmt[i].sdr.entityInst)) {
+            sens->mgmtIndex = i;
+            return;
+        }
+    }
 
-	if ( MCH_IS_NAT( mchData->mchSess->type ) ) {
-		/* Find entities that do not have SDRs */
-		if ( sens->sdr.entityId == VT_ENTITY_ID_AMC ) {
-			id = UTCA_FRU_TYPE_AMC_MIN + sens->sdr.entityInst - 0x60 - 1;
-			sens->fruIndex = mchSys->fruLkup[id];
-			printf("sensor_get_fru_microtca: Found AMC that does not have SDR, fru id %i entity id 0x%02x entity inst 0x%02x\n", 
-			    id, sens->sdr.entityId, sens->sdr.entityInst);
-			return;
-		}
-		else if ( sens->sdr.entityId == VT_ENTITY_ID_RTM ) {
-			id = UTCA_FRU_TYPE_RTM_MIN + sens->sdr.entityInst - 0x60 - 1;
-			sens->fruIndex = mchSys->fruLkup[id];
-			printf("sensor_get_fru_microtca: Found RTM that does not have SDR, FRU ID %i\n", id);
-			return;
-		}
-	}
+    if (MCH_IS_NAT(mchData->mchSess->type)) {
+        /* Find entities that do not have SDRs */
+        if (sens->sdr.entityId == VT_ENTITY_ID_AMC) {
+            id             = UTCA_FRU_TYPE_AMC_MIN + sens->sdr.entityInst - 0x60 - 1;
+            sens->fruIndex = mchSys->fruLkup[id];
+            printf("sensor_get_fru_microtca: Found AMC that does not have SDR, fru id %i entity id 0x%02x entity inst "
+                   "0x%02x\n",
+                   id, sens->sdr.entityId, sens->sdr.entityInst);
+            return;
+        } else if (sens->sdr.entityId == VT_ENTITY_ID_RTM) {
+            id             = UTCA_FRU_TYPE_RTM_MIN + sens->sdr.entityInst - 0x60 - 1;
+            sens->fruIndex = mchSys->fruLkup[id];
+            printf("sensor_get_fru_microtca: Found RTM that does not have SDR, FRU ID %i\n", id);
+            return;
+        }
+    }
 
-	return; /* Did not find match */
+    return; /* Did not find match */
 }
 
 /* Get PICMG Properties - For ATCA (and MicroTCA?)
@@ -491,28 +478,28 @@ int i, natid, id;
  *            0 on success
  *            non-zero for error
  */
-int
-mchMsgGetPicmgProp(MchData mchData, uint8_t *data)
-{
-uint8_t  response[MSG_MAX_LENGTH] = { 0 }; 
-size_t   roffs, responseSize = 0, payloadSize = IPMI_RPLY_IMSG2_GET_PICMG_PROP_LENGTH; 
-int      rval, bridged = 0;
-uint8_t  rsAddr = IPMI_MSG_ADDR_BMC, rqAddr;
+int mchMsgGetPicmgProp(MchData mchData, uint8_t* data) {
+    uint8_t response[MSG_MAX_LENGTH] = {0};
+    size_t  roffs, responseSize = 0, payloadSize = IPMI_RPLY_IMSG2_GET_PICMG_PROP_LENGTH;
+    int     rval, bridged = 0;
+    uint8_t rsAddr = IPMI_MSG_ADDR_BMC, rqAddr;
 
-	mchSetSizeOffs( mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr );
+    mchSetSizeOffs(mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr);
 
-	if ( (rval = ipmiMsgGetPicmgProp( mchData->mchSess, mchData->ipmiSess, response, bridged, rsAddr, rqAddr, &responseSize, roffs )) )
-		goto bail;
+    if ((rval = ipmiMsgGetPicmgProp(mchData->mchSess, mchData->ipmiSess, response, bridged, rsAddr, rqAddr,
+                                    &responseSize, roffs))) {
+        goto bail;
+    }
 
-	if ( (rval = mchMsgCheckSizes( sizeof( response ), roffs, payloadSize )) ) {
-		printf("mchMsgGetPicmgProp size error\n");
-		goto bail;
-	}
+    if ((rval = mchMsgCheckSizes(sizeof(response), roffs, payloadSize))) {
+        printf("mchMsgGetPicmgProp size error\n");
+        goto bail;
+    }
 
-	memcpy( data, response + roffs, payloadSize );
+    memcpy(data, response + roffs, payloadSize);
 
 bail:
-	return rval;
+    return rval;
 }
 
 /* Set FRU Activation - For NAT MCH, used to deactivate/activate FRU
@@ -522,29 +509,28 @@ bail:
  *            0 on success
  *            non-zero for error
  */
-int
-mchMsgSetFruActNat(MchData mchData, uint8_t *data, uint8_t fruIndex, uint8_t parm)
-{
-uint8_t  message[MSG_MAX_LENGTH] = { 0 };
-size_t   imsg2Size    = sizeof( SET_FRU_ACT_MSG );
-uint8_t  imsg2[imsg2Size];
-size_t   messageSize;
-size_t   responseSize = 0;/*IPMI_RPLY_SET_FRU_ACT_LENGTH_NAT; - determine length */
-uint8_t  cmd   = IPMI_MSG_CMD_SET_FRU_ACT;
-uint8_t  netfn = IPMI_MSG_NETFN_PICMG;
-int      offs = 0; /* determine needed offset */
-uint8_t  fruId;
+int mchMsgSetFruActNat(MchData mchData, uint8_t* data, uint8_t fruIndex, uint8_t parm) {
+    uint8_t message[MSG_MAX_LENGTH] = {0};
+    size_t  imsg2Size               = sizeof(SET_FRU_ACT_MSG);
+    uint8_t imsg2[imsg2Size];
+    size_t  messageSize;
+    size_t  responseSize = 0; /*IPMI_RPLY_SET_FRU_ACT_LENGTH_NAT; - determine length */
+    uint8_t cmd          = IPMI_MSG_CMD_SET_FRU_ACT;
+    uint8_t netfn        = IPMI_MSG_NETFN_PICMG;
+    int     offs         = 0; /* determine needed offset */
+    uint8_t fruId;
 
-	memcpy( imsg2, SET_FRU_ACT_MSG, imsg2Size );
+    memcpy(imsg2, SET_FRU_ACT_MSG, imsg2Size);
 
-	fruId = mchData->mchSys->fru[fruIndex].sdr.fruId;
-	imsg2[IPMI_MSG2_RQADDR_OFFSET] = IPMI_MSG_ADDR_SW;
-	imsg2[IPMI_MSG2_SET_FRU_ACT_FRU_OFFSET] = fruId;
-	imsg2[IPMI_MSG2_SET_FRU_ACT_CMD_OFFSET] = parm;
+    fruId                                   = mchData->mchSys->fru[fruIndex].sdr.fruId;
+    imsg2[IPMI_MSG2_RQADDR_OFFSET]          = IPMI_MSG_ADDR_SW;
+    imsg2[IPMI_MSG2_SET_FRU_ACT_FRU_OFFSET] = fruId;
+    imsg2[IPMI_MSG2_SET_FRU_ACT_CMD_OFFSET] = parm;
 
-       	messageSize = ipmiMsgBuild( mchData->ipmiSess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0 );
+    messageSize = ipmiMsgBuild(mchData->ipmiSess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0);
 
-	return mchMsgWriteReadHelper( mchData->mchSess, mchData->ipmiSess, message, messageSize, data, &responseSize, cmd, netfn, offs/*need to set codeoffs*/, 0 );
+    return mchMsgWriteReadHelper(mchData->mchSess, mchData->ipmiSess, message, messageSize, data, &responseSize, cmd,
+                                 netfn, offs /*need to set codeoffs*/, 0);
 }
 
 /* Set FRU Activation Policy - For Vadatech MCH, used to deactivate/activate FRU
@@ -553,55 +539,54 @@ uint8_t  fruId;
  *
  * Activate version causes FRU to transition from "Inactive" to "Activation Request"
  * Deactivate version causes FRU to transition from "Active" to "Deactivation Request"
- * 
+ *
  *   RETURNS: status from mchMsgWriteReadHelper
  *            0 on success
  *            non-zero for error
  */
-int 
-mchMsgSetFruActPolicyVt(MchData mchData, uint8_t *data, uint8_t fruIndex, uint8_t parm)
-{
-uint8_t  message[MSG_MAX_LENGTH] = { 0 };
-size_t   imsg2Size   = sizeof( SEND_MSG_MSG );
-size_t   b1msg1Size   = sizeof( IPMI_MSG1 );
-size_t   b1msg2Size   = sizeof( SET_FRU_POLICY_MSG );
-uint8_t  imsg2[imsg2Size];
-uint8_t  b1msg1[b1msg1Size];
-uint8_t  b1msg2[b1msg2Size];
-size_t   messageSize;
-size_t   responseSize = IPMI_RPLY_SET_FRU_POLICY_LENGTH_VT;
-uint8_t  cmd   = IPMI_MSG_CMD_SET_FRU_POLICY;
-uint8_t  netfn = IPMI_MSG_NETFN_PICMG;
-uint8_t  fruId, mask, bits;
+int mchMsgSetFruActPolicyVt(MchData mchData, uint8_t* data, uint8_t fruIndex, uint8_t parm) {
+    uint8_t message[MSG_MAX_LENGTH] = {0};
+    size_t  imsg2Size               = sizeof(SEND_MSG_MSG);
+    size_t  b1msg1Size              = sizeof(IPMI_MSG1);
+    size_t  b1msg2Size              = sizeof(SET_FRU_POLICY_MSG);
+    uint8_t imsg2[imsg2Size];
+    uint8_t b1msg1[b1msg1Size];
+    uint8_t b1msg2[b1msg2Size];
+    size_t  messageSize;
+    size_t  responseSize = IPMI_RPLY_SET_FRU_POLICY_LENGTH_VT;
+    uint8_t cmd          = IPMI_MSG_CMD_SET_FRU_POLICY;
+    uint8_t netfn        = IPMI_MSG_NETFN_PICMG;
+    uint8_t fruId, mask, bits;
 
-	if ( parm == 0 ) {
-		mask = 1 << 1; /* make this #define */
-		bits = 0;
-	}
-	else if ( parm == 1 ){
-		mask = 1;
-		bits = 0;
-	} 
-	else
-		return -1;
+    if (parm == 0) {
+        mask = 1 << 1; /* make this #define */
+        bits = 0;
+    } else if (parm == 1) {
+        mask = 1;
+        bits = 0;
+    } else {
+        return -1;
+    }
 
-	memcpy( imsg2, SEND_MSG_MSG   , imsg2Size );
-	memcpy( b1msg1, IPMI_MSG1      , b1msg1Size );
-	memcpy( b1msg2, SET_FRU_POLICY_MSG, b1msg2Size );
+    memcpy(imsg2, SEND_MSG_MSG, imsg2Size);
+    memcpy(b1msg1, IPMI_MSG1, b1msg1Size);
+    memcpy(b1msg2, SET_FRU_POLICY_MSG, b1msg2Size);
 
-	imsg2[IPMI_MSG2_CHAN_OFFSET] = IPMI_MSG_CHAN_IPMB0 + IPMI_MSG_TRACKING;
+    imsg2[IPMI_MSG2_CHAN_OFFSET] = IPMI_MSG_CHAN_IPMB0 + IPMI_MSG_TRACKING;
 
-	b1msg1[IPMI_MSG1_RSADDR_OFFSET]   = IPMI_MSG_ADDR_CM;
-	b1msg1[IPMI_MSG1_NETFNLUN_OFFSET] = netfn << 2;
+    b1msg1[IPMI_MSG1_RSADDR_OFFSET]   = IPMI_MSG_ADDR_CM;
+    b1msg1[IPMI_MSG1_NETFNLUN_OFFSET] = netfn << 2;
 
-	fruId = mchData->mchSys->fru[fruIndex].sdr.fruId;
-	b1msg2[IPMI_MSG2_SET_FRU_ACT_FRU_OFFSET] = fruId;
-	b1msg2[IPMI_MSG2_SET_FRU_POLICY_MASK_OFFSET] = mask;
-	b1msg2[IPMI_MSG2_SET_FRU_POLICY_BITS_OFFSET] = bits;
+    fruId                                        = mchData->mchSys->fru[fruIndex].sdr.fruId;
+    b1msg2[IPMI_MSG2_SET_FRU_ACT_FRU_OFFSET]     = fruId;
+    b1msg2[IPMI_MSG2_SET_FRU_POLICY_MASK_OFFSET] = mask;
+    b1msg2[IPMI_MSG2_SET_FRU_POLICY_BITS_OFFSET] = bits;
 
-	messageSize = ipmiMsgBuild( mchData->ipmiSess, message, cmd, IPMI_MSG_NETFN_APP_REQUEST, imsg2, imsg2Size, b1msg1, b1msg2, b1msg2Size, 0, 0, 0 );
+    messageSize = ipmiMsgBuild(mchData->ipmiSess, message, cmd, IPMI_MSG_NETFN_APP_REQUEST, imsg2, imsg2Size, b1msg1,
+                               b1msg2, b1msg2Size, 0, 0, 0);
 
-	return mchMsgWriteReadHelper( mchData->mchSess, mchData->ipmiSess, message, messageSize, data, &responseSize, cmd, netfn, 0/*need to set codeoffs*/, 0 );
+    return mchMsgWriteReadHelper(mchData->mchSess, mchData->ipmiSess, message, messageSize, data, &responseSize, cmd,
+                                 netfn, 0 /*need to set codeoffs*/, 0);
 }
 
 /* Set FRU Activation - For ATCA
@@ -611,32 +596,33 @@ uint8_t  fruId, mask, bits;
  *            0 on success
  *            non-zero for error
  */
-int
-mchMsgSetFruActAtca(MchData mchData, uint8_t *data, uint8_t fruIndex, uint8_t parm)
-{
-uint8_t  response[MSG_MAX_LENGTH] = { 0 }; 
-size_t   roffs, responseSize = 0, payloadSize = PICMG_RPLY_SET_FRU_ACT_LENGTH;
-int      rval, bridged = 0;
-Fru      fru = &mchData->mchSys->fru[fruIndex];
-uint8_t  rsAddr = fru->sdr.addr, rqAddr;
+int mchMsgSetFruActAtca(MchData mchData, uint8_t* data, uint8_t fruIndex, uint8_t parm) {
+    uint8_t response[MSG_MAX_LENGTH] = {0};
+    size_t  roffs, responseSize = 0, payloadSize = PICMG_RPLY_SET_FRU_ACT_LENGTH;
+    int     rval, bridged = 0;
+    Fru     fru    = &mchData->mchSys->fru[fruIndex];
+    uint8_t rsAddr = fru->sdr.addr, rqAddr;
 
-	if ( rsAddr != IPMI_MSG_ADDR_BMC )
-		bridged = 1;
+    if (rsAddr != IPMI_MSG_ADDR_BMC) {
+        bridged = 1;
+    }
 
-	mchSetSizeOffs( mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr );
+    mchSetSizeOffs(mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr);
 
-	if ( (rval = ipmiMsgSetFruAct( mchData->mchSess, mchData->ipmiSess, response, bridged, rsAddr, rqAddr, &responseSize, roffs, fru->sdr.fruId, parm )) )
-		goto bail;
+    if ((rval = ipmiMsgSetFruAct(mchData->mchSess, mchData->ipmiSess, response, bridged, rsAddr, rqAddr, &responseSize,
+                                 roffs, fru->sdr.fruId, parm))) {
+        goto bail;
+    }
 
-	if ( (rval = mchMsgCheckSizes( sizeof( response ), roffs, payloadSize )) ) {
-		printf("mchMsgSetFruActAtca size error\n");
-		goto bail;
-	}
+    if ((rval = mchMsgCheckSizes(sizeof(response), roffs, payloadSize))) {
+        printf("mchMsgSetFruActAtca size error\n");
+        goto bail;
+    }
 
-	memcpy( data, response + roffs, payloadSize );
+    memcpy(data, response + roffs, payloadSize);
 
 bail:
-	return rval;
+    return rval;
 }
 
 /* Get FRU Activation Policy using Vadatech MCH; message contains 1 bridged message -> needs updating 3/23/16
@@ -645,37 +631,36 @@ bail:
  *            0 on success
  *            non-zero for error
  */
-int
-mchMsgGetFruActPolicyVt(MchData mchData, uint8_t *data, uint8_t fru)
-{
-uint8_t  message[MSG_MAX_LENGTH] = { 0 };
-size_t   imsg2Size   = sizeof( SEND_MSG_MSG );
-size_t   b1msg1Size   = sizeof( IPMI_MSG1 );
-size_t   b1msg2Size   = sizeof( GET_FAN_PROP_MSG );
-uint8_t  imsg2[imsg2Size];
-uint8_t  b1msg1[b1msg1Size];
-uint8_t  b1msg2[b1msg2Size];
-size_t   messageSize;
-size_t   responseSize = IPMI_RPLY_GET_FRU_POLICY_LENGTH_VT;
-uint8_t  cmd   = IPMI_MSG_CMD_GET_FRU_POLICY;
-uint8_t  netfn = IPMI_MSG_NETFN_PICMG;
+int mchMsgGetFruActPolicyVt(MchData mchData, uint8_t* data, uint8_t fru) {
+    uint8_t message[MSG_MAX_LENGTH] = {0};
+    size_t  imsg2Size               = sizeof(SEND_MSG_MSG);
+    size_t  b1msg1Size              = sizeof(IPMI_MSG1);
+    size_t  b1msg2Size              = sizeof(GET_FAN_PROP_MSG);
+    uint8_t imsg2[imsg2Size];
+    uint8_t b1msg1[b1msg1Size];
+    uint8_t b1msg2[b1msg2Size];
+    size_t  messageSize;
+    size_t  responseSize = IPMI_RPLY_GET_FRU_POLICY_LENGTH_VT;
+    uint8_t cmd          = IPMI_MSG_CMD_GET_FRU_POLICY;
+    uint8_t netfn        = IPMI_MSG_NETFN_PICMG;
 
-	memcpy( imsg2,  SEND_MSG_MSG, imsg2Size );
-	memcpy( b1msg1, IPMI_MSG1   , b1msg1Size );
-	memcpy( b1msg2, GET_FRU_POLICY_MSG, b1msg2Size );
+    memcpy(imsg2, SEND_MSG_MSG, imsg2Size);
+    memcpy(b1msg1, IPMI_MSG1, b1msg1Size);
+    memcpy(b1msg2, GET_FRU_POLICY_MSG, b1msg2Size);
 
-	imsg2[IPMI_MSG2_CHAN_OFFSET] = IPMI_MSG_CHAN_IPMB0 + IPMI_MSG_TRACKING;
+    imsg2[IPMI_MSG2_CHAN_OFFSET] = IPMI_MSG_CHAN_IPMB0 + IPMI_MSG_TRACKING;
 
-	b1msg1[IPMI_MSG1_RSADDR_OFFSET]   = IPMI_MSG_ADDR_CM;
-	b1msg1[IPMI_MSG1_NETFNLUN_OFFSET] = netfn << 2;
+    b1msg1[IPMI_MSG1_RSADDR_OFFSET]   = IPMI_MSG_ADDR_CM;
+    b1msg1[IPMI_MSG1_NETFNLUN_OFFSET] = netfn << 2;
 
-	b1msg2[IPMI_MSG2_SET_FRU_ACT_FRU_OFFSET] = fru;
+    b1msg2[IPMI_MSG2_SET_FRU_ACT_FRU_OFFSET] = fru;
 
-	messageSize = ipmiMsgBuild( mchData->ipmiSess, message, cmd, IPMI_MSG_NETFN_APP_REQUEST, imsg2, imsg2Size, b1msg1, b1msg2, b1msg2Size, 0, 0, 0 );
+    messageSize = ipmiMsgBuild(mchData->ipmiSess, message, cmd, IPMI_MSG_NETFN_APP_REQUEST, imsg2, imsg2Size, b1msg1,
+                               b1msg2, b1msg2Size, 0, 0, 0);
 
-	return mchMsgWriteReadHelper( mchData->mchSess, mchData->ipmiSess, message, messageSize, data, &responseSize, cmd, netfn, 0/*need to set codeoffs*/, 0 );
+    return mchMsgWriteReadHelper(mchData->mchSess, mchData->ipmiSess, message, messageSize, data, &responseSize, cmd,
+                                 netfn, 0 /*need to set codeoffs*/, 0);
 }
-
 
 /* Get FRU Activation Policy using NAT MCH - not yet tested; may be single message like SetFruActNat
  *
@@ -683,60 +668,58 @@ uint8_t  netfn = IPMI_MSG_NETFN_PICMG;
  *            0 on success
  *            non-zero for error
  */
-int
-mchMsgGetFruActPolicyNat(MchData mchData, uint8_t *data, uint8_t fru)
-{
-uint8_t  message[MSG_MAX_LENGTH] = { 0 };
-size_t   imsg2Size    = sizeof( SEND_MSG_MSG );
-size_t   b1msg1Size   = sizeof( IPMI_MSG1 );
-size_t   b1msg2Size   = sizeof( SEND_MSG_MSG );
-size_t   b2msg1Size   = sizeof( IPMI_MSG1 );
-size_t   b2msg2Size   = sizeof( GET_FRU_POLICY_MSG );
-uint8_t  imsg2[imsg2Size];
-uint8_t  b1msg1[b1msg1Size];
-uint8_t  b1msg2[b1msg2Size];
-uint8_t  b2msg1[b2msg1Size];
-uint8_t  b2msg2[b2msg2Size];
-size_t   messageSize;
-size_t   roffs;
-size_t   payloadSize  = IPMI_RPLY_GET_FRU_POLICY_LENGTH;
-size_t   responseSize = 2*IPMI_MSG1_LENGTH + 2*IPMI_RPLY_IMSG2_SEND_MSG_LENGTH;
-uint8_t  cmd          = IPMI_MSG_CMD_GET_FRU_POLICY;
-uint8_t  netfn        = IPMI_MSG_NETFN_PICMG;
-int      bridged = 0;
-uint8_t  rsAddr = IPMI_MSG_ADDR_BMC, rqAddr;
+int mchMsgGetFruActPolicyNat(MchData mchData, uint8_t* data, uint8_t fru) {
+    uint8_t message[MSG_MAX_LENGTH] = {0};
+    size_t  imsg2Size               = sizeof(SEND_MSG_MSG);
+    size_t  b1msg1Size              = sizeof(IPMI_MSG1);
+    size_t  b1msg2Size              = sizeof(SEND_MSG_MSG);
+    size_t  b2msg1Size              = sizeof(IPMI_MSG1);
+    size_t  b2msg2Size              = sizeof(GET_FRU_POLICY_MSG);
+    uint8_t imsg2[imsg2Size];
+    uint8_t b1msg1[b1msg1Size];
+    uint8_t b1msg2[b1msg2Size];
+    uint8_t b2msg1[b2msg1Size];
+    uint8_t b2msg2[b2msg2Size];
+    size_t  messageSize;
+    size_t  roffs;
+    size_t  payloadSize  = IPMI_RPLY_GET_FRU_POLICY_LENGTH;
+    size_t  responseSize = 2 * IPMI_MSG1_LENGTH + 2 * IPMI_RPLY_IMSG2_SEND_MSG_LENGTH;
+    uint8_t cmd          = IPMI_MSG_CMD_GET_FRU_POLICY;
+    uint8_t netfn        = IPMI_MSG_NETFN_PICMG;
+    int     bridged      = 0;
+    uint8_t rsAddr       = IPMI_MSG_ADDR_BMC, rqAddr;
 
-	mchSetSizeOffs( mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr );
+    mchSetSizeOffs(mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr);
 
-	memcpy( imsg2,  SEND_MSG_MSG , imsg2Size  );
-	memcpy( b1msg1, IPMI_MSG1    , b1msg1Size );
+    memcpy(imsg2, SEND_MSG_MSG, imsg2Size);
+    memcpy(b1msg1, IPMI_MSG1, b1msg1Size);
 
-	imsg2[IPMI_MSG2_CHAN_OFFSET]    = IPMI_MSG_CHAN_IPMB0 + IPMI_MSG_TRACKING;
-	b1msg1[IPMI_MSG1_RSADDR_OFFSET] = IPMI_MSG_ADDR_CM;
+    imsg2[IPMI_MSG2_CHAN_OFFSET]    = IPMI_MSG_CHAN_IPMB0 + IPMI_MSG_TRACKING;
+    b1msg1[IPMI_MSG1_RSADDR_OFFSET] = IPMI_MSG_ADDR_CM;
 
-	memcpy( b1msg2, SEND_MSG_MSG     , b1msg2Size );
-	memcpy( b2msg1, IPMI_MSG1        , b2msg1Size );
-	memcpy( b2msg2, GET_FRU_POLICY_MSG , b2msg2Size );
+    memcpy(b1msg2, SEND_MSG_MSG, b1msg2Size);
+    memcpy(b2msg1, IPMI_MSG1, b2msg1Size);
+    memcpy(b2msg2, GET_FRU_POLICY_MSG, b2msg2Size);
 
-	b1msg2[IPMI_MSG2_RQADDR_OFFSET]   = IPMI_MSG_ADDR_BMC;
-	b2msg1[IPMI_MSG1_NETFNLUN_OFFSET] = netfn << 2;
-	b1msg2[IPMI_MSG2_CHAN_OFFSET]     = IPMI_MSG_CHAN_IPMBL + IPMI_MSG_TRACKING;
-	b2msg1[IPMI_MSG1_RSADDR_OFFSET]   = FRU_I2C_ADDR[fru];
-	b2msg2[IPMI_MSG2_SET_FRU_ACT_FRU_OFFSET] = 0;
+    b1msg2[IPMI_MSG2_RQADDR_OFFSET]          = IPMI_MSG_ADDR_BMC;
+    b2msg1[IPMI_MSG1_NETFNLUN_OFFSET]        = netfn << 2;
+    b1msg2[IPMI_MSG2_CHAN_OFFSET]            = IPMI_MSG_CHAN_IPMBL + IPMI_MSG_TRACKING;
+    b2msg1[IPMI_MSG1_RSADDR_OFFSET]          = FRU_I2C_ADDR[fru];
+    b2msg2[IPMI_MSG2_SET_FRU_ACT_FRU_OFFSET] = 0;
 
-       	messageSize = ipmiMsgBuild( mchData->ipmiSess, message, cmd, IPMI_MSG_NETFN_APP_REQUEST, imsg2, imsg2Size, b1msg1, b1msg2, b1msg2Size, b2msg1, b2msg2, b2msg2Size );
+    messageSize = ipmiMsgBuild(mchData->ipmiSess, message, cmd, IPMI_MSG_NETFN_APP_REQUEST, imsg2, imsg2Size, b1msg1,
+                               b1msg2, b1msg2Size, b2msg1, b2msg2, b2msg2Size);
 
-	return mchMsgWriteReadHelper( mchData->mchSess, mchData->ipmiSess, message, messageSize, data, &responseSize, cmd, netfn, roffs, 0);
+    return mchMsgWriteReadHelper(mchData->mchSess, mchData->ipmiSess, message, messageSize, data, &responseSize, cmd,
+                                 netfn, roffs, 0);
 }
 
-int
-mchMsgGetFruActPolicyHelper(MchData mchData, uint8_t *data, uint8_t fru)
-{
-	if ( !( MCH_IS_VT( mchData->mchSess->type )) )
-		return mchMsgGetFruActPolicyVt( mchData, data, fru );
-	else
-		return mchMsgGetFruActPolicyNat( mchData, data, fru );
-
+int mchMsgGetFruActPolicyHelper(MchData mchData, uint8_t* data, uint8_t fru) {
+    if (!(MCH_IS_VT(mchData->mchSess->type))) {
+        return mchMsgGetFruActPolicyVt(mchData, data, fru);
+    } else {
+        return mchMsgGetFruActPolicyNat(mchData, data, fru);
+    }
 }
 
 /* Get Fan Speed Properties using Vadatech MCH; message contains 1 bridged message -> needs updating 3/23/16
@@ -745,44 +728,45 @@ mchMsgGetFruActPolicyHelper(MchData mchData, uint8_t *data, uint8_t fru)
  *            0 on success
  *            non-zero for error
  */
-int
-mchMsgGetFanPropVt(MchData mchData, uint8_t *data, uint8_t fruIndex)
-{
-uint8_t  message[MSG_MAX_LENGTH] = { 0 };
-uint8_t  imsg2Size = sizeof( GET_FAN_PROP_MSG );
-uint8_t  imsg2[imsg2Size];
-size_t   messageSize;
-Fru      fru = &mchData->mchSys->fru[fruIndex];
-uint8_t  response[MSG_MAX_LENGTH] = { 0 }; 
-size_t   roffs, responseSize, payloadSize = IPMI_RPLY_GET_FAN_PROP_LENGTH; 
-int      rval, offs=0, bridged = 0;
-uint8_t  rsAddr = IPMI_MSG_ADDR_BMC, rqAddr, fruId = fru->sdr.fruId;
-uint8_t  cmd   = IPMI_MSG_CMD_GET_FAN_PROP;
-uint8_t  netfn = IPMI_MSG_NETFN_PICMG;
+int mchMsgGetFanPropVt(MchData mchData, uint8_t* data, uint8_t fruIndex) {
+    uint8_t message[MSG_MAX_LENGTH] = {0};
+    uint8_t imsg2Size               = sizeof(GET_FAN_PROP_MSG);
+    uint8_t imsg2[imsg2Size];
+    size_t  messageSize;
+    Fru     fru                      = &mchData->mchSys->fru[fruIndex];
+    uint8_t response[MSG_MAX_LENGTH] = {0};
+    size_t  roffs, responseSize, payloadSize = IPMI_RPLY_GET_FAN_PROP_LENGTH;
+    int     rval, offs = 0, bridged = 0;
+    uint8_t rsAddr = IPMI_MSG_ADDR_BMC, rqAddr, fruId = fru->sdr.fruId;
+    uint8_t cmd   = IPMI_MSG_CMD_GET_FAN_PROP;
+    uint8_t netfn = IPMI_MSG_NETFN_PICMG;
 
-	mchSetSizeOffs( mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr);
+    mchSetSizeOffs(mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr);
 
-	memcpy( imsg2, GET_FAN_PROP_MSG, imsg2Size );
+    memcpy(imsg2, GET_FAN_PROP_MSG, imsg2Size);
 
-	imsg2[IPMI_MSG2_SET_FRU_ACT_FRU_OFFSET] = fruId;
+    imsg2[IPMI_MSG2_SET_FRU_ACT_FRU_OFFSET] = fruId;
 
-	if ( bridged ) // may need to distinguish between once and twice-bridged messages
-		ipmiBuildSendMsg( mchData->ipmiSess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0 );
-	else
-		messageSize = ipmiMsgBuild( mchData->ipmiSess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0 );
+    if (bridged) { // may need to distinguish between once and twice-bridged messages
+        ipmiBuildSendMsg(mchData->ipmiSess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0);
+    } else {
+        messageSize = ipmiMsgBuild(mchData->ipmiSess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0);
+    }
 
-	if ( (rval = mchMsgWriteReadHelper( mchData->mchSess, mchData->ipmiSess, message, messageSize, response, &responseSize, cmd, netfn, offs/*need to set codeoffs*/, 0 )) )
-		goto bail;
+    if ((rval = mchMsgWriteReadHelper(mchData->mchSess, mchData->ipmiSess, message, messageSize, response,
+                                      &responseSize, cmd, netfn, offs /*need to set codeoffs*/, 0))) {
+        goto bail;
+    }
 
-	if ( (rval = mchMsgCheckSizes( sizeof( response ), roffs, payloadSize )) ) {
-		printf("mchMsgGetFanPropVt size error\n");
-		goto bail;
-	}
+    if ((rval = mchMsgCheckSizes(sizeof(response), roffs, payloadSize))) {
+        printf("mchMsgGetFanPropVt size error\n");
+        goto bail;
+    }
 
-	memcpy( data, response + roffs, payloadSize );
+    memcpy(data, response + roffs, payloadSize);
 
 bail:
-	return rval;
+    return rval;
 }
 
 /* Get Fan Speed Properties using NAT MCH; message contains 2 bridged messages
@@ -791,63 +775,64 @@ bail:
  *            0 on success
  *            non-zero for error
  */
-int
-mchMsgGetFanPropNat(MchData mchData, uint8_t *data, uint8_t fruIndex)
-{
-uint8_t  message[MSG_MAX_LENGTH]  = { 0 };
-uint8_t  response[MSG_MAX_LENGTH] = { 0 };
-size_t   imsg2Size    = sizeof( SEND_MSG_MSG );
-size_t   b1msg1Size   = sizeof( IPMI_MSG1 );
-size_t   b1msg2Size   = sizeof( SEND_MSG_MSG );
-size_t   b2msg1Size   = sizeof( IPMI_MSG1 );
-size_t   b2msg2Size   = sizeof( GET_FAN_PROP_MSG );
-uint8_t  imsg2[imsg2Size];
-uint8_t  b1msg1[b1msg1Size];
-uint8_t  b1msg2[b1msg2Size];
-uint8_t  b2msg1[b2msg1Size];
-uint8_t  b2msg2[b2msg2Size];
-size_t   messageSize;
-size_t   roffs;
-size_t   payloadSize  = IPMI_RPLY_GET_FAN_PROP_LENGTH;
-size_t   responseSize = 2*IPMI_MSG1_LENGTH + 2*IPMI_RPLY_IMSG2_SEND_MSG_LENGTH;
-uint8_t  cmd          = IPMI_MSG_CMD_GET_FAN_PROP;
-uint8_t  netfn        = IPMI_MSG_NETFN_PICMG;
-int      rval, bridged = 0;
-Fru      fru = &mchData->mchSys->fru[fruIndex];
-uint8_t  rsAddr = IPMI_MSG_ADDR_BMC, rqAddr, fruId = fru->sdr.fruId;
+int mchMsgGetFanPropNat(MchData mchData, uint8_t* data, uint8_t fruIndex) {
+    uint8_t message[MSG_MAX_LENGTH]  = {0};
+    uint8_t response[MSG_MAX_LENGTH] = {0};
+    size_t  imsg2Size                = sizeof(SEND_MSG_MSG);
+    size_t  b1msg1Size               = sizeof(IPMI_MSG1);
+    size_t  b1msg2Size               = sizeof(SEND_MSG_MSG);
+    size_t  b2msg1Size               = sizeof(IPMI_MSG1);
+    size_t  b2msg2Size               = sizeof(GET_FAN_PROP_MSG);
+    uint8_t imsg2[imsg2Size];
+    uint8_t b1msg1[b1msg1Size];
+    uint8_t b1msg2[b1msg2Size];
+    uint8_t b2msg1[b2msg1Size];
+    uint8_t b2msg2[b2msg2Size];
+    size_t  messageSize;
+    size_t  roffs;
+    size_t  payloadSize  = IPMI_RPLY_GET_FAN_PROP_LENGTH;
+    size_t  responseSize = 2 * IPMI_MSG1_LENGTH + 2 * IPMI_RPLY_IMSG2_SEND_MSG_LENGTH;
+    uint8_t cmd          = IPMI_MSG_CMD_GET_FAN_PROP;
+    uint8_t netfn        = IPMI_MSG_NETFN_PICMG;
+    int     rval, bridged = 0;
+    Fru     fru    = &mchData->mchSys->fru[fruIndex];
+    uint8_t rsAddr = IPMI_MSG_ADDR_BMC, rqAddr, fruId = fru->sdr.fruId;
 
-	mchSetSizeOffs( mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr );
+    mchSetSizeOffs(mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr);
 
-	memcpy( imsg2,  SEND_MSG_MSG , imsg2Size  );
-	memcpy( b1msg1, IPMI_MSG1    , b1msg1Size );
+    memcpy(imsg2, SEND_MSG_MSG, imsg2Size);
+    memcpy(b1msg1, IPMI_MSG1, b1msg1Size);
 
-	imsg2[IPMI_MSG2_CHAN_OFFSET]    = IPMI_MSG_CHAN_IPMB0 + IPMI_MSG_TRACKING;
-	b1msg1[IPMI_MSG1_RSADDR_OFFSET] = IPMI_MSG_ADDR_CM;
+    imsg2[IPMI_MSG2_CHAN_OFFSET]    = IPMI_MSG_CHAN_IPMB0 + IPMI_MSG_TRACKING;
+    b1msg1[IPMI_MSG1_RSADDR_OFFSET] = IPMI_MSG_ADDR_CM;
 
-	memcpy( b1msg2, SEND_MSG_MSG      , b1msg2Size );
-	memcpy( b2msg1, IPMI_MSG1         , b2msg1Size );
-	memcpy( b2msg2, GET_FAN_PROP_MSG , b2msg2Size );
+    memcpy(b1msg2, SEND_MSG_MSG, b1msg2Size);
+    memcpy(b2msg1, IPMI_MSG1, b2msg1Size);
+    memcpy(b2msg2, GET_FAN_PROP_MSG, b2msg2Size);
 
-	b1msg2[IPMI_MSG2_RQADDR_OFFSET]   = IPMI_MSG_ADDR_BMC;
-	b2msg1[IPMI_MSG1_NETFNLUN_OFFSET] = netfn << 2;
-	b1msg2[IPMI_MSG2_CHAN_OFFSET]     = IPMI_MSG_CHAN_IPMBL + IPMI_MSG_TRACKING;
-	b2msg1[IPMI_MSG1_RSADDR_OFFSET]   = FRU_I2C_ADDR[fruId];
-	b2msg2[IPMI_MSG2_SET_FRU_ACT_FRU_OFFSET] = 0;
+    b1msg2[IPMI_MSG2_RQADDR_OFFSET]          = IPMI_MSG_ADDR_BMC;
+    b2msg1[IPMI_MSG1_NETFNLUN_OFFSET]        = netfn << 2;
+    b1msg2[IPMI_MSG2_CHAN_OFFSET]            = IPMI_MSG_CHAN_IPMBL + IPMI_MSG_TRACKING;
+    b2msg1[IPMI_MSG1_RSADDR_OFFSET]          = FRU_I2C_ADDR[fruId];
+    b2msg2[IPMI_MSG2_SET_FRU_ACT_FRU_OFFSET] = 0;
 
-       	messageSize = ipmiMsgBuild( mchData->ipmiSess, message, cmd, IPMI_MSG_NETFN_APP_REQUEST, imsg2, imsg2Size, b1msg1, b1msg2, b1msg2Size, b2msg1, b2msg2, b2msg2Size );
+    messageSize = ipmiMsgBuild(mchData->ipmiSess, message, cmd, IPMI_MSG_NETFN_APP_REQUEST, imsg2, imsg2Size, b1msg1,
+                               b1msg2, b1msg2Size, b2msg1, b2msg2, b2msg2Size);
 
-	if ( (rval = mchMsgWriteReadHelper( mchData->mchSess, mchData->ipmiSess, message, messageSize, response, &responseSize, cmd, netfn, roffs, 0 )) )
-		goto bail;
+    if ((rval = mchMsgWriteReadHelper(mchData->mchSess, mchData->ipmiSess, message, messageSize, response,
+                                      &responseSize, cmd, netfn, roffs, 0))) {
+        goto bail;
+    }
 
-	if ( (rval = mchMsgCheckSizes( sizeof( response ), roffs, payloadSize )) ) {
-		printf("mchMsgGetFanPropNat size error\n");
-		goto bail;
-	}
+    if ((rval = mchMsgCheckSizes(sizeof(response), roffs, payloadSize))) {
+        printf("mchMsgGetFanPropNat size error\n");
+        goto bail;
+    }
 
-	memcpy( data, response + roffs, payloadSize );
-    
+    memcpy(data, response + roffs, payloadSize);
+
 bail:
-	return rval;
+    return rval;
 }
 
 /* Get Fan Properties - For ATCA
@@ -857,173 +842,177 @@ bail:
  *            0 on success
  *            non-zero for error
  */
-int
-mchMsgGetFanPropAtca(MchData mchData, uint8_t *data, uint8_t fruIndex)
-{
-uint8_t  response[MSG_MAX_LENGTH] = { 0 }; 
-size_t   roffs, responseSize = 0, payloadSize = IPMI_RPLY_GET_FAN_PROP_LENGTH; 
-int      rval, bridged = 0;
-Fru      fru = &mchData->mchSys->fru[fruIndex];
-uint8_t  rsAddr = fru->sdr.addr, rqAddr;
+int mchMsgGetFanPropAtca(MchData mchData, uint8_t* data, uint8_t fruIndex) {
+    uint8_t response[MSG_MAX_LENGTH] = {0};
+    size_t  roffs, responseSize = 0, payloadSize = IPMI_RPLY_GET_FAN_PROP_LENGTH;
+    int     rval, bridged = 0;
+    Fru     fru    = &mchData->mchSys->fru[fruIndex];
+    uint8_t rsAddr = fru->sdr.addr, rqAddr;
 
-	if ( rsAddr != IPMI_MSG_ADDR_BMC )
-		bridged = 1;
+    if (rsAddr != IPMI_MSG_ADDR_BMC) {
+        bridged = 1;
+    }
 
-	mchSetSizeOffs( mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr );
+    mchSetSizeOffs(mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr);
 
-	if ( (rval = ipmiMsgGetFanProp( mchData->mchSess, mchData->ipmiSess, response, bridged, rsAddr, rqAddr, &responseSize, roffs, fru->sdr.fruId )) )
-		goto bail;
+    if ((rval = ipmiMsgGetFanProp(mchData->mchSess, mchData->ipmiSess, response, bridged, rsAddr, rqAddr, &responseSize,
+                                  roffs, fru->sdr.fruId))) {
+        goto bail;
+    }
 
-	if ( (rval = mchMsgCheckSizes( sizeof( response ), roffs, payloadSize )) ) {
-		printf("mchMsgGetFanPropAtca size error\n");
-		goto bail;
-	}
+    if ((rval = mchMsgCheckSizes(sizeof(response), roffs, payloadSize))) {
+        printf("mchMsgGetFanPropAtca size error\n");
+        goto bail;
+    }
 
-	memcpy( data, response + roffs, payloadSize );
+    memcpy(data, response + roffs, payloadSize);
 
 bail:
-	return rval;
+    return rval;
 }
 
 /* Details of this algorithm specified in PICMG 3.0 Rev 3.0 ATCA Base Spec, Table 3-87 */
-void
-mchGetFanLevel(uint8_t *data, uint8_t *level, uint8_t fanProp)
-{
-uint8_t llevel, olevel, lenabled;
+void mchGetFanLevel(uint8_t* data, uint8_t* level, uint8_t fanProp) {
+    uint8_t llevel, olevel, lenabled;
 
-	olevel = data[PICMG_RPLY_IMSG2_GET_FAN_OVERRIDE_LEVEL_OFFSET];
+    olevel = data[PICMG_RPLY_IMSG2_GET_FAN_OVERRIDE_LEVEL_OFFSET];
 
-	if ( PICMG_FAN_LOCAL_CONTROL_SUPPORTED( fanProp ) ) {
+    if (PICMG_FAN_LOCAL_CONTROL_SUPPORTED(fanProp)) {
 
-		llevel   = data[PICMG_RPLY_IMSG2_GET_FAN_LOCAL_LEVEL_OFFSET];
-		lenabled = data[ PICMG_RPLY_IMSG2_GET_FAN_LOCAL_ENABLED_OFFSET];
+        llevel   = data[PICMG_RPLY_IMSG2_GET_FAN_LOCAL_LEVEL_OFFSET];
+        lenabled = data[PICMG_RPLY_IMSG2_GET_FAN_LOCAL_ENABLED_OFFSET];
 
-		if ( olevel == 0xFF )
-			*level = llevel;
+        if (olevel == 0xFF) {
+            *level = llevel;
+        }
 
-		else if ( lenabled )
-			*level = (llevel > olevel) ? llevel : olevel;
+        else if (lenabled) {
+            *level = (llevel > olevel) ? llevel : olevel;
+        }
 
-		else if ( (0xFE==llevel) || (0xFE==olevel) )
-			*level = -1; /* Shut down state; arbitrarily choose -1 for this state for now */
+        else if ((0xFE == llevel) || (0xFE == olevel)) {
+            *level = -1; /* Shut down state; arbitrarily choose -1 for this state for now */
+        }
 
-		else
-			*level = olevel;
-	}
-	else
-		*level = olevel;
-
+        else {
+            *level = olevel;
+        }
+    } else {
+        *level = olevel;
+    }
 }
 
 /* -> needs updating 3/23/16 */
-int
-mchMsgGetFanLevelVt(MchData mchData, uint8_t *data, uint8_t fruIndex, uint8_t *level)
-{
-uint8_t  message[MSG_MAX_LENGTH] = { 0 };
-uint8_t  imsg2Size = sizeof( GET_FAN_LEVEL_MSG );
-uint8_t  imsg2[imsg2Size];
-size_t   messageSize;
-Fru      fru = &mchData->mchSys->fru[fruIndex];
+int mchMsgGetFanLevelVt(MchData mchData, uint8_t* data, uint8_t fruIndex, uint8_t* level) {
+    uint8_t message[MSG_MAX_LENGTH] = {0};
+    uint8_t imsg2Size               = sizeof(GET_FAN_LEVEL_MSG);
+    uint8_t imsg2[imsg2Size];
+    size_t  messageSize;
+    Fru     fru = &mchData->mchSys->fru[fruIndex];
 
-uint8_t  response[MSG_MAX_LENGTH] = { 0 }; 
-size_t   roffs, responseSize, payloadSize = IPMI_RPLY_GET_FAN_LEVEL_LENGTH; 
-int      rval, offs=0, bridged = 0;
-uint8_t  rsAddr = IPMI_MSG_ADDR_BMC, rqAddr, fruId = fru->sdr.fruId;
-uint8_t  cmd   = IPMI_MSG_CMD_GET_FAN_LEVEL;
-uint8_t  netfn = IPMI_MSG_NETFN_PICMG;
+    uint8_t response[MSG_MAX_LENGTH] = {0};
+    size_t  roffs, responseSize, payloadSize = IPMI_RPLY_GET_FAN_LEVEL_LENGTH;
+    int     rval, offs = 0, bridged = 0;
+    uint8_t rsAddr = IPMI_MSG_ADDR_BMC, rqAddr, fruId = fru->sdr.fruId;
+    uint8_t cmd   = IPMI_MSG_CMD_GET_FAN_LEVEL;
+    uint8_t netfn = IPMI_MSG_NETFN_PICMG;
 
-	mchSetSizeOffs( mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr);
+    mchSetSizeOffs(mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr);
 
-	memcpy( imsg2, GET_FAN_LEVEL_MSG, imsg2Size );
+    memcpy(imsg2, GET_FAN_LEVEL_MSG, imsg2Size);
 
-	imsg2[IPMI_MSG2_SET_FRU_ACT_FRU_OFFSET] = fruId;
+    imsg2[IPMI_MSG2_SET_FRU_ACT_FRU_OFFSET] = fruId;
 
-	if ( bridged ) // may need to distinguish between once and twice-bridged messages
-		ipmiBuildSendMsg( mchData->ipmiSess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0 );
-	else
-		messageSize = ipmiMsgBuild( mchData->ipmiSess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0 );
+    if (bridged) { // may need to distinguish between once and twice-bridged messages
+        ipmiBuildSendMsg(mchData->ipmiSess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0);
+    } else {
+        messageSize = ipmiMsgBuild(mchData->ipmiSess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0);
+    }
 
-	if ( (rval = mchMsgWriteReadHelper( mchData->mchSess, mchData->ipmiSess, message, messageSize, response, &responseSize, cmd, netfn, offs/*need to set codeoffs*/, 0 )) )
-		goto bail;
+    if ((rval = mchMsgWriteReadHelper(mchData->mchSess, mchData->ipmiSess, message, messageSize, response,
+                                      &responseSize, cmd, netfn, offs /*need to set codeoffs*/, 0))) {
+        goto bail;
+    }
 
-	if ( (rval = mchMsgCheckSizes( sizeof( response ), roffs, payloadSize )) ) {
-		printf("mchMsgGetFanLevelVt size error\n");
-		goto bail;
-	}
+    if ((rval = mchMsgCheckSizes(sizeof(response), roffs, payloadSize))) {
+        printf("mchMsgGetFanLevelVt size error\n");
+        goto bail;
+    }
 
-	memcpy( data, response + roffs, payloadSize );
+    memcpy(data, response + roffs, payloadSize);
 
-	mchGetFanLevel( data, level, fru->fanProp );
+    mchGetFanLevel(data, level, fru->fanProp);
 
 bail:
-	return rval;
+    return rval;
 }
 
-/* Get Fan Level using NAT MCH; message contains 2 bridged messages 
+/* Get Fan Level using NAT MCH; message contains 2 bridged messages
  *
  *   RETURNS: status from mchMsgWriteReadHelper
  *            0 on success
  *            non-zero for error
  */
-int
-mchMsgGetFanLevelNat(MchData mchData, uint8_t *data, uint8_t fruIndex, uint8_t *level)
-{
-uint8_t  message[MSG_MAX_LENGTH]  = { 0 };
-uint8_t  response[MSG_MAX_LENGTH] = { 0 };
-size_t   imsg2Size    = sizeof( SEND_MSG_MSG );
-size_t   b1msg1Size   = sizeof( IPMI_MSG1 );
-size_t   b1msg2Size   = sizeof( SEND_MSG_MSG );
-size_t   b2msg1Size   = sizeof( IPMI_MSG1 );
-size_t   b2msg2Size   = sizeof( GET_FAN_LEVEL_MSG );
-uint8_t  imsg2[imsg2Size];
-uint8_t  b1msg1[b1msg1Size];
-uint8_t  b1msg2[b1msg2Size];
-uint8_t  b2msg1[b2msg1Size];
-uint8_t  b2msg2[b2msg2Size];
-size_t   messageSize;
-size_t   roffs;
-size_t   payloadSize  = IPMI_RPLY_GET_FAN_LEVEL_LENGTH;
-size_t   responseSize = 2*IPMI_MSG1_LENGTH + 2*IPMI_RPLY_IMSG2_SEND_MSG_LENGTH;
-uint8_t  cmd          = IPMI_MSG_CMD_GET_FAN_LEVEL;
-uint8_t  netfn        = IPMI_MSG_NETFN_PICMG;
-int      rval, bridged = 0;
-Fru      fru = &mchData->mchSys->fru[fruIndex];
-uint8_t  rsAddr = IPMI_MSG_ADDR_BMC, rqAddr, fruId = fru->sdr.fruId;
+int mchMsgGetFanLevelNat(MchData mchData, uint8_t* data, uint8_t fruIndex, uint8_t* level) {
+    uint8_t message[MSG_MAX_LENGTH]  = {0};
+    uint8_t response[MSG_MAX_LENGTH] = {0};
+    size_t  imsg2Size                = sizeof(SEND_MSG_MSG);
+    size_t  b1msg1Size               = sizeof(IPMI_MSG1);
+    size_t  b1msg2Size               = sizeof(SEND_MSG_MSG);
+    size_t  b2msg1Size               = sizeof(IPMI_MSG1);
+    size_t  b2msg2Size               = sizeof(GET_FAN_LEVEL_MSG);
+    uint8_t imsg2[imsg2Size];
+    uint8_t b1msg1[b1msg1Size];
+    uint8_t b1msg2[b1msg2Size];
+    uint8_t b2msg1[b2msg1Size];
+    uint8_t b2msg2[b2msg2Size];
+    size_t  messageSize;
+    size_t  roffs;
+    size_t  payloadSize  = IPMI_RPLY_GET_FAN_LEVEL_LENGTH;
+    size_t  responseSize = 2 * IPMI_MSG1_LENGTH + 2 * IPMI_RPLY_IMSG2_SEND_MSG_LENGTH;
+    uint8_t cmd          = IPMI_MSG_CMD_GET_FAN_LEVEL;
+    uint8_t netfn        = IPMI_MSG_NETFN_PICMG;
+    int     rval, bridged = 0;
+    Fru     fru    = &mchData->mchSys->fru[fruIndex];
+    uint8_t rsAddr = IPMI_MSG_ADDR_BMC, rqAddr, fruId = fru->sdr.fruId;
 
-	mchSetSizeOffs( mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr );
+    mchSetSizeOffs(mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr);
 
-	memcpy( imsg2,  SEND_MSG_MSG , imsg2Size  );
-	memcpy( b1msg1, IPMI_MSG1    , b1msg1Size );
+    memcpy(imsg2, SEND_MSG_MSG, imsg2Size);
+    memcpy(b1msg1, IPMI_MSG1, b1msg1Size);
 
-	imsg2[IPMI_MSG2_CHAN_OFFSET]    = IPMI_MSG_CHAN_IPMB0 + IPMI_MSG_TRACKING;
-	b1msg1[IPMI_MSG1_RSADDR_OFFSET] = IPMI_MSG_ADDR_CM;
+    imsg2[IPMI_MSG2_CHAN_OFFSET]    = IPMI_MSG_CHAN_IPMB0 + IPMI_MSG_TRACKING;
+    b1msg1[IPMI_MSG1_RSADDR_OFFSET] = IPMI_MSG_ADDR_CM;
 
-	memcpy( b1msg2, SEND_MSG_MSG      , b1msg2Size );
-	memcpy( b2msg1, IPMI_MSG1         , b2msg1Size );
-	memcpy( b2msg2, GET_FAN_LEVEL_MSG , b2msg2Size );
+    memcpy(b1msg2, SEND_MSG_MSG, b1msg2Size);
+    memcpy(b2msg1, IPMI_MSG1, b2msg1Size);
+    memcpy(b2msg2, GET_FAN_LEVEL_MSG, b2msg2Size);
 
-	b1msg2[IPMI_MSG2_RQADDR_OFFSET]   = IPMI_MSG_ADDR_BMC;
-	b2msg1[IPMI_MSG1_NETFNLUN_OFFSET] = netfn << 2;
-	b1msg2[IPMI_MSG2_CHAN_OFFSET]     = IPMI_MSG_CHAN_IPMBL + IPMI_MSG_TRACKING;
-	b2msg1[IPMI_MSG1_RSADDR_OFFSET]   = FRU_I2C_ADDR[fruId];
-	b2msg2[IPMI_MSG2_SET_FRU_ACT_FRU_OFFSET] = 0;
+    b1msg2[IPMI_MSG2_RQADDR_OFFSET]          = IPMI_MSG_ADDR_BMC;
+    b2msg1[IPMI_MSG1_NETFNLUN_OFFSET]        = netfn << 2;
+    b1msg2[IPMI_MSG2_CHAN_OFFSET]            = IPMI_MSG_CHAN_IPMBL + IPMI_MSG_TRACKING;
+    b2msg1[IPMI_MSG1_RSADDR_OFFSET]          = FRU_I2C_ADDR[fruId];
+    b2msg2[IPMI_MSG2_SET_FRU_ACT_FRU_OFFSET] = 0;
 
-       	messageSize = ipmiMsgBuild( mchData->ipmiSess, message, cmd, IPMI_MSG_NETFN_APP_REQUEST, imsg2, imsg2Size, b1msg1, b1msg2, b1msg2Size, b2msg1, b2msg2, b2msg2Size );
+    messageSize = ipmiMsgBuild(mchData->ipmiSess, message, cmd, IPMI_MSG_NETFN_APP_REQUEST, imsg2, imsg2Size, b1msg1,
+                               b1msg2, b1msg2Size, b2msg1, b2msg2, b2msg2Size);
 
-	if ( (rval = mchMsgWriteReadHelper( mchData->mchSess, mchData->ipmiSess, message, messageSize, response, &responseSize, cmd, netfn, roffs, 0 )) )
-		goto bail;
+    if ((rval = mchMsgWriteReadHelper(mchData->mchSess, mchData->ipmiSess, message, messageSize, response,
+                                      &responseSize, cmd, netfn, roffs, 0))) {
+        goto bail;
+    }
 
-	if ( (rval = mchMsgCheckSizes( sizeof( response ), roffs, payloadSize )) ) {
-		printf("mchMsgGetFanLevelNat size error\n");
-		goto bail;
-	}
+    if ((rval = mchMsgCheckSizes(sizeof(response), roffs, payloadSize))) {
+        printf("mchMsgGetFanLevelNat size error\n");
+        goto bail;
+    }
 
-	memcpy( data, response + roffs, payloadSize );
+    memcpy(data, response + roffs, payloadSize);
 
-	mchGetFanLevel( data, level, fru->fanProp );
+    mchGetFanLevel(data, level, fru->fanProp);
 
-bail:    
-	return rval;
+bail:
+    return rval;
 }
 
 /* Get Fan Level - For ATCA
@@ -1033,34 +1022,35 @@ bail:
  *            0 on success
  *            non-zero for error
  */
-int
-mchMsgGetFanLevelAtca(MchData mchData, uint8_t *data, uint8_t fruIndex, uint8_t *level)
-{
-uint8_t  response[MSG_MAX_LENGTH] = { 0 }; 
-size_t   roffs, responseSize = 0, payloadSize = IPMI_RPLY_GET_FAN_LEVEL_LENGTH; 
-int      rval, bridged = 0;
-Fru      fru = &mchData->mchSys->fru[fruIndex];
-uint8_t  rsAddr = fru->sdr.addr, rqAddr;
+int mchMsgGetFanLevelAtca(MchData mchData, uint8_t* data, uint8_t fruIndex, uint8_t* level) {
+    uint8_t response[MSG_MAX_LENGTH] = {0};
+    size_t  roffs, responseSize = 0, payloadSize = IPMI_RPLY_GET_FAN_LEVEL_LENGTH;
+    int     rval, bridged = 0;
+    Fru     fru    = &mchData->mchSys->fru[fruIndex];
+    uint8_t rsAddr = fru->sdr.addr, rqAddr;
 
-	if ( rsAddr != IPMI_MSG_ADDR_BMC )
-		bridged = 1;
+    if (rsAddr != IPMI_MSG_ADDR_BMC) {
+        bridged = 1;
+    }
 
-	mchSetSizeOffs( mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr );
+    mchSetSizeOffs(mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr);
 
-	if ( (rval = ipmiMsgGetFanLevel( mchData->mchSess, mchData->ipmiSess, response, bridged, rsAddr, rqAddr, &responseSize, roffs, fru->sdr.fruId )) )
-		goto bail;
+    if ((rval = ipmiMsgGetFanLevel(mchData->mchSess, mchData->ipmiSess, response, bridged, rsAddr, rqAddr,
+                                   &responseSize, roffs, fru->sdr.fruId))) {
+        goto bail;
+    }
 
-	if ( (rval = mchMsgCheckSizes( sizeof( response ), roffs, payloadSize )) ) {
-		printf("mchMsgGetFanLevelAtca size error\n");
-		goto bail;
-	}
+    if ((rval = mchMsgCheckSizes(sizeof(response), roffs, payloadSize))) {
+        printf("mchMsgGetFanLevelAtca size error\n");
+        goto bail;
+    }
 
-	memcpy( data, response + roffs, payloadSize );
+    memcpy(data, response + roffs, payloadSize);
 
-	mchGetFanLevel( data, level, fru->fanProp );
+    mchGetFanLevel(data, level, fru->fanProp);
 
 bail:
-	return rval;
+    return rval;
 }
 
 /* Set Fan Level using Vadatech MCH; message contains 1 bridged message  -> needs updating 3/23/16
@@ -1069,44 +1059,45 @@ bail:
  *            0 on success
  *            non-zero for error
  */
-int
-mchMsgSetFanLevelVt(MchData mchData, uint8_t *data, uint8_t fruIndex, uint8_t level)
-{
-uint8_t  message[MSG_MAX_LENGTH] = { 0 };
-uint8_t  imsg2Size = sizeof( SET_FAN_LEVEL_MSG );
-uint8_t  imsg2[imsg2Size];
-size_t   messageSize;
+int mchMsgSetFanLevelVt(MchData mchData, uint8_t* data, uint8_t fruIndex, uint8_t level) {
+    uint8_t message[MSG_MAX_LENGTH] = {0};
+    uint8_t imsg2Size               = sizeof(SET_FAN_LEVEL_MSG);
+    uint8_t imsg2[imsg2Size];
+    size_t  messageSize;
 
-uint8_t  response[MSG_MAX_LENGTH] = { 0 }; 
-size_t   roffs, responseSize, payloadSize = IPMI_RPLY_SET_FAN_LEVEL_LENGTH; 
-int      rval, offs=0, bridged = 0;
-uint8_t  rsAddr = IPMI_MSG_ADDR_BMC, rqAddr, fruId = mchData->mchSys->fru[fruIndex].sdr.fruId;
-uint8_t  cmd   = IPMI_MSG_CMD_SET_FAN_LEVEL;
-uint8_t  netfn = IPMI_MSG_NETFN_PICMG;
+    uint8_t response[MSG_MAX_LENGTH] = {0};
+    size_t  roffs, responseSize, payloadSize = IPMI_RPLY_SET_FAN_LEVEL_LENGTH;
+    int     rval, offs = 0, bridged = 0;
+    uint8_t rsAddr = IPMI_MSG_ADDR_BMC, rqAddr, fruId = mchData->mchSys->fru[fruIndex].sdr.fruId;
+    uint8_t cmd   = IPMI_MSG_CMD_SET_FAN_LEVEL;
+    uint8_t netfn = IPMI_MSG_NETFN_PICMG;
 
-	mchSetSizeOffs( mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr);
+    mchSetSizeOffs(mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr);
 
-	memcpy( imsg2, SET_FAN_LEVEL_MSG, imsg2Size );
+    memcpy(imsg2, SET_FAN_LEVEL_MSG, imsg2Size);
 
-	imsg2[IPMI_MSG2_SET_FRU_ACT_FRU_OFFSET] = fruId;
-	imsg2[IPMI_MSG2_SET_FAN_LEVEL_OFFSET]   = level;
+    imsg2[IPMI_MSG2_SET_FRU_ACT_FRU_OFFSET] = fruId;
+    imsg2[IPMI_MSG2_SET_FAN_LEVEL_OFFSET]   = level;
 
-	if ( bridged ) // may need to distinguish between once and twice-bridged messages
-		ipmiBuildSendMsg( mchData->ipmiSess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0 );
-	else
-		messageSize = ipmiMsgBuild( mchData->ipmiSess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0 );
+    if (bridged) { // may need to distinguish between once and twice-bridged messages
+        ipmiBuildSendMsg(mchData->ipmiSess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0);
+    } else {
+        messageSize = ipmiMsgBuild(mchData->ipmiSess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0);
+    }
 
-	if ( (rval = mchMsgWriteReadHelper( mchData->mchSess, mchData->ipmiSess, message, messageSize, response, &responseSize, cmd, netfn, offs/*need to set codeoffs*/, 0 )) )
-		goto bail;
+    if ((rval = mchMsgWriteReadHelper(mchData->mchSess, mchData->ipmiSess, message, messageSize, response,
+                                      &responseSize, cmd, netfn, offs /*need to set codeoffs*/, 0))) {
+        goto bail;
+    }
 
-	if ( (rval = mchMsgCheckSizes( sizeof( response ), roffs, payloadSize )) ) {
-		printf("mchMsgSetFanLevelVt size error\n");
-		goto bail;
-	}
-	memcpy( data, response + roffs, payloadSize );
+    if ((rval = mchMsgCheckSizes(sizeof(response), roffs, payloadSize))) {
+        printf("mchMsgSetFanLevelVt size error\n");
+        goto bail;
+    }
+    memcpy(data, response + roffs, payloadSize);
 
 bail:
-	return rval;
+    return rval;
 }
 
 /* Set Fan Level using NAT MCH; message contains 2 bridged messages
@@ -1115,61 +1106,62 @@ bail:
  *            0 on success
  *            non-zero for error
  */
-int
-mchMsgSetFanLevelNat(MchData mchData, uint8_t *data, uint8_t fruIndex, uint8_t level)
-{
-uint8_t  message[MSG_MAX_LENGTH]  = { 0 };
-uint8_t  response[MSG_MAX_LENGTH] = { 0 };
-size_t   imsg2Size    = sizeof( SEND_MSG_MSG );
-size_t   b1msg1Size   = sizeof( IPMI_MSG1 );
-size_t   b1msg2Size   = sizeof( SEND_MSG_MSG );
-size_t   b2msg1Size   = sizeof( IPMI_MSG1 );
-size_t   b2msg2Size   = sizeof( GET_FAN_LEVEL_MSG );
-uint8_t  imsg2[imsg2Size];
-uint8_t  b1msg1[b1msg1Size];
-uint8_t  b1msg2[b1msg2Size];
-uint8_t  b2msg1[b2msg1Size];
-uint8_t  b2msg2[b2msg2Size];
-size_t   messageSize;
-size_t   offs         = IPMI_RPLY_2ND_BRIDGED_OFFSET_NAT;
-size_t   roffs        = IPMI_RPLY_HEADER_LENGTH + 3 + offs;
-size_t   payloadSize  = IPMI_RPLY_SET_FAN_LEVEL_LENGTH;
-size_t   responseSize = roffs + payloadSize + FOOTER_LENGTH;
-uint8_t  cmd          = IPMI_MSG_CMD_SET_FAN_LEVEL;
-uint8_t  netfn        = IPMI_MSG_NETFN_PICMG;
-int      rval;
-uint8_t  fruId = mchData->mchSys->fru[fruIndex].sdr.fruId;
+int mchMsgSetFanLevelNat(MchData mchData, uint8_t* data, uint8_t fruIndex, uint8_t level) {
+    uint8_t message[MSG_MAX_LENGTH]  = {0};
+    uint8_t response[MSG_MAX_LENGTH] = {0};
+    size_t  imsg2Size                = sizeof(SEND_MSG_MSG);
+    size_t  b1msg1Size               = sizeof(IPMI_MSG1);
+    size_t  b1msg2Size               = sizeof(SEND_MSG_MSG);
+    size_t  b2msg1Size               = sizeof(IPMI_MSG1);
+    size_t  b2msg2Size               = sizeof(GET_FAN_LEVEL_MSG);
+    uint8_t imsg2[imsg2Size];
+    uint8_t b1msg1[b1msg1Size];
+    uint8_t b1msg2[b1msg2Size];
+    uint8_t b2msg1[b2msg1Size];
+    uint8_t b2msg2[b2msg2Size];
+    size_t  messageSize;
+    size_t  offs         = IPMI_RPLY_2ND_BRIDGED_OFFSET_NAT;
+    size_t  roffs        = IPMI_RPLY_HEADER_LENGTH + 3 + offs;
+    size_t  payloadSize  = IPMI_RPLY_SET_FAN_LEVEL_LENGTH;
+    size_t  responseSize = roffs + payloadSize + FOOTER_LENGTH;
+    uint8_t cmd          = IPMI_MSG_CMD_SET_FAN_LEVEL;
+    uint8_t netfn        = IPMI_MSG_NETFN_PICMG;
+    int     rval;
+    uint8_t fruId = mchData->mchSys->fru[fruIndex].sdr.fruId;
 
-	memcpy( imsg2,  SEND_MSG_MSG , imsg2Size  );
-	memcpy( b1msg1, IPMI_MSG1    , b1msg1Size );
+    memcpy(imsg2, SEND_MSG_MSG, imsg2Size);
+    memcpy(b1msg1, IPMI_MSG1, b1msg1Size);
 
-	imsg2[IPMI_MSG2_CHAN_OFFSET]    = IPMI_MSG_CHAN_IPMB0 + IPMI_MSG_TRACKING;
-	b1msg1[IPMI_MSG1_RSADDR_OFFSET] = IPMI_MSG_ADDR_CM;
+    imsg2[IPMI_MSG2_CHAN_OFFSET]    = IPMI_MSG_CHAN_IPMB0 + IPMI_MSG_TRACKING;
+    b1msg1[IPMI_MSG1_RSADDR_OFFSET] = IPMI_MSG_ADDR_CM;
 
-	memcpy( b1msg2, SEND_MSG_MSG      , b1msg2Size );
-	memcpy( b2msg1, IPMI_MSG1         , b2msg1Size );
-	memcpy( b2msg2, SET_FAN_LEVEL_MSG , b2msg2Size );
+    memcpy(b1msg2, SEND_MSG_MSG, b1msg2Size);
+    memcpy(b2msg1, IPMI_MSG1, b2msg1Size);
+    memcpy(b2msg2, SET_FAN_LEVEL_MSG, b2msg2Size);
 
-	b1msg2[IPMI_MSG2_RQADDR_OFFSET]   = IPMI_MSG_ADDR_BMC;
-	b2msg1[IPMI_MSG1_NETFNLUN_OFFSET] = netfn << 2;
-	b1msg2[IPMI_MSG2_CHAN_OFFSET]     = IPMI_MSG_CHAN_IPMBL + IPMI_MSG_TRACKING;
-	b2msg1[IPMI_MSG1_RSADDR_OFFSET]   = FRU_I2C_ADDR[fruId];
-	b2msg2[IPMI_MSG2_SET_FRU_ACT_FRU_OFFSET] = 0;
-	b2msg2[IPMI_MSG2_SET_FAN_LEVEL_OFFSET] = level;
+    b1msg2[IPMI_MSG2_RQADDR_OFFSET]          = IPMI_MSG_ADDR_BMC;
+    b2msg1[IPMI_MSG1_NETFNLUN_OFFSET]        = netfn << 2;
+    b1msg2[IPMI_MSG2_CHAN_OFFSET]            = IPMI_MSG_CHAN_IPMBL + IPMI_MSG_TRACKING;
+    b2msg1[IPMI_MSG1_RSADDR_OFFSET]          = FRU_I2C_ADDR[fruId];
+    b2msg2[IPMI_MSG2_SET_FRU_ACT_FRU_OFFSET] = 0;
+    b2msg2[IPMI_MSG2_SET_FAN_LEVEL_OFFSET]   = level;
 
-       	messageSize = ipmiMsgBuild( mchData->ipmiSess, message, cmd, IPMI_MSG_NETFN_APP_REQUEST, imsg2, imsg2Size, b1msg1, b1msg2, b1msg2Size, b2msg1, b2msg2, b2msg2Size );
+    messageSize = ipmiMsgBuild(mchData->ipmiSess, message, cmd, IPMI_MSG_NETFN_APP_REQUEST, imsg2, imsg2Size, b1msg1,
+                               b1msg2, b1msg2Size, b2msg1, b2msg2, b2msg2Size);
 
-	if ( (rval = mchMsgWriteReadHelper( mchData->mchSess, mchData->ipmiSess, message, messageSize, response, &responseSize, cmd, netfn, offs/*need to set codeoffs*/, 0 )) )
-		goto bail;
+    if ((rval = mchMsgWriteReadHelper(mchData->mchSess, mchData->ipmiSess, message, messageSize, response,
+                                      &responseSize, cmd, netfn, offs /*need to set codeoffs*/, 0))) {
+        goto bail;
+    }
 
-	if ( (rval = mchMsgCheckSizes( sizeof( response ), roffs, payloadSize )) ) {
-		printf("mchMsgSetFanLevelNat size error\n");
-		goto bail;
-	}
-	memcpy( data, response + roffs, payloadSize );
-    
+    if ((rval = mchMsgCheckSizes(sizeof(response), roffs, payloadSize))) {
+        printf("mchMsgSetFanLevelNat size error\n");
+        goto bail;
+    }
+    memcpy(data, response + roffs, payloadSize);
+
 bail:
-	return rval;
+    return rval;
 }
 
 /* Set Fan Level - For ATCA
@@ -1179,74 +1171,76 @@ bail:
  *            0 on success
  *            non-zero for error
  */
-int
-mchMsgSetFanLevelAtca(MchData mchData, uint8_t *data, uint8_t fruIndex, uint8_t level)
-{
-uint8_t  response[MSG_MAX_LENGTH] = { 0 }; 
-size_t   roffs, responseSize = 0, payloadSize = IPMI_RPLY_SET_FAN_LEVEL_LENGTH; 
-int      rval, bridged = 0;
-Fru      fru = &mchData->mchSys->fru[fruIndex];
-uint8_t  rsAddr = fru->sdr.addr, rqAddr;
+int mchMsgSetFanLevelAtca(MchData mchData, uint8_t* data, uint8_t fruIndex, uint8_t level) {
+    uint8_t response[MSG_MAX_LENGTH] = {0};
+    size_t  roffs, responseSize = 0, payloadSize = IPMI_RPLY_SET_FAN_LEVEL_LENGTH;
+    int     rval, bridged = 0;
+    Fru     fru    = &mchData->mchSys->fru[fruIndex];
+    uint8_t rsAddr = fru->sdr.addr, rqAddr;
 
-	if ( rsAddr != IPMI_MSG_ADDR_BMC )
-		bridged = 1;
+    if (rsAddr != IPMI_MSG_ADDR_BMC) {
+        bridged = 1;
+    }
 
-	mchSetSizeOffs( mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr );
+    mchSetSizeOffs(mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr);
 
-	if ( (rval = ipmiMsgSetFanLevel( mchData->mchSess, mchData->ipmiSess, response, bridged, rsAddr, rqAddr, &responseSize, roffs, fru->sdr.fruId, level )) )
-		goto bail;
+    if ((rval = ipmiMsgSetFanLevel(mchData->mchSess, mchData->ipmiSess, response, bridged, rsAddr, rqAddr,
+                                   &responseSize, roffs, fru->sdr.fruId, level))) {
+        goto bail;
+    }
 
-	if ( (rval = mchMsgCheckSizes( sizeof( response ), roffs, payloadSize )) ) {
-		printf("mchMsgSetFanLevelAtca size error\n");
-		goto bail;
-	}
+    if ((rval = mchMsgCheckSizes(sizeof(response), roffs, payloadSize))) {
+        printf("mchMsgSetFanLevelAtca size error\n");
+        goto bail;
+    }
 
-	memcpy( data, response + roffs, payloadSize );
+    memcpy(data, response + roffs, payloadSize);
 
 bail:
-	return rval;
+    return rval;
 }
 
 /*  -> needs updating 3/23/16 */
-int
-mchMsgGetPowerLevelVt(MchData mchData, uint8_t *data, uint8_t fruIndex, uint8_t parm)
-{
-uint8_t  message[MSG_MAX_LENGTH] = { 0 };
-uint8_t  imsg2Size = sizeof( GET_POWER_LEVEL_MSG );
-uint8_t  imsg2[imsg2Size];
-size_t   messageSize;
-Fru      fru = &mchData->mchSys->fru[fruIndex];
+int mchMsgGetPowerLevelVt(MchData mchData, uint8_t* data, uint8_t fruIndex, uint8_t parm) {
+    uint8_t message[MSG_MAX_LENGTH] = {0};
+    uint8_t imsg2Size               = sizeof(GET_POWER_LEVEL_MSG);
+    uint8_t imsg2[imsg2Size];
+    size_t  messageSize;
+    Fru     fru = &mchData->mchSys->fru[fruIndex];
 
-uint8_t  response[MSG_MAX_LENGTH] = { 0 }; 
-size_t   roffs, responseSize, payloadSize = IPMI_RPLY_GET_POWER_LEVEL_LENGTH; 
-int      rval, offs=0, bridged = 0;
-uint8_t  rsAddr = IPMI_MSG_ADDR_BMC, rqAddr;
-uint8_t  cmd   = IPMI_MSG_CMD_GET_POWER_LEVEL;
-uint8_t  netfn = IPMI_MSG_NETFN_PICMG;
+    uint8_t response[MSG_MAX_LENGTH] = {0};
+    size_t  roffs, responseSize, payloadSize = IPMI_RPLY_GET_POWER_LEVEL_LENGTH;
+    int     rval, offs = 0, bridged = 0;
+    uint8_t rsAddr = IPMI_MSG_ADDR_BMC, rqAddr;
+    uint8_t cmd    = IPMI_MSG_CMD_GET_POWER_LEVEL;
+    uint8_t netfn  = IPMI_MSG_NETFN_PICMG;
 
-	mchSetSizeOffs( mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr);
+    mchSetSizeOffs(mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr);
 
-	memcpy( imsg2, GET_POWER_LEVEL_MSG, imsg2Size );
+    memcpy(imsg2, GET_POWER_LEVEL_MSG, imsg2Size);
 
-	imsg2[IPMI_MSG2_SET_FRU_ACT_FRU_OFFSET]      = fru->sdr.fruId;
-	imsg2[PICMG_RPLY_IMSG2_GET_POWER_LEVEL_TYPE_OFFSET] = parm;
+    imsg2[IPMI_MSG2_SET_FRU_ACT_FRU_OFFSET]             = fru->sdr.fruId;
+    imsg2[PICMG_RPLY_IMSG2_GET_POWER_LEVEL_TYPE_OFFSET] = parm;
 
-	if ( bridged ) // may need to distinguish between once and twice-bridged messages
-		ipmiBuildSendMsg( mchData->ipmiSess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0 );
-	else
-		messageSize = ipmiMsgBuild( mchData->ipmiSess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0 );
+    if (bridged) { // may need to distinguish between once and twice-bridged messages
+        ipmiBuildSendMsg(mchData->ipmiSess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0);
+    } else {
+        messageSize = ipmiMsgBuild(mchData->ipmiSess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0);
+    }
 
-	if ( (rval = mchMsgWriteReadHelper( mchData->mchSess, mchData->ipmiSess, message, messageSize, response, &responseSize, cmd, netfn, offs/*need to set codeoffs*/, 0 )) )
-		goto bail;
+    if ((rval = mchMsgWriteReadHelper(mchData->mchSess, mchData->ipmiSess, message, messageSize, response,
+                                      &responseSize, cmd, netfn, offs /*need to set codeoffs*/, 0))) {
+        goto bail;
+    }
 
-	if ( (rval = mchMsgCheckSizes( sizeof( response ), roffs, payloadSize )) ) {
-		printf("mchMsgGetPowerLevelVt size error\n");
-		goto bail;
-	}
-	memcpy( data, response + roffs, payloadSize );
+    if ((rval = mchMsgCheckSizes(sizeof(response), roffs, payloadSize))) {
+        printf("mchMsgGetPowerLevelVt size error\n");
+        goto bail;
+    }
+    memcpy(data, response + roffs, payloadSize);
 
 bail:
-	return rval;
+    return rval;
 }
 
 /* Set Fan Level - For ATCA
@@ -1256,83 +1250,81 @@ bail:
  *            0 on success
  *            non-zero for error
  */
-int
-mchMsgGetPowerLevelAtca(MchData mchData, uint8_t *data, uint8_t fruIndex, uint8_t parm)
-{
-uint8_t  response[MSG_MAX_LENGTH] = { 0 }; 
-size_t   roffs, responseSize = 0, payloadSize = IPMI_RPLY_GET_POWER_LEVEL_LENGTH; 
-int      rval, bridged = 0;
-Fru      fru = &mchData->mchSys->fru[fruIndex];
-uint8_t  rsAddr = fru->sdr.addr, rqAddr;
+int mchMsgGetPowerLevelAtca(MchData mchData, uint8_t* data, uint8_t fruIndex, uint8_t parm) {
+    uint8_t response[MSG_MAX_LENGTH] = {0};
+    size_t  roffs, responseSize = 0, payloadSize = IPMI_RPLY_GET_POWER_LEVEL_LENGTH;
+    int     rval, bridged = 0;
+    Fru     fru    = &mchData->mchSys->fru[fruIndex];
+    uint8_t rsAddr = fru->sdr.addr, rqAddr;
 
-	if ( rsAddr != IPMI_MSG_ADDR_BMC )
-		bridged = 1;
+    if (rsAddr != IPMI_MSG_ADDR_BMC) {
+        bridged = 1;
+    }
 
-	mchSetSizeOffs( mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr );
+    mchSetSizeOffs(mchData->ipmiSess, payloadSize, &roffs, &responseSize, &bridged, &rsAddr, &rqAddr);
 
-	if ( (rval = ipmiMsgGetPowerLevel( mchData->mchSess, mchData->ipmiSess, response, bridged, rsAddr, rqAddr, &responseSize, roffs, fru->sdr.fruId, parm )) )
-		goto bail;
+    if ((rval = ipmiMsgGetPowerLevel(mchData->mchSess, mchData->ipmiSess, response, bridged, rsAddr, rqAddr,
+                                     &responseSize, roffs, fru->sdr.fruId, parm))) {
+        goto bail;
+    }
 
-	if ( (rval = mchMsgCheckSizes( sizeof( response ), roffs, payloadSize )) ) {
-		printf("mchMsgSetFanLevelAtca size error\n");
-		goto bail;
-	}
+    if ((rval = mchMsgCheckSizes(sizeof(response), roffs, payloadSize))) {
+        printf("mchMsgSetFanLevelAtca size error\n");
+        goto bail;
+    }
 
-	memcpy( data, response + roffs, payloadSize );
+    memcpy(data, response + roffs, payloadSize);
 
 bail:
-	return rval;
+    return rval;
 }
 
-
 MchCbRec drvMchMicrotcaVtCb = {
-    assign_sys_sizes: 0,   
-    assign_site_info: 0,
-    assign_fru_lkup:  assign_fru_lkup_microtca,
-    fru_data_suppl:   fru_data_suppl_picmg,
-    sensor_get_fru:   sensor_get_fru_microtca,
-    get_chassis_status: 0,
-    set_fru_act:      mchMsgSetFruActPolicyVt,
-    get_fan_prop:     mchMsgGetFanPropVt,
-    get_fan_level:    mchMsgGetFanLevelVt,
-    set_fan_level:    mchMsgSetFanLevelVt,
-    get_power_level:  mchMsgGetPowerLevelVt
+    assign_sys_sizes : 0,
+    assign_site_info : 0,
+    assign_fru_lkup : assign_fru_lkup_microtca,
+    fru_data_suppl : fru_data_suppl_picmg,
+    sensor_get_fru : sensor_get_fru_microtca,
+    get_chassis_status : 0,
+    set_fru_act : mchMsgSetFruActPolicyVt,
+    get_fan_prop : mchMsgGetFanPropVt,
+    get_fan_level : mchMsgGetFanLevelVt,
+    set_fan_level : mchMsgSetFanLevelVt,
+    get_power_level : mchMsgGetPowerLevelVt
 };
 
 MchCbRec drvMchMicrotcaNatCb = {
-    assign_sys_sizes: 0,   
-    assign_site_info: 0,
-    assign_fru_lkup:  assign_fru_lkup_microtca,
-    fru_data_suppl:   fru_data_suppl_picmg,
-    sensor_get_fru:   sensor_get_fru_microtca,
-    get_chassis_status: 0,
-    set_fru_act:      mchMsgSetFruActNat,
-    get_fan_prop:     mchMsgGetFanPropNat,
-    get_fan_level:    mchMsgGetFanLevelNat,
-    set_fan_level:    mchMsgSetFanLevelNat,
-    get_power_level:  0
+    assign_sys_sizes : 0,
+    assign_site_info : 0,
+    assign_fru_lkup : assign_fru_lkup_microtca,
+    fru_data_suppl : fru_data_suppl_picmg,
+    sensor_get_fru : sensor_get_fru_microtca,
+    get_chassis_status : 0,
+    set_fru_act : mchMsgSetFruActNat,
+    get_fan_prop : mchMsgGetFanPropNat,
+    get_fan_level : mchMsgGetFanLevelNat,
+    set_fan_level : mchMsgSetFanLevelNat,
+    get_power_level : 0
 };
 
 MchCbRec drvMchAtcaCb = {
-    assign_sys_sizes: assign_sys_sizes_atca,   
-    assign_site_info: assign_site_info_atca,
-    assign_fru_lkup:  assign_fru_lkup_atca,
-    fru_data_suppl:   fru_data_suppl_picmg,
-    sensor_get_fru:   sensor_get_fru_atca,
-    get_chassis_status: mchMsgGetChassisStatus,
-    set_fru_act:      mchMsgSetFruActAtca,
-    get_fan_prop:     mchMsgGetFanPropAtca,
-    get_fan_level:    mchMsgGetFanLevelAtca,
-    set_fan_level:    mchMsgSetFanLevelAtca,
-    get_power_level:  mchMsgGetPowerLevelAtca
+    assign_sys_sizes : assign_sys_sizes_atca,
+    assign_site_info : assign_site_info_atca,
+    assign_fru_lkup : assign_fru_lkup_atca,
+    fru_data_suppl : fru_data_suppl_picmg,
+    sensor_get_fru : sensor_get_fru_atca,
+    get_chassis_status : mchMsgGetChassisStatus,
+    set_fru_act : mchMsgSetFruActAtca,
+    get_fan_prop : mchMsgGetFanPropAtca,
+    get_fan_level : mchMsgGetFanLevelAtca,
+    set_fan_level : mchMsgSetFanLevelAtca,
+    get_power_level : mchMsgGetPowerLevelAtca
 };
 
-static void
-drvMchPicmgRegistrar(void)
-{
-	registryAdd( (void*)mchCbRegistryId, "drvMchMicrotcaVtCb",  &drvMchMicrotcaVtCb );
-	registryAdd( (void*)mchCbRegistryId, "drvMchMicrotcaNatCb", &drvMchMicrotcaNatCb );
-	registryAdd( (void*)mchCbRegistryId, "drvMchAtcaCb",        &drvMchAtcaCb );
+static void drvMchPicmgRegistrar(void) {
+    registryAdd((void*)mchCbRegistryId, "drvMchMicrotcaVtCb", &drvMchMicrotcaVtCb);
+    registryAdd((void*)mchCbRegistryId, "drvMchMicrotcaNatCb", &drvMchMicrotcaNatCb);
+    registryAdd((void*)mchCbRegistryId, "drvMchAtcaCb", &drvMchAtcaCb);
 }
 
 epicsExportRegistrar(drvMchPicmgRegistrar);

--- a/src/drvMchServerPc.c
+++ b/src/drvMchServerPc.c
@@ -1,10 +1,10 @@
 //////////////////////////////////////////////////////////////////////////////
 // This file is part of 'ipmiComm'.
-// It is subject to the license terms in the LICENSE.txt file found in the 
-// top-level directory of this distribution and at: 
-//    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
-// No part of 'ipmiComm', including this file, 
-// may be copied, modified, propagated, or distributed except according to 
+// It is subject to the license terms in the LICENSE.txt file found in the
+// top-level directory of this distribution and at:
+//    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+// No part of 'ipmiComm', including this file,
+// may be copied, modified, propagated, or distributed except according to
 // the terms contained in the LICENSE.txt file.
 //////////////////////////////////////////////////////////////////////////////
 #include <stdint.h>
@@ -19,106 +19,89 @@
 #include <drvMchMsg.h>
 #include <ipmiMsg.h>
 
-static void
-assign_sys_sizes_supermicro(MchData mchData)
-{
-	mchData->mchSys->fruCountMax  = 1;
-	mchData->mchSys->mgmtCountMax = 1;
+static void assign_sys_sizes_supermicro(MchData mchData) {
+    mchData->mchSys->fruCountMax  = 1;
+    mchData->mchSys->mgmtCountMax = 1;
 }
 
-static void
-sensor_get_fru_supermicro(MchData mchData, Sensor sens)
-{
-	/* Supermicro does not use FRU device locator records, so no means to read a FRU ID
-	 * Associate all Supermicro and Advantech sensors with single FRU, arbitrarily choose 0
-	 */
-	sens->fruId = sens->fruIndex = 0;
+static void sensor_get_fru_supermicro(MchData mchData, Sensor sens) {
+    /* Supermicro does not use FRU device locator records, so no means to read a FRU ID
+     * Associate all Supermicro and Advantech sensors with single FRU, arbitrarily choose 0
+     */
+    sens->fruId = sens->fruIndex = 0;
 }
 
-static void
-assign_fru_lkup_supermicro(MchData mchData)
-{
-uint8_t id, index;
+static void assign_fru_lkup_supermicro(MchData mchData) {
+    uint8_t id, index;
 
-	/* Supermicro does not use FRU device locator records, so no means to read a FRU ID
-	 * Associate all Supermicro and Advantech sensors with single FRU, arbitrarily choose 0
-	 * Set FRU address to BMC 
-	 * Force FRU count to be 1
-	 */
-	id = index = 0;
-	mchData->mchSys->fru[index].id = id;
-	mchData->mchSys->fru[index].sdr.addr = IPMI_MSG_ADDR_BMC;
-	mchData->mchSys->fruLkup[id] = index;
-	mchData->mchSys->fruCount = 1;
-
+    /* Supermicro does not use FRU device locator records, so no means to read a FRU ID
+     * Associate all Supermicro and Advantech sensors with single FRU, arbitrarily choose 0
+     * Set FRU address to BMC
+     * Force FRU count to be 1
+     */
+    id = index                           = 0;
+    mchData->mchSys->fru[index].id       = id;
+    mchData->mchSys->fru[index].sdr.addr = IPMI_MSG_ADDR_BMC;
+    mchData->mchSys->fruLkup[id]         = index;
+    mchData->mchSys->fruCount            = 1;
 }
 
-static void
-sensor_get_fru_advantech(MchData mchData, Sensor sens)
-{
-int i;
-Fru fru;
-	/* Associate all Supermicro and Advantech sensors with single FRU, ID 0 */
-	sens->fruId = 0;
-	for ( i = 0; i < mchData->mchSys->fruCount; i++ ) {
-		fru = &mchData->mchSys->fru[i];
-		if ( (fru->id == 0) )  {
-			sens->fruIndex = i;
-			break;
-		}
-	}
+static void sensor_get_fru_advantech(MchData mchData, Sensor sens) {
+    int i;
+    Fru fru;
+    /* Associate all Supermicro and Advantech sensors with single FRU, ID 0 */
+    sens->fruId = 0;
+    for (i = 0; i < mchData->mchSys->fruCount; i++) {
+        fru = &mchData->mchSys->fru[i];
+        if ((fru->id == 0)) {
+            sens->fruIndex = i;
+            break;
+        }
+    }
 }
 
-static void
-assign_fru_lkup_advantech(MchData mchData)
-{
-int i, found = 0;
-Fru fru;
-	for ( i = 0; i < mchData->mchSys->fruCount ; i++ ) {
+static void assign_fru_lkup_advantech(MchData mchData) {
+    int i, found = 0;
+    Fru fru;
+    for (i = 0; i < mchData->mchSys->fruCount; i++) {
 
-	       	fru = &mchData->mchSys->fru[i];
+        fru = &mchData->mchSys->fru[i];
 
-		if ( fru->sdr.recType ) { /* If real entity */
+        if (fru->sdr.recType) { /* If real entity */
 
-			fru->id = fru->sdr.fruId;
-			mchData->mchSys->fruLkup[fru->id] = i;
-			if ( fru->id == 0 )
-				found = 1;
-		}
-	}
-	if ( found == 0 ) { /* If FRU 0 not already in the data structure, add it */
-		fru = &mchData->mchSys->fru[mchData->mchSys->fruCount];
-		fru->id = 0;
-		mchData->mchSys->fruLkup[fru->id] = i;
-		fru->sdr.addr = IPMI_MSG_ADDR_BMC;
-		mchData->mchSys->fruCount++;		
-	}
-
+            fru->id                           = fru->sdr.fruId;
+            mchData->mchSys->fruLkup[fru->id] = i;
+            if (fru->id == 0) {
+                found = 1;
+            }
+        }
+    }
+    if (found == 0) { /* If FRU 0 not already in the data structure, add it */
+        fru                               = &mchData->mchSys->fru[mchData->mchSys->fruCount];
+        fru->id                           = 0;
+        mchData->mchSys->fruLkup[fru->id] = i;
+        fru->sdr.addr                     = IPMI_MSG_ADDR_BMC;
+        mchData->mchSys->fruCount++;
+    }
 }
 
-MchCbRec drvMchSupermicroCb = {
-    .assign_sys_sizes	= assign_sys_sizes_supermicro,   
-    .assign_site_info	= 0,
-    .assign_fru_lkup	= assign_fru_lkup_supermicro,
-    .fru_data_suppl		= 0,
-    .sensor_get_fru		= sensor_get_fru_supermicro,
-    .get_chassis_status	= mchMsgGetChassisStatus
-};
+MchCbRec drvMchSupermicroCb = {.assign_sys_sizes   = assign_sys_sizes_supermicro,
+                               .assign_site_info   = 0,
+                               .assign_fru_lkup    = assign_fru_lkup_supermicro,
+                               .fru_data_suppl     = 0,
+                               .sensor_get_fru     = sensor_get_fru_supermicro,
+                               .get_chassis_status = mchMsgGetChassisStatus};
 
-MchCbRec drvMchAdvantechCb = {
-    .assign_sys_sizes 	= 0,   
-    .assign_site_info 	= 0,
-    .assign_fru_lkup 	= assign_fru_lkup_advantech,
-    .fru_data_suppl 	= 0,
-    .sensor_get_fru 	= sensor_get_fru_advantech,
-    .get_chassis_status = mchMsgGetChassisStatus
-};
+MchCbRec drvMchAdvantechCb = {.assign_sys_sizes   = 0,
+                              .assign_site_info   = 0,
+                              .assign_fru_lkup    = assign_fru_lkup_advantech,
+                              .fru_data_suppl     = 0,
+                              .sensor_get_fru     = sensor_get_fru_advantech,
+                              .get_chassis_status = mchMsgGetChassisStatus};
 
-static void
-drvMchServerPcRegistrar(void)
-{
-	registryAdd( (void*)mchCbRegistryId, "drvMchSupermicroCb", &drvMchSupermicroCb );
-	registryAdd( (void*)mchCbRegistryId, "drvMchAdvantechCb",  &drvMchAdvantechCb );
+static void drvMchServerPcRegistrar(void) {
+    registryAdd((void*)mchCbRegistryId, "drvMchSupermicroCb", &drvMchSupermicroCb);
+    registryAdd((void*)mchCbRegistryId, "drvMchAdvantechCb", &drvMchAdvantechCb);
 }
 
 epicsExportRegistrar(drvMchServerPcRegistrar);

--- a/src/ipmiDef.c
+++ b/src/ipmiDef.c
@@ -1,26 +1,27 @@
 //////////////////////////////////////////////////////////////////////////////
 // This file is part of 'ipmiComm'.
-// It is subject to the license terms in the LICENSE.txt file found in the 
-// top-level directory of this distribution and at: 
-//    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
-// No part of 'ipmiComm', including this file, 
-// may be copied, modified, propagated, or distributed except according to 
+// It is subject to the license terms in the LICENSE.txt file found in the
+// top-level directory of this distribution and at:
+//    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+// No part of 'ipmiComm', including this file,
+// may be copied, modified, propagated, or distributed except according to
 // the terms contained in the LICENSE.txt file.
 //////////////////////////////////////////////////////////////////////////////
+// clang-format off
 #include <inttypes.h>
 #include <ipmiMsg.h>
 
-uint8_t RMCP_HEADER[] = { RMCP_MSG_VER,           /* RMCP message version */	     
-                          0,		          /* Reserved */		     
-                          RMCP_MSG_SEQ,	          /* RMCP message header */	     
-                          RMCP_MSG_CLASS_IPMI };  /* Message class */		     
+uint8_t RMCP_HEADER[] = {RMCP_MSG_VER,         /* RMCP message version */
+                         0,                    /* Reserved */
+                         RMCP_MSG_SEQ,         /* RMCP message header */
+                         RMCP_MSG_CLASS_IPMI}; /* Message class */
 
 /* ASF message, used only for Presence Ping */
-uint8_t ASF_MSG[]     = { 0, 0, 0x11, 0xBE,       /* ASF IANA Enterprise number */	     
-                          0x80,		          /* Message type, Presence Ping */		     
-                          0,	                  /* Message tag */	     
-                          0,                      /* Reserved */
-			  0 };                    /* Data length */		     
+uint8_t ASF_MSG[] = {0,    0, 0x11, 0xBE, /* ASF IANA Enterprise number */
+                     0x80,                /* Message type, Presence Ping */
+                     0,                   /* Message tag */
+                     0,                   /* Reserved */
+                     0};                  /* Data length */
 
 /* For messages with authentication type = NONE */
 uint8_t IPMI_WRAPPER[] = { IPMI_MSG_AUTH_TYPE_NONE,/* Auth type none */
@@ -33,146 +34,145 @@ uint8_t IPMI_WRAPPER_PWD_KEY[] = { IPMI_MSG_AUTH_TYPE_PWD_KEY, /* Auth type */
                           0, 0, 0, 0,             /* 4-byte Session sequence number */
                           0, 0, 0, 0,             /* 4-byte Session ID */
                           'I', 'p', 'm', 'i', '2', 'A', 'd', 'm', 'i', 'n', 0, 0, 0, 0, 0, 0, /* Message Authentication Code (password) */
-                          0 };                    /* Number of bytes in message */
+                          0};
 
 /* IPMI message part 1 */
-uint8_t IPMI_MSG1[]   = { IPMI_MSG_ADDR_BMC,	           /* Responder's address */
-		          IPMI_MSG_NETFN_APP_REQUEST << 2, /* Network function code/LUN */
-		          0 };                             /* For checksum */
+uint8_t IPMI_MSG1[] = {IPMI_MSG_ADDR_BMC,               /* Responder's address */
+                       IPMI_MSG_NETFN_APP_REQUEST << 2, /* Network function code/LUN */
+                       0};                              /* For checksum */
 
-size_t IPMI_MSG1_LENGTH = sizeof( IPMI_MSG1 );
-size_t IPMI_WRAPPER_LENGTH = sizeof( IPMI_WRAPPER );
-size_t IPMI_WRAPPER_AUTH_LENGTH = sizeof( IPMI_WRAPPER_PWD_KEY );
-
+size_t IPMI_MSG1_LENGTH         = sizeof(IPMI_MSG1);
+size_t IPMI_WRAPPER_LENGTH      = sizeof(IPMI_WRAPPER);
+size_t IPMI_WRAPPER_AUTH_LENGTH = sizeof(IPMI_WRAPPER_PWD_KEY);
 
 /*
  *  Below are IPMI messages part 2 - all variations we use
  */
 
 /* Get Authentication Capabilities */
-uint8_t GET_AUTH_MSG_ADMIN[] = { IPMI_MSG_ADDR_SW,	       /* Requester's address */		   
-		           0,			       /* Message sequence number */	    
-		           IPMI_MSG_CMD_GET_CHAN_AUTH, /* Command code */	   
-		           IPMI_MSG_CURR_CHAN,         /* Channel number */   
-		           IPMI_MSG_PRIV_LEVEL_ADMIN,  /* Privilege level */
-                           0 };                        /* For checksum */
+uint8_t GET_AUTH_MSG_ADMIN[] = {IPMI_MSG_ADDR_SW,           /* Requester's address */
+                                0,                          /* Message sequence number */
+                                IPMI_MSG_CMD_GET_CHAN_AUTH, /* Command code */
+                                IPMI_MSG_CURR_CHAN,         /* Channel number */
+                                IPMI_MSG_PRIV_LEVEL_ADMIN,  /* Privilege level */
+                                0};                         /* For checksum */
 
 /* Get Authentication Capabilities */
-uint8_t GET_AUTH_MSG[] = { IPMI_MSG_ADDR_SW,	       /* Requester's address */		   
-		           0,			       /* Message sequence number */	    
-		           IPMI_MSG_CMD_GET_CHAN_AUTH, /* Command code */	   
-		           IPMI_MSG_CURR_CHAN,         /* Channel number */   
-		           IPMI_MSG_PRIV_LEVEL_OPER,  /* Privilege level */
-                           0 };                        /* For checksum */
+uint8_t GET_AUTH_MSG[] = {IPMI_MSG_ADDR_SW,           /* Requester's address */
+                          0,                          /* Message sequence number */
+                          IPMI_MSG_CMD_GET_CHAN_AUTH, /* Command code */
+                          IPMI_MSG_CURR_CHAN,         /* Channel number */
+                          IPMI_MSG_PRIV_LEVEL_OPER,   /* Privilege level */
+                          0};                         /* For checksum */
 
 /* Get Session Challenge, no-authentication version */
-uint8_t GET_SESS_MSG[] = { IPMI_MSG_ADDR_SW,	               /* Requester's address */		   
-			   0,			               /* Message sequence number */	    
-			   IPMI_MSG_CMD_GET_SESSION_CHALLENGE, /* Command code */	   
-			   IPMI_MSG_AUTH_TYPE_NONE,            /* Authentication type */   
-			   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* Null user name */
-                           0 };                                /* For checksum */
+uint8_t GET_SESS_MSG[] = {IPMI_MSG_ADDR_SW,                   /* Requester's address */
+                          0,                                  /* Message sequence number */
+                          IPMI_MSG_CMD_GET_SESSION_CHALLENGE, /* Command code */
+                          IPMI_MSG_AUTH_TYPE_NONE,            /* Authentication type */
+                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  /* Null user name */
+                          0}; /* For checksum */
 
 /* Get Session Challenge, with password/key authentication */
-uint8_t GET_SESS_MSG_PWD_KEY[] = { IPMI_MSG_ADDR_SW,	       /* Requester's address */		   
-			   0,			               /* Message sequence number */	    
-			   IPMI_MSG_CMD_GET_SESSION_CHALLENGE, /* Command code */	   
-			   IPMI_MSG_AUTH_TYPE_PWD_KEY,         /* Authentication type */   
-			   'c', 'o', 'n', 't', 'r', 'o', 'l', 's', 0, 0, 0, 0, 0, 0, 0, 0, /* User name */
-                           0 };                                /* For checksum */
+uint8_t GET_SESS_MSG_PWD_KEY[] = {IPMI_MSG_ADDR_SW,                   /* Requester's address */
+                                  0,                                  /* Message sequence number */
+                                  IPMI_MSG_CMD_GET_SESSION_CHALLENGE, /* Command code */
+                                  IPMI_MSG_AUTH_TYPE_PWD_KEY,         /* Authentication type */
+                                  'c', 'o', 'n', 't', 'r', 'o', 'l', 's', 0, 0, 0, 0, 0, 0, 0, 0,  /* User name */
+                                  0}; /* For checksum */
 
 /* Activate Session */
-uint8_t ACT_SESS_MSG[] = { IPMI_MSG_ADDR_SW,	         /* Requester's address */		   
-			   0,			         /* Message sequence number */	    
-			   IPMI_MSG_CMD_ACTIVATE_SESSION,/* Command code */
-		           IPMI_MSG_AUTH_TYPE_NONE,      /* Authentication type (must match that in GET_SESS_MSG) */
-			   IPMI_MSG_PRIV_LEVEL_OPER,    /* Max priv level for session */   
-			   0, 0, 0, 0,                   /* For 16-byte challenge string */
-			   0, 0, 0, 0,
-			   0, 0, 0, 0,
-			   0, 0, 0, 0,
-                           IPMI_WRAPPER_SEQ_INITIAL, 0x00, 0x00, 0x00 , /* Session sequence number; set to initial value */
-                           0 };                          /* For checksum */
+uint8_t ACT_SESS_MSG[] = {IPMI_MSG_ADDR_SW,              /* Requester's address */
+                          0,                             /* Message sequence number */
+                          IPMI_MSG_CMD_ACTIVATE_SESSION, /* Command code */
+                          IPMI_MSG_AUTH_TYPE_NONE,       /* Authentication type (must match that in GET_SESS_MSG) */
+                          IPMI_MSG_PRIV_LEVEL_OPER,      /* Max priv level for session */
+                          0, 0, 0, 0, /* For 16-byte challenge string */
+                          0, 0, 0, 0,
+                          0, 0, 0, 0,
+                          0, 0, 0, 0,
+                          IPMI_WRAPPER_SEQ_INITIAL, 0x00, 0x00, 0x00, /* Session sequence number; set to initial value */
+                          0};   /* For checksum */
 
 /* Set Privilege Level */
-uint8_t SET_PRIV_MSG[] = { IPMI_MSG_ADDR_SW,	         /* Requester's address */		   
-			   0,			         /* Message sequence number */	    
-			   IPMI_MSG_CMD_SET_PRIV_LEVEL,  /* Command code */
-			   IPMI_MSG_PRIV_LEVEL_OPER,    /* Priv level for session  */   
-                           0 };                          /* For checksum */
+uint8_t SET_PRIV_MSG[] = {IPMI_MSG_ADDR_SW,            /* Requester's address */
+                          0,                           /* Message sequence number */
+                          IPMI_MSG_CMD_SET_PRIV_LEVEL, /* Command code */
+                          IPMI_MSG_PRIV_LEVEL_OPER,    /* Priv level for session  */
+                          0};                          /* For checksum */
 
 /* Send Message to other channel */
-uint8_t SEND_MSG_MSG[] = { IPMI_MSG_ADDR_SW,             /* Requester's address */            
-                           0,                            /* Message sequence number */         
-                           IPMI_MSG_CMD_SEND_MSG,        /* Command code */         
-			   0,                            /* Channel (IMPB) */
-                           0 };                          /* For checksum */
+uint8_t SEND_MSG_MSG[] = {IPMI_MSG_ADDR_SW,      /* Requester's address */
+                          0,                     /* Message sequence number */
+                          IPMI_MSG_CMD_SEND_MSG, /* Command code */
+                          0,                     /* Channel (IMPB) */
+                          0};                    /* For checksum */
 
 /* Get Sensor Reading  */
-uint8_t SENS_READ_MSG[] = { IPMI_MSG_ADDR_SW,            /* Requester's address */            
-                            0,                           /* Message sequence number */         
-                            IPMI_MSG_CMD_SENSOR_READ,    /* Command code */         
-			    0,                           /* For sensor number */
-                            0 };                         /* For checksum */
+uint8_t SENS_READ_MSG[] = {IPMI_MSG_ADDR_SW,         /* Requester's address */
+                           0,                        /* Message sequence number */
+                           IPMI_MSG_CMD_SENSOR_READ, /* Command code */
+                           0,                        /* For sensor number */
+                           0};                       /* For checksum */
 
 /* Get Sensor Thresholds  */
-uint8_t GET_SENSOR_THRESH_MSG[] = { IPMI_MSG_ADDR_SW,    /* Requester's address */            
-                            0,                           /* Message sequence number */         
-                            IPMI_MSG_CMD_GET_SENSOR_THRESH,    /* Command code */         
-			    0,                           /* For sensor number */
-                            0 };                         /* For checksum */
+uint8_t GET_SENSOR_THRESH_MSG[] = {IPMI_MSG_ADDR_SW,               /* Requester's address */
+                                   0,                              /* Message sequence number */
+                                   IPMI_MSG_CMD_GET_SENSOR_THRESH, /* Command code */
+                                   0,                              /* For sensor number */
+                                   0};                             /* For checksum */
 
 /* Read FRU Data  */
-uint8_t FRU_READ_MSG[]  = { IPMI_MSG_ADDR_SW,            /* Requester's address */            
-                            0,                           /* Message sequence number */         
-                            IPMI_MSG_CMD_READ_FRU_DATA,  /* Command code */         
-			    0,                           /* FRU device ID */
-			    0,                           /* FRU inventory offset to read, LS byte */
-			    0,                           /* FRU inventory offset to read, MS byte */
-			    0,                           /* Count to read (1-based) */
-                            0 };                         /* For checksum */
+uint8_t FRU_READ_MSG[] = {IPMI_MSG_ADDR_SW,           /* Requester's address */
+                          0,                          /* Message sequence number */
+                          IPMI_MSG_CMD_READ_FRU_DATA, /* Command code */
+                          0,                          /* FRU device ID */
+                          0,                          /* FRU inventory offset to read, LS byte */
+                          0,                          /* FRU inventory offset to read, MS byte */
+                          0,                          /* Count to read (1-based) */
+                          0};                         /* For checksum */
 
 /*  Reserve SDR Repository */
-uint8_t RESERVE_SDR_MSG[]  =  { IPMI_MSG_ADDR_SW,        /* Requester's address */            
-                            0,                           /* Message sequence number */         
-                            0,                           /* Command code */         
-                            0 };                         /* For checksum */
+uint8_t RESERVE_SDR_MSG[] = {IPMI_MSG_ADDR_SW, /* Requester's address */
+                             0,                /* Message sequence number */
+                             0,                /* Command code */
+                             0};               /* For checksum */
 
 /* Get Sensor Data Record (SDR) and Get Device SDR */
-uint8_t GET_SDR_MSG[]  =  { IPMI_MSG_ADDR_SW,            /* Requester's address */            
-                            0,                           /* Message sequence number */         
-                            0,                           /* Command code */         
-			    0, 0,                        /* Reservation ID, LS byte first */
-			    0, 0,                        /* Record ID, LS byte first */
-			    0,                           /* Offset into record to begin read */
-                            0,                           /* Bytes to read (0xFF for entire record) */
-                            0 };                         /* For checksum */
+uint8_t GET_SDR_MSG[] = {IPMI_MSG_ADDR_SW, /* Requester's address */
+                         0,                /* Message sequence number */
+                         0,                /* Command code */
+                         0, 0, /* Reservation ID, LS byte first */
+                         0, 0, /* Record ID, LS byte first */
+                         0,    /* Offset into record to begin read */
+                         0,    /* Bytes to read (0xFF for entire record) */
+                         0};   /* For checksum */
 
 /* Get Device SDR Info   */
-uint8_t GET_DEV_SDR_INFO_MSG[] = { IPMI_MSG_ADDR_SW,      /* Requester's address */            
-                            0,                             /* Message sequence number */         
-                            IPMI_MSG_CMD_GET_DEV_SDR_INFO, /* Command code */         
-			    IPMI_GET_DEV_SDR_INFO_SDR_COUNT,/* Request data, get SDR count or sensor count for specified LUN */
-                            0 };                           /* For checksum */
+uint8_t GET_DEV_SDR_INFO_MSG[] = {
+    IPMI_MSG_ADDR_SW,                /* Requester's address */
+    0,                               /* Message sequence number */
+    IPMI_MSG_CMD_GET_DEV_SDR_INFO,   /* Command code */
+    IPMI_GET_DEV_SDR_INFO_SDR_COUNT, /* Request data, get SDR count or sensor count for specified LUN */
+    0};                              /* For checksum */
 
 /* Close Session */
-uint8_t CLOSE_SESS_MSG[]= { IPMI_MSG_ADDR_SW,            /* Requester's address */            
-                            0,                           /* Message sequence number */         
-                            IPMI_MSG_CMD_CLOSE_SESSION,  /* Command code */         
-			    0, 0, 0, 0,                  /* For 4-byte session ID */
-                            0 };                         /* For checksum */
+uint8_t CLOSE_SESS_MSG[] = {IPMI_MSG_ADDR_SW,           /* Requester's address */
+                            0,                          /* Message sequence number */
+                            IPMI_MSG_CMD_CLOSE_SESSION, /* Command code */
+                            0, 0, 0, 0,  /* For 4-byte session ID */
+                            0}; /* For checksum */
 
 /* Chassis Control */
-uint8_t CHAS_CTRL_MSG[] = { IPMI_MSG_ADDR_SW,           /* Requester's address */            
-                            0,                           /* Message sequence number */         
-                            IPMI_MSG_CMD_CHAS_CTRL,      /* Command code */         
-                            0,                           /* Command value (on, off, reset) */         
-                            0 };                         /* For checksum */
+uint8_t CHAS_CTRL_MSG[] = {IPMI_MSG_ADDR_SW,       /* Requester's address */
+                           0,                      /* Message sequence number */
+                           IPMI_MSG_CMD_CHAS_CTRL, /* Command code */
+                           0,                      /* Command value (on, off, reset) */
+                           0};                     /* For checksum */
 
 /* Default message (no data) */
-uint8_t BASIC_MSG[]=    { IPMI_MSG_ADDR_SW,              /* Requester's address */            
-                            0,                           /* Message sequence number */         
-                            0,                           /* Command code */         
-                            0 };                         /* For checksum */
-
-
+uint8_t BASIC_MSG[] = {IPMI_MSG_ADDR_SW, /* Requester's address */
+                       0,                /* Message sequence number */
+                       0,                /* Command code */
+                       0};               /* For checksum */
+// clang-format on

--- a/src/ipmiDef.h
+++ b/src/ipmiDef.h
@@ -1,10 +1,10 @@
 //////////////////////////////////////////////////////////////////////////////
 // This file is part of 'ipmiComm'.
-// It is subject to the license terms in the LICENSE.txt file found in the 
-// top-level directory of this distribution and at: 
-//    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
-// No part of 'ipmiComm', including this file, 
-// may be copied, modified, propagated, or distributed except according to 
+// It is subject to the license terms in the LICENSE.txt file found in the
+// top-level directory of this distribution and at:
+//    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+// No part of 'ipmiComm', including this file,
+// may be copied, modified, propagated, or distributed except according to
 // the terms contained in the LICENSE.txt file.
 //////////////////////////////////////////////////////////////////////////////
 #ifndef IPMI_DEF_H
@@ -29,19 +29,20 @@ Change language/names everywhere to no longer use 'MCH' to describe a general sy
 
 ***************************/
 
-
 #include <math.h> /* pow */
 
-#define MSG_MAX_LENGTH  200 /* arbitrarily chosen, not in the specs */
+#define MSG_MAX_LENGTH 200 /* arbitrarily chosen, not in the specs */
 
 /* BMC features; currently named MCH, which will eventually have to be changed everywhere to be more generic */
-#define MCH_FEAT_SENDMSG_RPLY   (1<<0) /* BMC responds separately to send-message before responding to embedded message; also requires longer message timeout */
-#define MCH_FEAT_PLL_MON      (1<<1) /* Monitor additional voltage/temp of PLL */
-#define MCH_FEAT_FPGA_MON     (1<<2) /* Monitor Xilinx */
-#define MCH_FEAT_FOT_MON      (1<<3) /* Monitor transceiver */
-#define MCH_FEAT_SYS_INFO     (1<<4) /* Monitor system info */
+#define MCH_FEAT_SENDMSG_RPLY                                                                                          \
+    (1 << 0)                       /* BMC responds separately to send-message before responding to                     \
+                                    * embedded message; also requires longer message timeout */
+#define MCH_FEAT_PLL_MON  (1 << 1) /* Monitor additional voltage/temp of PLL */
+#define MCH_FEAT_FPGA_MON (1 << 2) /* Monitor Xilinx */
+#define MCH_FEAT_FOT_MON  (1 << 3) /* Monitor transceiver */
+#define MCH_FEAT_SYS_INFO (1 << 4) /* Monitor system info */
 
-typedef struct IpmiSessRec_ *IpmiSess;
+typedef struct IpmiSessRec_* IpmiSess;
 
 /*   Callback helper function to write/read IPMI messages
  *
@@ -56,202 +57,235 @@ typedef struct IpmiSessRec_ *IpmiSess;
  *   offs     - Offset from IPMI_RPLY_COMPLETION_CODE_OFFSET to read comp code (see ipmiDef.h)
  *   outsess  - 1 if outside a session; 0 if in a session
  */
-typedef int
-(*IpmiWriteReadHelper)(void *device, IpmiSess sess, uint8_t *msg, size_t msg_n, uint8_t *rply, size_t *rply_n, uint8_t cmd, uint8_t netfn, int offs, int outsess);
+typedef int (*IpmiWriteReadHelper)(void* device, IpmiSess sess, uint8_t* msg, size_t msg_n, uint8_t* rply,
+                                   size_t* rply_n, uint8_t cmd, uint8_t netfn, int offs, int outsess);
 
 /* Struct for IPMI session information */
 typedef struct IpmiSessRec_ {
-	uint8_t       ivers;         /* IPMI version number */
-	uint8_t       id[4];         /* Session ID */
-	uint8_t       str[16];       /* Session challenge string; used in establishing a session */
-        uint8_t       seqSend[4];    /* Message sequence number for messages to device, null until session activated; chosen by system software (us); rolls over at 0xFFFFFFFF */
-        uint8_t       seqRply[4];    /* Message sequence number for messages from device; rolls over at 0xFFFFFFFF */
-	uint8_t       seq;           /* IPMI sequence (6-bit number); used to confirm reply is for correct request */
-	uint8_t       chan;          /* Channel number, returned by Get Channel Authentication Capabilities response */
-	uint8_t       authSup;       /* Channel authentication types supported, returned by Get Channel Authentication Capabilities response */
-	uint8_t       authReq;       /* Authentication type requested, used in Get Session Challenge and Activate Session requests (and any other authenticated requests) */
-	uint8_t       features;      /* Mask to describe vendor-specific behavior */
-	double        timeout;       /* Asyn read timeout */
-        IpmiWriteReadHelper wrf;     /* Callback to driver write/read function */
+    uint8_t ivers;      /* IPMI version number */
+    uint8_t id[4];      /* Session ID */
+    uint8_t str[16];    /* Session challenge string; used in establishing a session */
+    uint8_t seqSend[4]; /* Message sequence number for messages to device, null until session activated; chosen by
+                           system software (us); rolls over at 0xFFFFFFFF */
+    uint8_t seqRply[4]; /* Message sequence number for messages from device; rolls over at 0xFFFFFFFF */
+    uint8_t seq;        /* IPMI sequence (6-bit number); used to confirm reply is for correct request */
+    uint8_t chan;       /* Channel number, returned by Get Channel Authentication Capabilities response */
+    uint8_t authSup;    /* Channel authentication types supported, returned by Get Channel Authentication Capabilities
+                           response */
+    uint8_t authReq; /* Authentication type requested, used in Get Session Challenge and Activate Session requests (and
+                        any other authenticated requests) */
+    uint8_t             features; /* Mask to describe vendor-specific behavior */
+    double              timeout;  /* Asyn read timeout */
+    IpmiWriteReadHelper wrf;      /* Callback to driver write/read function */
 } IpmiSessRec;
 
-	
 /* Data structure for Sensor Data Record (one per sensor) IPMI v2.0 Section 43.1
  * Used for both Full and Compact SDRs
  * In this implementation, we don't support all of the Full SDR fields
  */
 typedef struct SdrFullRec_ {
-	uint8_t      id[2];         /* Sensor ID (can change, so key bytes must also be used to identify a sensor) */
-	uint8_t      ver;           /* SDR version (0x51) */
-	uint8_t      recType;       /* Record type, 0x01 for Full Sensor Record */
-        uint8_t      length;        /* Number of remaining record bytes */
-	uint8_t      owner;         /* Sensor owner ID, [7:1] slave address or software ID; [0] 0 = IPMB, 1 = system software */
-	uint8_t      lun;           /* Sensor owner LUN, [7:4] channel number; [3:2] reserved; [1:0] sensor owner LUN */
-	uint8_t      number;        /* Sensor number, unique behind given address and LUN, 0xFF reserved */
-	uint8_t      entityId;      /* Entity ID (physical entity that sensor is associated with) */
-	uint8_t      entityInst;    /* Entity instance, [7] 0 = physical entity, 1 = logical; [6:0] instance number 0x00-0x5F system-relative, 0x60-0x7F device-relative */
-        uint8_t      init;          /* Sensor initialization (see IPMI spec page 472 for details) */
-        uint8_t      cap;           /* Sensor capabilities (see IPMI spec page 473 for details) */
-	uint8_t      sensType;      /* Sensor type code (see IPMI spec table 42-3) */
-	uint8_t      readType;      /* Event/reading type code (see IPMI spec table 42-1) */
-	/* Following fields only applicable to Full SDR */
-	uint8_t      units1;        /* [7:6] analog data format, [5:3] rate unit, [2:1] modifier unit, [0] percentage */
-	uint8_t      units2;        /* Units type code, IPMI 43-15 */
-	uint8_t      units3;        /* Units type code, 0x00 if unused */
-	uint8_t      linear;        /* Linearization [7] reserved, [6:0] formula type */
-	uint8_t      M;             /* M in conversion, LS 8 bits (2's complement signed 10-bit 'M' value) */
-	uint8_t      MTol;          /* [7:6] MS 2 bits of M, [5:0] tolerance 6 bits unsigned (in +/- 1/2 raw counts) */
-	uint8_t      B;             /* B in conversion, LS 8 bits (2's complement signed 10-bit 'B' value) */
-	uint8_t      BAcc;          /* [7:6] MS 2 bits of B, [5:0] accuracy LW 6 bits (unsigned 10-bit Basic Sensor Accuracy in 1/100 % scaled up by accuracy exponent */
-	uint8_t      acc;           /* [7:4] MS 4 bits of accuracy, [3:2] accuracy exponent 2 bits unsigned, [1:0] sensor direction */
-	uint8_t      RexpBexp;      /* [7:4] R (result) exponent 4 bits 2's complement signed, [3:0] B exponent 4 bits, 2's complement signed */
-	uint8_t      strLength;     /* Sensor ID string type/length */
-	uint8_t      anlgChar;      /* Analog characteristics [7:3] reserved, [2] normal min specified, [1] normal max specified [0], nominal reading specified */
-	uint8_t      nominal;       /* Nominal reading (raw units) */
-	uint8_t      normMax;       /* Normal maximum (raw units) */
-	uint8_t      normMin;       /* Normal minimum (raw units) */
-	char         str[17];       /* Sensor ID string, 16 bytes maximum */
-	/* calculated values, only supported for Full SDR */
-	int          m;             
-	int          b;             
-	int          rexp;             
-	int          bexp;             
+    uint8_t id[2];      /* Sensor ID (can change, so key bytes must also be used to identify a sensor) */
+    uint8_t ver;        /* SDR version (0x51) */
+    uint8_t recType;    /* Record type, 0x01 for Full Sensor Record */
+    uint8_t length;     /* Number of remaining record bytes */
+    uint8_t owner;      /* Sensor owner ID, [7:1] slave address or software ID; [0] 0 = IPMB, 1 = system software */
+    uint8_t lun;        /* Sensor owner LUN, [7:4] channel number; [3:2] reserved; [1:0] sensor owner LUN */
+    uint8_t number;     /* Sensor number, unique behind given address and LUN, 0xFF reserved */
+    uint8_t entityId;   /* Entity ID (physical entity that sensor is associated with) */
+    uint8_t entityInst; /* Entity instance, [7] 0 = physical entity, 1 = logical; [6:0] instance number 0x00-0x5F
+                           system-relative, 0x60-0x7F device-relative */
+    uint8_t init;       /* Sensor initialization (see IPMI spec page 472 for details) */
+    uint8_t cap;        /* Sensor capabilities (see IPMI spec page 473 for details) */
+    uint8_t sensType;   /* Sensor type code (see IPMI spec table 42-3) */
+    uint8_t readType;   /* Event/reading type code (see IPMI spec table 42-1) */
+    /* Following fields only applicable to Full SDR */
+    uint8_t units1; /* [7:6] analog data format, [5:3] rate unit, [2:1] modifier unit, [0] percentage */
+    uint8_t units2; /* Units type code, IPMI 43-15 */
+    uint8_t units3; /* Units type code, 0x00 if unused */
+    uint8_t linear; /* Linearization [7] reserved, [6:0] formula type */
+    uint8_t M;      /* M in conversion, LS 8 bits (2's complement signed 10-bit 'M' value) */
+    uint8_t MTol;   /* [7:6] MS 2 bits of M, [5:0] tolerance 6 bits unsigned (in +/- 1/2 raw counts) */
+    uint8_t B;      /* B in conversion, LS 8 bits (2's complement signed 10-bit 'B' value) */
+    uint8_t BAcc;   /* [7:6] MS 2 bits of B, [5:0] accuracy LW 6 bits (unsigned 10-bit Basic Sensor Accuracy in 1/100 %
+                       scaled up by accuracy exponent */
+    uint8_t acc;    /* [7:4] MS 4 bits of accuracy, [3:2] accuracy exponent 2 bits unsigned, [1:0] sensor direction */
+    uint8_t RexpBexp; /* [7:4] R (result) exponent 4 bits 2's complement signed, [3:0] B exponent 4 bits, 2's complement
+                         signed */
+    uint8_t strLength; /* Sensor ID string type/length */
+    uint8_t anlgChar;  /* Analog characteristics [7:3] reserved, [2] normal min specified, [1] normal max specified [0],
+                          nominal reading specified */
+    uint8_t nominal;   /* Nominal reading (raw units) */
+    uint8_t normMax;   /* Normal maximum (raw units) */
+    uint8_t normMin;   /* Normal minimum (raw units) */
+    char    str[17];   /* Sensor ID string, 16 bytes maximum */
+    /* calculated values, only supported for Full SDR */
+    int m;
+    int b;
+    int rexp;
+    int bexp;
 
 } SdrFullRec, *SdrFull;
-	
-/* 
+
+/*
  * Data structure for FRU Device Locator Record, IPMI v2.0 Table 43-7
  */
 typedef struct SdrFruRec_ {
-	uint8_t      id[2];         /* Sensor ID (can change, so key bytes must also be used to identify a sensor) */
-	uint8_t      ver;           /* SDR version (0x51) */
-	uint8_t      recType;       /* Record type, 0x11 for FRU Device Locator Record */
-        uint8_t      length;        /* Number of remaining record bytes */
-	uint8_t      addr;          /* [7:1] slave address of controller, all 0 if dev on IPMB, [0] reserved */
-	uint8_t      fruId;         /* FRU Device ID/Slave address. For logical FRU device, [7:0] FRU dev ID, for non-intelligent, [7:1] slave address, [0] reserved */
-	uint8_t      lun;           /* [7] logical/physical FRU device, [6:5] reserved, [4:3] LUN for FRU commands, [2:0] private bus ID */
-	uint8_t      chan;          /* [7:4] Channel number to access device, 0 if on IPMB (MS bit in next byte?); [3:0] reserved */
-	uint8_t      devType;       /* Device type code Table 43-12 */
-	uint8_t      devMod;        /* Device type modifier Table 43-12 */
-	uint8_t      entityId;      /* Entity ID (physical entity that sensor is associated with) */
-	uint8_t      entityInst;    /* Entity instance, [7] 0 = physical entity, 1 = logical; [6:0] instance number 0x00-0x5F system-relative, 0x60-0x7F device-relative */
-	uint8_t      strLength;     /* Device ID string type/length Section 43.15*/
-	char         str[17];       /* Device ID string, 16 bytes maximum */
+    uint8_t id[2];   /* Sensor ID (can change, so key bytes must also be used to identify a sensor) */
+    uint8_t ver;     /* SDR version (0x51) */
+    uint8_t recType; /* Record type, 0x11 for FRU Device Locator Record */
+    uint8_t length;  /* Number of remaining record bytes */
+    uint8_t addr;    /* [7:1] slave address of controller, all 0 if dev on IPMB, [0] reserved */
+    uint8_t fruId; /* FRU Device ID/Slave address. For logical FRU device, [7:0] FRU dev ID, for non-intelligent, [7:1]
+                      slave address, [0] reserved */
+    uint8_t lun; /* [7] logical/physical FRU device, [6:5] reserved, [4:3] LUN for FRU commands, [2:0] private bus ID */
+    uint8_t chan;       /* [7:4] Channel number to access device, 0 if on IPMB (MS bit in next byte?); [3:0] reserved */
+    uint8_t devType;    /* Device type code Table 43-12 */
+    uint8_t devMod;     /* Device type modifier Table 43-12 */
+    uint8_t entityId;   /* Entity ID (physical entity that sensor is associated with) */
+    uint8_t entityInst; /* Entity instance, [7] 0 = physical entity, 1 = logical; [6:0] instance number 0x00-0x5F
+                           system-relative, 0x60-0x7F device-relative */
+    uint8_t strLength;  /* Device ID string type/length Section 43.15*/
+    char    str[17];    /* Device ID string, 16 bytes maximum */
 } SdrFruRec, *SdrFru;
-	
-/* 
+
+/*
  * Data structure for Management Controller Device Locator Record, IPMI v2.0 Table 43-8
  */
 typedef struct SdrMgmtRec_ {
-	uint8_t      id[2];         /* Record ID */
-	uint8_t      ver;           /* SDR version */
-	uint8_t      recType;       /* Record type, 0x12 for Management Controller Locator */
-        uint8_t      length;        /* Number of remaining record bytes */
-	uint8_t      addr;          /* [7:1] I2C slave address of device on channel, [0] reserved */
-	uint8_t      chan;          /* [7:4] reserved; [3:0] Channel number for the channel that the management controller is on, use 0 for primary BMC */
-	uint8_t      pwr;           /* Power state notification and Global initialization, see IPMI spec for meaning of each bit */
-	uint8_t      cap;           /* Device capabilities, see IPMI spec for meaning of each bit */
-	/* next 3 bytes reserved */
-	uint8_t      entityId;      /* Entity ID for the FRU associated with this device, 0 if not specified */
-	uint8_t      entityInst;    /* Entity instance */
-	uint8_t      strLength;     /* Device ID string type/length Section 43.15*/
-	char         str[17];       /* Device ID string, 16 bytes maximum */
+    uint8_t id[2];   /* Record ID */
+    uint8_t ver;     /* SDR version */
+    uint8_t recType; /* Record type, 0x12 for Management Controller Locator */
+    uint8_t length;  /* Number of remaining record bytes */
+    uint8_t addr;    /* [7:1] I2C slave address of device on channel, [0] reserved */
+    uint8_t chan;    /* [7:4] reserved; [3:0] Channel number for the channel that the management controller is on, use 0
+                        for primary BMC */
+    uint8_t pwr;     /* Power state notification and Global initialization, see IPMI spec for meaning of each bit */
+    uint8_t cap;     /* Device capabilities, see IPMI spec for meaning of each bit */
+    /* next 3 bytes reserved */
+    uint8_t entityId;   /* Entity ID for the FRU associated with this device, 0 if not specified */
+    uint8_t entityInst; /* Entity instance */
+    uint8_t strLength;  /* Device ID string type/length Section 43.15*/
+    char    str[17];    /* Device ID string, 16 bytes maximum */
 } SdrMgmtRec, *SdrMgmt;
 
-/* 
+/*
  * Data structure for Entity Association Record, IPMI v2.0 Table 43-4
  */
 typedef struct SdrEntAssocRec_ {
-	uint8_t      id[2];         /* Record ID */
-	uint8_t      ver;           /* SDR version */
-	uint8_t      recType;       /* Record type, 0x08 for Entity Association Record */
-        uint8_t      length;        /* Number of remaining record bytes */
-	uint8_t      cntnrId;       /* Entity ID for container entity */
-	uint8_t      cntnrInst;     /* Entity instance for container entity */
-	uint8_t      flags;         /* [7] 0=contained entities specified as list, 1=specified as range;
-				     * [6] 0=no linked Entity Assoc records, 1=linked Entity Assoc records exist;
-				     * [5] 0=container and contained entities can be assumed absent if presence sensor for container 
-				     *       cannot be acessed, 1=presence sensor should always be available
-				     * [4:0] reserved
-				     */
-	uint8_t      cntndId1;      /* If list Entity Id for contained entity 1, if range Entity Id of entity for contained entity range 1 */
-	uint8_t      cntndInst1;    /* If list Entity Inst for contained entity 1, if range Entity Inst for *first* entity in contained entity range 1 */
-/* contained entity id/inst fields 2-4 are 0 if unspecified */
-	uint8_t      cntndId2;      /* If list Entity Id for contained entity 2, if range Entity Id of entity for contained entity range 1 (must match cnndEntId1) */
-	uint8_t      cntndInst2;    /* If list Entity Inst for contained entity 2, if range Entity Inst for *last* entity in contained entity range 1 */
-	uint8_t      cntndId3;      /* If list Entity Id for contained entity 3, if range Entity Id of entity for contained entity range 2 */
-	uint8_t      cntndInst3;    /* If list Entity Inst for contained entity 13 if range Entity Inst for *first* entity in contained entity range 2 */
-	uint8_t      cntndId4;      /* If list Entity Id for contained entity 4, if range Entity Id of entity for contained entity range 2 */
-	uint8_t      cntndInst4;    /* If list Entity Inst for contained entity 4, if range Entity Inst for *last* entity in contained entity range 2 */
+    uint8_t id[2];      /* Record ID */
+    uint8_t ver;        /* SDR version */
+    uint8_t recType;    /* Record type, 0x08 for Entity Association Record */
+    uint8_t length;     /* Number of remaining record bytes */
+    uint8_t cntnrId;    /* Entity ID for container entity */
+    uint8_t cntnrInst;  /* Entity instance for container entity */
+    uint8_t flags;      /* [7] 0=contained entities specified as list, 1=specified as range;
+                         * [6] 0=no linked Entity Assoc records, 1=linked Entity Assoc records exist;
+                         * [5] 0=container and contained entities can be assumed absent if presence sensor for container
+                         *       cannot be acessed, 1=presence sensor should always be available
+                         * [4:0] reserved
+                         */
+    uint8_t cntndId1;   /* If list Entity Id for contained entity 1, if range Entity Id of entity for contained entity
+                           range 1 */
+    uint8_t cntndInst1; /* If list Entity Inst for contained entity 1, if range Entity Inst for *first* entity in
+                           contained entity range 1 */
+                        /* contained entity id/inst fields 2-4 are 0 if unspecified */
+    uint8_t cntndId2;   /* If list Entity Id for contained entity 2, if range Entity Id of entity for contained entity
+                           range 1 (must match cnndEntId1) */
+    uint8_t cntndInst2; /* If list Entity Inst for contained entity 2, if range Entity Inst for *last* entity in
+                           contained entity range 1 */
+    uint8_t cntndId3;   /* If list Entity Id for contained entity 3, if range Entity Id of entity for contained entity
+                           range 2 */
+    uint8_t cntndInst3; /* If list Entity Inst for contained entity 13 if range Entity Inst for *first* entity in
+                           contained entity range 2 */
+    uint8_t cntndId4;   /* If list Entity Id for contained entity 4, if range Entity Id of entity for contained entity
+                           range 2 */
+    uint8_t cntndInst4; /* If list Entity Inst for contained entity 4, if range Entity Inst for *last* entity in
+                           contained entity range 2 */
 } SdrEntAssocRec, *SdrEntAssoc;
 
-/* 
+/*
  * Data structure for Device-relative Entity Association Record, IPMI v2.0 Table 43-4
  */
 typedef struct SdrDevEntAssocRec_ {
-	uint8_t      id[2];         /* Record ID */
-	uint8_t      ver;           /* SDR version */
-	uint8_t      recType;       /* Record type, 0x08 for Entity Association Record */
-        uint8_t      length;        /* Number of remaining record bytes */
-	uint8_t      cntnrId;       /* Entity ID for container entity */
-	uint8_t      cntnrInst;     /* Entity instance for container entity */
-	uint8_t      cntnrAddr;     /* Device address for container entity, [7:1] slave address of mgmt cntrlr against which device-relative instance is defined, [0] reserved */
-	uint8_t      cntnrChan;     /* [7:4] Channel number of channel that holds the mgmt cntrlr, 0 if Entity Inst is device-relative, [3:0] reserved */
-	uint8_t      flags;         /* [7] 0=contained entities specified as list, 1=specified as range;
-				     * [6] 0=no linked Entity Assoc records, 1=linked Entity Assoc records exist;
-				     * [5] 0=container and contained entities can be assumed absent if presence sensor for container 
-				     *       cannot be acessed, 1=presence sensor should always be available
-				     * [4:0] reserved
-				     */
-	uint8_t      cntndAddr1;    /* [7:1] Slave address of mgmt cntrlr against which device-relative Entity Inst for contained entity 1 is defined, [0] reserved */
-	uint8_t      cntndChan1;    /* [7:4] Channel number of channel that holds mgmt cntrlr against which device-relative Entity Inst for contained entity 1 is defined,
-				     * 0 if instance values are device-relative; [3:0] reserved 
-				     */
-	uint8_t      cntndId1;      /* If list Entity Id for contained entity 1, if range Entity Id of entity for contained entity range 1 */
-	uint8_t      cntndInst1;    /* If list Entity Inst for contained entity 1, if range Entity Inst for *first* entity in contained entity range 1 */
-/* contained entity id/inst fields 2-4 are 0 if unspecified */
-	uint8_t      cntndAddr2;    /* [7:1] Slave address of mgmt cntrlr against which device-relative Entity Inst for contained entity 1 is defined, [0] reserved */
-	uint8_t      cntndChan2;    /* [7:4] Channel number of channel that holds mgmt cntrlr against which device-relative Entity Inst for contained entity 1 is defined,
-				     * 0 if instance values are device-relative; [3:0] reserved 
-				     */
-	uint8_t      cntndId2;      /* If list Entity Id for contained entity 2, if range Entity Id of entity for contained entity range 2 (must match containedEntityId1) */
-	uint8_t      cntndInst2;    /* If list Entity Inst for contained entity 2, if range Entity Inst for *last* entity in contained entity range 2 */
+    uint8_t id[2];      /* Record ID */
+    uint8_t ver;        /* SDR version */
+    uint8_t recType;    /* Record type, 0x08 for Entity Association Record */
+    uint8_t length;     /* Number of remaining record bytes */
+    uint8_t cntnrId;    /* Entity ID for container entity */
+    uint8_t cntnrInst;  /* Entity instance for container entity */
+    uint8_t cntnrAddr;  /* Device address for container entity, [7:1] slave address of mgmt cntrlr against which
+                           device-relative instance is defined, [0] reserved */
+    uint8_t cntnrChan;  /* [7:4] Channel number of channel that holds the mgmt cntrlr, 0 if Entity Inst is
+                           device-relative, [3:0] reserved */
+    uint8_t flags;      /* [7] 0=contained entities specified as list, 1=specified as range;
+                         * [6] 0=no linked Entity Assoc records, 1=linked Entity Assoc records exist;
+                         * [5] 0=container and contained entities can be assumed absent if presence sensor for container
+                         *       cannot be acessed, 1=presence sensor should always be available
+                         * [4:0] reserved
+                         */
+    uint8_t cntndAddr1; /* [7:1] Slave address of mgmt cntrlr against which device-relative Entity Inst for contained
+                           entity 1 is defined, [0] reserved */
+    uint8_t
+        cntndChan1; /* [7:4] Channel number of channel that holds mgmt cntrlr against which device-relative Entity Inst
+                     * for contained entity 1 is defined, 0 if instance values are device-relative; [3:0] reserved
+                     */
+    uint8_t cntndId1;   /* If list Entity Id for contained entity 1, if range Entity Id of entity for contained entity
+                           range 1 */
+    uint8_t cntndInst1; /* If list Entity Inst for contained entity 1, if range Entity Inst for *first* entity in
+                           contained entity range 1 */
+                        /* contained entity id/inst fields 2-4 are 0 if unspecified */
+    uint8_t cntndAddr2; /* [7:1] Slave address of mgmt cntrlr against which device-relative Entity Inst for contained
+                           entity 1 is defined, [0] reserved */
+    uint8_t
+        cntndChan2; /* [7:4] Channel number of channel that holds mgmt cntrlr against which device-relative Entity Inst
+                     * for contained entity 1 is defined, 0 if instance values are device-relative; [3:0] reserved
+                     */
+    uint8_t cntndId2;   /* If list Entity Id for contained entity 2, if range Entity Id of entity for contained entity
+                           range 2 (must match containedEntityId1) */
+    uint8_t cntndInst2; /* If list Entity Inst for contained entity 2, if range Entity Inst for *last* entity in
+                           contained entity range 2 */
 
-	uint8_t      cntndAddr3;    /* [7:1] Slave address of mgmt cntrlr against which device-relative Entity Inst for contained entity 3 is defined, [0] reserved */
-	uint8_t      cntndChan3;    /* [7:4] Channel number of channel that holds mgmt cntrlr against which device-relative Entity Inst for contained entity 3 is defined,
-				     * 0 if instance values are device-relative; [3:0] reserved 
-				     */
-	uint8_t      cntndId3;      /* If list Entity Id for contained entity 3, if range Entity Id of entity for contained entity range 2 */
-	uint8_t      cntndInst3;    /* If list Entity Inst for contained entity 13 if range Entity Inst for *first* entity in contained entity range 2 */
+    uint8_t cntndAddr3; /* [7:1] Slave address of mgmt cntrlr against which device-relative Entity Inst for contained
+                           entity 3 is defined, [0] reserved */
+    uint8_t
+        cntndChan3; /* [7:4] Channel number of channel that holds mgmt cntrlr against which device-relative Entity Inst
+                     * for contained entity 3 is defined, 0 if instance values are device-relative; [3:0] reserved
+                     */
+    uint8_t cntndId3;   /* If list Entity Id for contained entity 3, if range Entity Id of entity for contained entity
+                           range 2 */
+    uint8_t cntndInst3; /* If list Entity Inst for contained entity 13 if range Entity Inst for *first* entity in
+                           contained entity range 2 */
 
-	uint8_t      cntndAddr4;    /* [7:1] Slave address of mgmt cntrlr against which device-relative Entity Inst for contained entity 4 is defined, [0] reserved */
-	uint8_t      cntndChan4;    /* [7:4] Channel number of channel that holds mgmt cntrlr against which device-relative Entity Inst for contained entity 4 is defined,
-				     * 0 if instance values are device-relative; [3:0] reserved 
-				     */
-	uint8_t      cntndId4;      /* If list Entity Id for contained entity 4, if range Entity Id of entity for contained entity range 2 */
-	uint8_t      cntndInst4;    /* If list Entity Inst for contained entity 4, if range Entity Inst for *last* entity in contained entity range 2 */
+    uint8_t cntndAddr4; /* [7:1] Slave address of mgmt cntrlr against which device-relative Entity Inst for contained
+                           entity 4 is defined, [0] reserved */
+    uint8_t
+        cntndChan4; /* [7:4] Channel number of channel that holds mgmt cntrlr against which device-relative Entity Inst
+                     * for contained entity 4 is defined, 0 if instance values are device-relative; [3:0] reserved
+                     */
+    uint8_t cntndId4;   /* If list Entity Id for contained entity 4, if range Entity Id of entity for contained entity
+                           range 2 */
+    uint8_t cntndInst4; /* If list Entity Inst for contained entity 4, if range Entity Inst for *last* entity in
+                           contained entity range 2 */
 
 } SdrDevEntAssocRec, *SdrDevEntAssoc;
-	
 
 /* Data structure for Sensor Data Record Repository and Dynamic Sensor Device */
 typedef struct SdrRepRec_ {
-	uint8_t      ver;           /* SDR Version (0x51) */
-        uint8_t      size[2];       /* Number of sensor data records; LS byte stored first */
-	uint8_t      free[2];       /* Free space in bytes; LS byte stored first */
-	uint32_t     addTs;         /* Timestamp of most recent addition - remove: ; LS byte stored first */
-        uint32_t     delTs;         /* Timestamp of most recent erase - remove: ; LS byte stored first */
-        uint8_t      config[1];     /* 8 bits to describe Respository configuration, mostly supported commands */
-	uint8_t      resId;         /* Reservation ID assigned when reserving SDR */
-/* remaining members used by dynamic sensor device only */
-        uint8_t      devSdrSize;    /* Number of sensor data records in chassis dynamic Device SDR */
-        uint8_t      devSdrDyn;     /* Sensor population dynamic, 1 is dynamic, 0 is static */
-        uint8_t      lun0;          /* Sensors in LUN 0, 1 yes, 0 no */
-        uint8_t      lun1;          /* Sensors in LUN 1, 1 yes, 0 no */
-        uint8_t      lun2;          /* Sensors in LUN 2, 1 yes, 0 no */
-        uint8_t      lun3;          /* Sensors in LUN 3, 1 yes, 0 no */
+    uint8_t  ver;       /* SDR Version (0x51) */
+    uint8_t  size[2];   /* Number of sensor data records; LS byte stored first */
+    uint8_t  free[2];   /* Free space in bytes; LS byte stored first */
+    uint32_t addTs;     /* Timestamp of most recent addition - remove: ; LS byte stored first */
+    uint32_t delTs;     /* Timestamp of most recent erase - remove: ; LS byte stored first */
+    uint8_t  config[1]; /* 8 bits to describe Respository configuration, mostly supported commands */
+    uint8_t  resId;     /* Reservation ID assigned when reserving SDR */
+                        /* remaining members used by dynamic sensor device only */
+    uint8_t devSdrSize; /* Number of sensor data records in chassis dynamic Device SDR */
+    uint8_t devSdrDyn;  /* Sensor population dynamic, 1 is dynamic, 0 is static */
+    uint8_t lun0;       /* Sensors in LUN 0, 1 yes, 0 no */
+    uint8_t lun1;       /* Sensors in LUN 1, 1 yes, 0 no */
+    uint8_t lun2;       /* Sensors in LUN 2, 1 yes, 0 no */
+    uint8_t lun3;       /* Sensors in LUN 3, 1 yes, 0 no */
 } SdrRepRec, *SdrRep;
-
 
 // Find a way to not hard-code array sizes below
 extern uint8_t RMCP_HEADER[4];
@@ -271,75 +305,76 @@ extern uint8_t FRU_READ_MSG[8];
 extern uint8_t GET_SDR_MSG[10];
 extern uint8_t CLOSE_SESS_MSG[8];
 extern uint8_t CHAS_CTRL_MSG[5];
-extern uint8_t GET_DEV_SDR_INFO_MSG[5];            
+extern uint8_t GET_DEV_SDR_INFO_MSG[5];
 extern uint8_t BASIC_MSG[4];
 
-/* RMCP message header */ 
-#define RMCP_MSG_VER        0x06  /* RMCP message version */
-#define RMCP_MSG_SEQ        0xFF  /* RMCP message header; 0xFF for no ack */
-#define RMCP_MSG_CLASS_ASF  0x06  /* Message class, ASF  */
-#define RMCP_MSG_CLASS_IPMI 0x07  /* Message class, IPMI */
-#define RMCP_MSG_AUTH_NONE  0x00  /* Message authentication type, 0 for none */
-#define RMCP_MSG_HEADER_LENGTH sizeof( RMCP_HEADER )
-#define RMCP_MSG_CLASS_OFFSET  3  /* Message class */
+/* RMCP message header */
+#define RMCP_MSG_VER           0x06 /* RMCP message version */
+#define RMCP_MSG_SEQ           0xFF /* RMCP message header; 0xFF for no ack */
+#define RMCP_MSG_CLASS_ASF     0x06 /* Message class, ASF  */
+#define RMCP_MSG_CLASS_IPMI    0x07 /* Message class, IPMI */
+#define RMCP_MSG_AUTH_NONE     0x00 /* Message authentication type, 0 for none */
+#define RMCP_MSG_HEADER_LENGTH sizeof(RMCP_HEADER)
+#define RMCP_MSG_CLASS_OFFSET  3 /* Message class */
 
 /* ASF message */
-#define ASF_MSG_OFFSET                      RMCP_MSG_HEADER_LENGTH
-#define ASF_MSG_HEADER_LENGTH               8
-#define ASF_RPLY_PONG_PAYLOAD_LENGTH        16
+#define ASF_MSG_OFFSET               RMCP_MSG_HEADER_LENGTH
+#define ASF_MSG_HEADER_LENGTH        8
+#define ASF_RPLY_PONG_PAYLOAD_LENGTH 16
 
 /* IPMI message wrapper */
 extern size_t IPMI_WRAPPER_LENGTH;
 extern size_t IPMI_WRAPPER_AUTH_LENGTH;
-#define IPMI_WRAPPER_AUTH_TYPE_OFFSET     0    /* Authentication type */
-#define IPMI_WRAPPER_SEQ_INITIAL          1    /* Our starting sequence number (arbitrary) */
-#define IPMI_WRAPPER_SEQ_OFFSET           1    /* Session sequence number */
-#define IPMI_WRAPPER_SEQ_LENGTH           4    /* Session sequence number length */
-#define IPMI_WRAPPER_ID_OFFSET            5    /* Session ID */
-#define IPMI_WRAPPER_ID_LENGTH            4    /* Session ID length */
-#define IPMI_WRAPPER_AUTH_CODE_OFFSET     9    /* Message authentication code offset (used in authenticated messages only) */
-#define IPMI_WRAPPER_AUTH_CODE_LENGTH     16   /* Message authentication code length */ 
-#define IPMI_WRAPPER_NBYTES_OFFSET        9    /* Number of bytes in IPMI message (includes bridged message) */
-#define IPMI_WRAPPER_AUTH_NBYTES_OFFSET   9 +  IPMI_WRAPPER_AUTH_CODE_LENGTH /* Number of bytes in IPMI message (includes bridged message) */
+#define IPMI_WRAPPER_AUTH_TYPE_OFFSET 0  /* Authentication type */
+#define IPMI_WRAPPER_SEQ_INITIAL      1  /* Our starting sequence number (arbitrary) */
+#define IPMI_WRAPPER_SEQ_OFFSET       1  /* Session sequence number */
+#define IPMI_WRAPPER_SEQ_LENGTH       4  /* Session sequence number length */
+#define IPMI_WRAPPER_ID_OFFSET        5  /* Session ID */
+#define IPMI_WRAPPER_ID_LENGTH        4  /* Session ID length */
+#define IPMI_WRAPPER_AUTH_CODE_OFFSET 9  /* Message authentication code offset (used in authenticated messages only) */
+#define IPMI_WRAPPER_AUTH_CODE_LENGTH 16 /* Message authentication code length */
+#define IPMI_WRAPPER_NBYTES_OFFSET    9  /* Number of bytes in IPMI message (includes bridged message) */
+#define IPMI_WRAPPER_AUTH_NBYTES_OFFSET                                                                                \
+    9 + IPMI_WRAPPER_AUTH_CODE_LENGTH /* Number of bytes in IPMI message (includes bridged message) */
 
 /* IPMI message bytes after wrapper but before payload
  * Includes IMSG1 and first 3 bytes of IMSG2 (up to but not including completion code)
  * Just convenient offsets for extracting payload data from replies
  */
-#define IPMI_MSG_HEADER_LENGTH           IPMI_MSG1_LENGTH + 3 
-#define IPMI_RPLY_HEADER_LENGTH          RMCP_MSG_HEADER_LENGTH + IPMI_WRAPPER_LENGTH      + IPMI_MSG_HEADER_LENGTH
-#define IPMI_RPLY_HEADER_AUTH_LENGTH     RMCP_MSG_HEADER_LENGTH + IPMI_WRAPPER_AUTH_LENGTH + IPMI_MSG_HEADER_LENGTH
+#define IPMI_MSG_HEADER_LENGTH       IPMI_MSG1_LENGTH + 3
+#define IPMI_RPLY_HEADER_LENGTH      RMCP_MSG_HEADER_LENGTH + IPMI_WRAPPER_LENGTH + IPMI_MSG_HEADER_LENGTH
+#define IPMI_RPLY_HEADER_AUTH_LENGTH RMCP_MSG_HEADER_LENGTH + IPMI_WRAPPER_AUTH_LENGTH + IPMI_MSG_HEADER_LENGTH
 
 /* IPMI message 1 */
 extern size_t IPMI_MSG1_LENGTH;
 
 /* IPMI message 2 common */
-#define IPMI_MSG2_SEQLUN_OFFSET              1
-#define IPMI_SEQLUN_EXTRACT_SEQ(x)          ((x&0xFC)>>2)
+#define IPMI_MSG2_SEQLUN_OFFSET    1
+#define IPMI_SEQLUN_EXTRACT_SEQ(x) ((x & 0xFC) >> 2)
 
 /* Authentication types */
-#define IPMI_AUTH_TYPE_SUPPORT(x) (x & 0x37)
-#define IPMI_MSG_AUTH_TYPE_NONE              0
-#define IPMI_MSG_AUTH_TYPE_MD2               1
-#define IPMI_MSG_AUTH_TYPE_MD5               2
-#define IPMI_MSG_AUTH_TYPE_PWD_KEY           4
-#define IPMI_MSG_AUTH_TYPE_OEM               5
+#define IPMI_AUTH_TYPE_SUPPORT(x)  (x & 0x37)
+#define IPMI_MSG_AUTH_TYPE_NONE    0
+#define IPMI_MSG_AUTH_TYPE_MD2     1
+#define IPMI_MSG_AUTH_TYPE_MD5     2
+#define IPMI_MSG_AUTH_TYPE_PWD_KEY 4
+#define IPMI_MSG_AUTH_TYPE_OEM     5
 
 /* Privilege levels */
-#define IPMI_MSG_PRIV_LEVEL_NONE             0x00 /* Privilege level: none  */
-#define IPMI_MSG_PRIV_LEVEL_CB               0x01 /* Privilege level: callback  */
-#define IPMI_MSG_PRIV_LEVEL_USER             0x02 /* Privilege level: user  */
-#define IPMI_MSG_PRIV_LEVEL_OPER             0x03 /* Privilege level: operator  */
-#define IPMI_MSG_PRIV_LEVEL_ADMIN            0x04 /* Privilege level: administrator  */
-#define IPMI_MSG_PRIV_LEVEL_OEM              0x05 /* Privilege level: OEM proprietary  */
+#define IPMI_MSG_PRIV_LEVEL_NONE  0x00 /* Privilege level: none  */
+#define IPMI_MSG_PRIV_LEVEL_CB    0x01 /* Privilege level: callback  */
+#define IPMI_MSG_PRIV_LEVEL_USER  0x02 /* Privilege level: user  */
+#define IPMI_MSG_PRIV_LEVEL_OPER  0x03 /* Privilege level: operator  */
+#define IPMI_MSG_PRIV_LEVEL_ADMIN 0x04 /* Privilege level: administrator  */
+#define IPMI_MSG_PRIV_LEVEL_OEM   0x05 /* Privilege level: OEM proprietary  */
 
 /* Channel numbers and request options */
-#define IPMI_MSG_CHAN_IPMB0                  0
-#define IPMI_MSG_CHAN_IPMBL                  7
-#define IPMI_MSG_NOTRACKING                  0
-#define IPMI_MSG_TRACKING                    (1 << 6)
-#define IPMI_MSG_RAW                         (1 << 7)
-#define IPMI_MSG_CURR_CHAN                   0x0E /* Channel number currently in use */
+#define IPMI_MSG_CHAN_IPMB0 0
+#define IPMI_MSG_CHAN_IPMBL 7
+#define IPMI_MSG_NOTRACKING 0
+#define IPMI_MSG_TRACKING   (1 << 6)
+#define IPMI_MSG_RAW        (1 << 7)
+#define IPMI_MSG_CURR_CHAN  0x0E /* Channel number currently in use */
 
 /* IPMI responder and requester addresses */
 #define IPMI_MSG_ADDR_BMC                    0x20 /* UTC001 MCH BMC address */
@@ -347,96 +382,96 @@ extern size_t IPMI_MSG1_LENGTH;
 #define IPMI_MSG_ADDR_SW                     0x81 /* Our address (can be 0x81, 0x83, 0x85, 0x87, 0x89) */
 #define IPMI_MSG1_RSADDR_OFFSET              0
 #define IPMI_MSG1_NETFNLUN_OFFSET            1
-#define IPMI_MSG2_RQADDR_OFFSET              0    /* Requester's address (used in bridged IPMI msg 2) */
-#define IPMI_MSG2_ID_OFFSET                  3    /* Session ID */
-#define IPMI_MSG2_ID_LENGTH                  4    
-#define IPMI_MSG2_STR_OFFSET                 5    /* Challenge string */
-#define IPMI_MSG2_STR_LENGTH                 16   
-#define IPMI_MSG2_SEQLUN_OFFSET              1    /* MS 6 bits: IPMI sequence, LS 2 bits: LUN */
-#define IPMI_MSG2_CMD_OFFSET                 2    /* Command code */
-#define IPMI_MSG2_CHAN_OFFSET                3    /* Channel to send message over (0 for IPMB) */
-#define IPMI_MSG2_SENSOR_OFFSET              3    /* Sensor number */
-#define IPMI_MSG2_AUTH_TYPE_OFFSET           3    /* For Get Session Challenge and Activate Session */
+#define IPMI_MSG2_RQADDR_OFFSET              0 /* Requester's address (used in bridged IPMI msg 2) */
+#define IPMI_MSG2_ID_OFFSET                  3 /* Session ID */
+#define IPMI_MSG2_ID_LENGTH                  4
+#define IPMI_MSG2_STR_OFFSET                 5 /* Challenge string */
+#define IPMI_MSG2_STR_LENGTH                 16
+#define IPMI_MSG2_SEQLUN_OFFSET              1 /* MS 6 bits: IPMI sequence, LS 2 bits: LUN */
+#define IPMI_MSG2_CMD_OFFSET                 2 /* Command code */
+#define IPMI_MSG2_CHAN_OFFSET                3 /* Channel to send message over (0 for IPMB) */
+#define IPMI_MSG2_SENSOR_OFFSET              3 /* Sensor number */
+#define IPMI_MSG2_AUTH_TYPE_OFFSET           3 /* For Get Session Challenge and Activate Session */
 #define IPMI_MSG2_PRIV_LEVEL_OFFSET          3
-#define IPMI_MSG2_READ_FRU_ID_OFFSET         3    
-#define IPMI_MSG2_READ_FRU_LSB_OFFSET        4    /* FRU Inventory Offset to read, LS Byte */
-#define IPMI_MSG2_READ_FRU_MSB_OFFSET        5    /* FRU Inventory Offset to read, MS Byte */
-#define IPMI_MSG2_READ_FRU_CNT_OFFSET        6    /* Count to read in bytes, 1-based */
-#define IPMI_MSG2_GET_SDR_RES_LSB_OFFSET     3    /* SDR Reservation ID, LS Byte */
-#define IPMI_MSG2_GET_SDR_RES_MSB_OFFSET     4    /* SDR Reservation ID, LS Byte */
-#define IPMI_MSG2_GET_SDR_ID_LSB_OFFSET      5    /* SDR Record ID, LS Byte */
-#define IPMI_MSG2_GET_SDR_ID_MSB_OFFSET      6    /* SDR Record ID, MS Byte */
-#define IPMI_MSG2_GET_SDR_OFFSET_OFFSET      7    /* Offset into record to start read */
-#define IPMI_MSG2_GET_SDR_CNT_OFFSET         8    /* Count to read in bytes (0xFF means entire record) */
-#define IPMI_MSG2_GET_DEV_SDR_INFO_OP_OFFSET 3    /* 1 get SDR count, 0 get sensor count */
+#define IPMI_MSG2_READ_FRU_ID_OFFSET         3
+#define IPMI_MSG2_READ_FRU_LSB_OFFSET        4 /* FRU Inventory Offset to read, LS Byte */
+#define IPMI_MSG2_READ_FRU_MSB_OFFSET        5 /* FRU Inventory Offset to read, MS Byte */
+#define IPMI_MSG2_READ_FRU_CNT_OFFSET        6 /* Count to read in bytes, 1-based */
+#define IPMI_MSG2_GET_SDR_RES_LSB_OFFSET     3 /* SDR Reservation ID, LS Byte */
+#define IPMI_MSG2_GET_SDR_RES_MSB_OFFSET     4 /* SDR Reservation ID, LS Byte */
+#define IPMI_MSG2_GET_SDR_ID_LSB_OFFSET      5 /* SDR Record ID, LS Byte */
+#define IPMI_MSG2_GET_SDR_ID_MSB_OFFSET      6 /* SDR Record ID, MS Byte */
+#define IPMI_MSG2_GET_SDR_OFFSET_OFFSET      7 /* Offset into record to start read */
+#define IPMI_MSG2_GET_SDR_CNT_OFFSET         8 /* Count to read in bytes (0xFF means entire record) */
+#define IPMI_MSG2_GET_DEV_SDR_INFO_OP_OFFSET 3 /* 1 get SDR count, 0 get sensor count */
 
 /* IPMI message command codes (cmd) */
-#define IPMI_MSG_CMD_GET_CHAN_AUTH           0x38
-#define IPMI_MSG_CMD_GET_SESSION_CHALLENGE   0x39
-#define IPMI_MSG_CMD_ACTIVATE_SESSION        0x3A
-#define IPMI_MSG_CMD_SET_PRIV_LEVEL          0x3B
-#define IPMI_MSG_CMD_CLOSE_SESSION           0x3C
-#define IPMI_MSG_CMD_SEND_MSG                0x34
-#define IPMI_MSG_CMD_SENSOR_READ             0x2D
-#define IPMI_MSG_CMD_SET_SENSOR_THRESH       0x26
-#define IPMI_MSG_CMD_GET_SENSOR_THRESH       0x27
-#define IPMI_MSG_CMD_GET_CHAS_STATUS         0x01
-#define IPMI_MSG_CMD_CHAS_CTRL               0x02
-#define IPMI_MSG_CMD_GET_FRU_INFO            0x10
-#define IPMI_MSG_CMD_READ_FRU_DATA           0x11
-#define IPMI_MSG_CMD_WRITE_FRU_DATA          0x12
-#define IPMI_MSG_CMD_GET_SDRREP_INFO         0x20
-#define IPMI_MSG_CMD_RESERVE_SDRREP          0x22
-#define IPMI_MSG_CMD_GET_SDR                 0x23
-#define IPMI_MSG_CMD_GET_DEV_SDR_INFO        0x20
-#define IPMI_MSG_CMD_GET_DEV_SDR             0x21
-#define IPMI_MSG_CMD_RESERVE_DEV_SDRREP      0x22
-#define IPMI_MSG_CMD_COLD_RESET              0x02
-#define IPMI_MSG_CMD_SET_FRU_POLICY          0x0A
-#define IPMI_MSG_CMD_GET_FRU_POLICY          0x0B
-#define IPMI_MSG_CMD_SET_FRU_ACT             0x0C
-#define IPMI_MSG_CMD_GET_DEVICE_ID           0x01
+#define IPMI_MSG_CMD_GET_CHAN_AUTH         0x38
+#define IPMI_MSG_CMD_GET_SESSION_CHALLENGE 0x39
+#define IPMI_MSG_CMD_ACTIVATE_SESSION      0x3A
+#define IPMI_MSG_CMD_SET_PRIV_LEVEL        0x3B
+#define IPMI_MSG_CMD_CLOSE_SESSION         0x3C
+#define IPMI_MSG_CMD_SEND_MSG              0x34
+#define IPMI_MSG_CMD_SENSOR_READ           0x2D
+#define IPMI_MSG_CMD_SET_SENSOR_THRESH     0x26
+#define IPMI_MSG_CMD_GET_SENSOR_THRESH     0x27
+#define IPMI_MSG_CMD_GET_CHAS_STATUS       0x01
+#define IPMI_MSG_CMD_CHAS_CTRL             0x02
+#define IPMI_MSG_CMD_GET_FRU_INFO          0x10
+#define IPMI_MSG_CMD_READ_FRU_DATA         0x11
+#define IPMI_MSG_CMD_WRITE_FRU_DATA        0x12
+#define IPMI_MSG_CMD_GET_SDRREP_INFO       0x20
+#define IPMI_MSG_CMD_RESERVE_SDRREP        0x22
+#define IPMI_MSG_CMD_GET_SDR               0x23
+#define IPMI_MSG_CMD_GET_DEV_SDR_INFO      0x20
+#define IPMI_MSG_CMD_GET_DEV_SDR           0x21
+#define IPMI_MSG_CMD_RESERVE_DEV_SDRREP    0x22
+#define IPMI_MSG_CMD_COLD_RESET            0x02
+#define IPMI_MSG_CMD_SET_FRU_POLICY        0x0A
+#define IPMI_MSG_CMD_GET_FRU_POLICY        0x0B
+#define IPMI_MSG_CMD_SET_FRU_ACT           0x0C
+#define IPMI_MSG_CMD_GET_DEVICE_ID         0x01
 
 /* IPMI message request network function codes */
-#define IPMI_MSG_NETFN_CHASSIS                0x00
-#define IPMI_MSG_NETFN_SENSOR_EVENT           0x04
-#define IPMI_MSG_NETFN_APP_REQUEST            0x06
-#define IPMI_MSG_NETFN_STORAGE                0x0A
-#define IPMI_MSG_NETFN_PICMG                  0x2C
+#define IPMI_MSG_NETFN_CHASSIS      0x00
+#define IPMI_MSG_NETFN_SENSOR_EVENT 0x04
+#define IPMI_MSG_NETFN_APP_REQUEST  0x06
+#define IPMI_MSG_NETFN_STORAGE      0x0A
+#define IPMI_MSG_NETFN_PICMG        0x2C
 
 /* Read offset: bridged request, reply is in 1 message packet (NAT) */
-#define IPMI_RPLY_BRIDGED_1REPLY_OFFSET      7
+#define IPMI_RPLY_BRIDGED_1REPLY_OFFSET 7
 /* Read offset: bridged request, reply is in 2 message packet2 (VT) */
-#define IPMI_RPLY_BRIDGED_2REPLY_OFFSET      22
+#define IPMI_RPLY_BRIDGED_2REPLY_OFFSET 22
 /* Read offset: double bridged request, reply is in 1 message packet (NAT), not sure about this one */
-#define IPMI_RPLY_2BRIDGED_1REPLY_OFFSET     0
+#define IPMI_RPLY_2BRIDGED_1REPLY_OFFSET 0
 
-#define FOOTER_LENGTH 1  /* checksum */
+#define FOOTER_LENGTH 1 /* checksum */
 
-/* Response payload (aka IMSG2) message lengths 
+/* Response payload (aka IMSG2) message lengths
  * Includes completion code, but not final checksum)
  * (set to 0 for those that can vary)
  */
-#define IPMI_RPLY_IMSG2_GET_CHAN_AUTH_LENGTH           9
-#define IPMI_RPLY_IMSG2_GET_SESSION_CHALLENGE_LENGTH   21
-#define IPMI_RPLY_IMSG2_ACTIVATE_SESSION_LENGTH        11
-#define IPMI_RPLY_IMSG2_SET_PRIV_LEVEL_LENGTH          2
-#define IPMI_RPLY_IMSG2_CLOSE_SESSION_LENGTH           1
-#define IPMI_RPLY_IMSG2_SENSOR_READ_MAX_LENGTH         5  /* length varies */
-#define IPMI_RPLY_IMSG2_GET_SENSOR_THRESH_LENGTH       8  /* need to determine this; using NAT length for now*/
-#define IPMI_RPLY_IMSG2_GET_CHAS_STATUS_LENGTH         4  /* does NOT include optional byte */
-#define IPMI_RPLY_IMSG2_CHAS_CTRL_LENGTH               1
-#define IPMI_RPLY_IMSG2_GET_FRU_INFO_LENGTH            4  /* get fru message length is this + remaining data bytes */
-#define IPMI_RPLY_IMSG2_READ_FRU_DATA_BASE_LENGTH      2
-#define IPMI_RPLY_IMSG2_WRITE_FRU_DATA_LENGTH          2
-#define IPMI_RPLY_IMSG2_GET_SDRREP_INFO_LENGTH         15
-#define IPMI_RPLY_IMSG2_RESERVE_SDRREP_LENGTH          3
-#define IPMI_RPLY_IMSG2_GET_SDR_BASE_LENGTH            3  /* get sdr message length is this + remaining data bytes */
-#define IPMI_RPLY_IMSG2_GET_SDR_LENGTH                 0  /* varies */
-#define IPMI_RPLY_IMSG2_GET_DEV_SDR_INFO_LENGTH        7
-#define IPMI_RPLY_IMSG2_GET_DEV_SDR_LENGTH             0  /* varies; base length is 3 */
-#define IPMI_RPLY_IMSG2_COLD_RESET_LENGTH              1
-#define IPMI_RPLY_IMSG2_SEND_MSG_LENGTH                4
+#define IPMI_RPLY_IMSG2_GET_CHAN_AUTH_LENGTH         9
+#define IPMI_RPLY_IMSG2_GET_SESSION_CHALLENGE_LENGTH 21
+#define IPMI_RPLY_IMSG2_ACTIVATE_SESSION_LENGTH      11
+#define IPMI_RPLY_IMSG2_SET_PRIV_LEVEL_LENGTH        2
+#define IPMI_RPLY_IMSG2_CLOSE_SESSION_LENGTH         1
+#define IPMI_RPLY_IMSG2_SENSOR_READ_MAX_LENGTH       5 /* length varies */
+#define IPMI_RPLY_IMSG2_GET_SENSOR_THRESH_LENGTH     8 /* need to determine this; using NAT length for now*/
+#define IPMI_RPLY_IMSG2_GET_CHAS_STATUS_LENGTH       4 /* does NOT include optional byte */
+#define IPMI_RPLY_IMSG2_CHAS_CTRL_LENGTH             1
+#define IPMI_RPLY_IMSG2_GET_FRU_INFO_LENGTH          4 /* get fru message length is this + remaining data bytes */
+#define IPMI_RPLY_IMSG2_READ_FRU_DATA_BASE_LENGTH    2
+#define IPMI_RPLY_IMSG2_WRITE_FRU_DATA_LENGTH        2
+#define IPMI_RPLY_IMSG2_GET_SDRREP_INFO_LENGTH       15
+#define IPMI_RPLY_IMSG2_RESERVE_SDRREP_LENGTH        3
+#define IPMI_RPLY_IMSG2_GET_SDR_BASE_LENGTH          3 /* get sdr message length is this + remaining data bytes */
+#define IPMI_RPLY_IMSG2_GET_SDR_LENGTH               0 /* varies */
+#define IPMI_RPLY_IMSG2_GET_DEV_SDR_INFO_LENGTH      7
+#define IPMI_RPLY_IMSG2_GET_DEV_SDR_LENGTH           0 /* varies; base length is 3 */
+#define IPMI_RPLY_IMSG2_COLD_RESET_LENGTH            1
+#define IPMI_RPLY_IMSG2_SEND_MSG_LENGTH              4
 #define IPMI_RPLY_IMSG2_CLOSE_SESSION_LENGTH         1
 #define IPMI_RPLY_IMSG2_SENSOR_READ_MAX_LENGTH       5 /* length varies */
 #define IPMI_RPLY_IMSG2_GET_SENSOR_THRESH_LENGTH     8 /* need to determine this; using NAT length for now*/
@@ -450,158 +485,167 @@ extern size_t IPMI_MSG1_LENGTH;
 #define IPMI_RPLY_IMSG2_GET_SDRREP_INFO_LENGTH       15
 #define IPMI_RPLY_IMSG2_RESERVE_SDRREP_LENGTH        3
 #define IPMI_RPLY_IMSG2_GET_SDR_BASE_LENGTH          3 /* get sdr message length is this + remaining data bytes */
-#define IPMI_RPLY_IMSG2_GET_SDR_LENGTH               0  /* varies */
+#define IPMI_RPLY_IMSG2_GET_SDR_LENGTH               0 /* varies */
 #define IPMI_RPLY_IMSG2_GET_DEV_SDR_INFO_LENGTH      7
-#define IPMI_RPLY_IMSG2_GET_DEV_SDR_LENGTH           0  /* varies; base length is 3 */
+#define IPMI_RPLY_IMSG2_GET_DEV_SDR_LENGTH           0 /* varies; base length is 3 */
 #define IPMI_RPLY_IMSG2_COLD_RESET_LENGTH            1
 
 /* Get Authentication Capabilities message */
-#define IPMI_RPLY_IMSG2_AUTH_CAP_CHAN_OFFSET           1  /* Get Authentication Capabilities response - channel number */
-#define IPMI_RPLY_IMSG2_AUTH_CAP_AUTH_OFFSET           2  /* Get Authentication Capabilities response - authentication type support */
+#define IPMI_RPLY_IMSG2_AUTH_CAP_CHAN_OFFSET 1 /* Get Authentication Capabilities response - channel number */
+#define IPMI_RPLY_IMSG2_AUTH_CAP_AUTH_OFFSET                                                                           \
+    2 /* Get Authentication Capabilities response - authentication type support */
 
 /* Get Session Challenge message */
-#define IPMI_RPLY_IMSG2_GET_SESS_TEMP_ID_OFFSET        1  /* Temporary session ID */
-#define IPMI_RPLY_IMSG2_SESSION_ID_LENGTH              4  /* For both permanent and temporary session ID (sess chall and act sess message replies) */
-#define IPMI_RPLY_IMSG2_GET_SESS_CHALLENGE_STR_OFFSET  5  /* Challenge string */
-#define IPMI_RPLY_CHALLENGE_STR_LENGTH                 16
+#define IPMI_RPLY_IMSG2_GET_SESS_TEMP_ID_OFFSET 1 /* Temporary session ID */
+#define IPMI_RPLY_IMSG2_SESSION_ID_LENGTH                                                                              \
+    4 /* For both permanent and temporary session ID (sess chall and act sess message replies) */
+#define IPMI_RPLY_IMSG2_GET_SESS_CHALLENGE_STR_OFFSET 5 /* Challenge string */
+#define IPMI_RPLY_CHALLENGE_STR_LENGTH                16
 
 /* Activate Session message */
-#define IPMI_RPLY_IMSG2_ACT_SESS_AUTH_TYPE_OFFSET      1  /* Authentication type */
-#define IPMI_RPLY_IMSG2_ACT_SESS_ID_OFFSET             2  /* Session ID for remainder of session */
-#define IPMI_RPLY_IMSG2_ACT_SESS_INIT_SEND_SEQ_OFFSET  6  /* Start sequence number for messages to MCH */
-#define IPMI_RPLY_INIT_SEND_SEQ_LENGTH                 4
-#define IPMI_RPLY_IMSG2_ACT_SESS_MAX_PRIV_OFFSET       10 /* Maximum privilege level allowed for session */
-#define IPMI_RPLY_HDR_SESS_SEQ_OFFSET                  1  /* From-MCH session sequence number (in reply to non-bridged message) */
-#define IPMI_RPLY_SEQ_LENGTH                           4
+#define IPMI_RPLY_IMSG2_ACT_SESS_AUTH_TYPE_OFFSET     1 /* Authentication type */
+#define IPMI_RPLY_IMSG2_ACT_SESS_ID_OFFSET            2 /* Session ID for remainder of session */
+#define IPMI_RPLY_IMSG2_ACT_SESS_INIT_SEND_SEQ_OFFSET 6 /* Start sequence number for messages to MCH */
+#define IPMI_RPLY_INIT_SEND_SEQ_LENGTH                4
+#define IPMI_RPLY_IMSG2_ACT_SESS_MAX_PRIV_OFFSET      10 /* Maximum privilege level allowed for session */
+#define IPMI_RPLY_HDR_SESS_SEQ_OFFSET 1 /* From-MCH session sequence number (in reply to non-bridged message) */
+#define IPMI_RPLY_SEQ_LENGTH          4
 
 /* Get Chassis Status message */
-#define IPMI_RPLY_IMSG2_GET_CHAS_POWER_STATE_OFFSET    1  /* Current power state */
-#define IPMI_RPLY_IMSG2_GET_CHAS_LAST_EVENT_OFFSET     2  /* Last power event */
-#define IPMI_RPLY_IMSG2_GET_CHAS_MISC_STATE_OFFSET     3  /* Misc chassis state */
-#define IPMI_GET_CHAS_POWER_STATE(x) (x & ~0x80)
-#define IPMI_GET_CHAS_LAST_EVENT(x)  (x & ~0xE0)
-#define IPMI_GET_CHAS_MISC_STATE(x)  (x & ~0xF0)
+#define IPMI_RPLY_IMSG2_GET_CHAS_POWER_STATE_OFFSET 1 /* Current power state */
+#define IPMI_RPLY_IMSG2_GET_CHAS_LAST_EVENT_OFFSET  2 /* Last power event */
+#define IPMI_RPLY_IMSG2_GET_CHAS_MISC_STATE_OFFSET  3 /* Misc chassis state */
+#define IPMI_GET_CHAS_POWER_STATE(x)                (x & ~0x80)
+#define IPMI_GET_CHAS_LAST_EVENT(x)                 (x & ~0xE0)
+#define IPMI_GET_CHAS_MISC_STATE(x)                 (x & ~0xF0)
 
 /* Get Device ID message */
-#define IPMI_RPLY_IMSG2_GET_DEVICE_ID_ID_OFFSET        1     /* Device ID, 0 = unspecified */
-#define IPMI_RPLY_IMSG2_GET_DEVICE_ID_DEVICE_VERS_OFFSET  2  /* Device revision, [7] 1=provides device SDR;[6:4] reserved; [3:0] device revision, binary encoded */
-#define IPMI_RPLY_IMSG2_GET_DEVICE_ID_FW_VERS1_OFFSET  3     /* FW revision 1, [7] device avail (see ipmi spec for details), [6:0] major fw revision, binary encoded */
-#define IPMI_RPLY_IMSG2_GET_DEVICE_ID_FW_VERS2_OFFSET  4     /* FW revision 2, minor firmware revision, BCD encoded */
-#define IPMI_RPLY_IMSG2_GET_DEVICE_ID_IPMI_VERS_OFFSET 5     /* IPMI version, BCD encoded, 0x00 reserved, [7:4] LS digit, [3:0] MS digit */
-#define IPMI_RPLY_IMSG2_GET_DEVICE_ID_SUPPORT_OFFSET   6     /* Additional support, see device capabilities in Management Controller record below*/
-#define IPMI_RPLY_IMSG2_GET_DEVICE_ID_MANUF_ID_OFFSET  7     /* Returned from Get Device ID Command */
-#define IPMI_RPLY_IPMI_VERS_OFFSET                     8     /* Returned from Get Device ID Command */
-#define IPMI_RPLY_IMSG2_GET_DEVICE_ID_IPMI_VERS_OFFSET 5     /* Returned from Get Device ID Command */
-#define IPMI_RPLY_MANUF_ID_LENGTH   3    
-#define IPMI_VER_LSD(x) (x & 0xF0)>>4   /* Extract IPMI version, least significant digit, eg 0x51 = version 1.5 */
-#define IPMI_VER_MSD(x)  x & 0x0F       /* Extract IPMI version, most significant digit */
-#define IPMI_MANUF_ID(x) x & 0x0FFFFF   /* Extract manufacturer ID */
-#define IPMI_DEVICE_PROVIDES_DEVICE_SDR(x)   ((x&1<<7)>>7)
-//#define IPMI_DEVICE_PROVIDES_FRU_INV_INFO(x) ((x&1<<3)>>3)
+#define IPMI_RPLY_IMSG2_GET_DEVICE_ID_ID_OFFSET 1 /* Device ID, 0 = unspecified */
+#define IPMI_RPLY_IMSG2_GET_DEVICE_ID_DEVICE_VERS_OFFSET                                                               \
+    2 /* Device revision, [7] 1=provides device SDR;[6:4] reserved; [3:0] device revision, binary encoded */
+#define IPMI_RPLY_IMSG2_GET_DEVICE_ID_FW_VERS1_OFFSET                                                                  \
+    3 /* FW revision 1, [7] device avail (see ipmi spec for details), [6:0] major fw revision, binary encoded */
+#define IPMI_RPLY_IMSG2_GET_DEVICE_ID_FW_VERS2_OFFSET 4 /* FW revision 2, minor firmware revision, BCD encoded */
+#define IPMI_RPLY_IMSG2_GET_DEVICE_ID_IPMI_VERS_OFFSET                                                                 \
+    5 /* IPMI version, BCD encoded, 0x00 reserved, [7:4] LS digit, [3:0] MS digit */
+#define IPMI_RPLY_IMSG2_GET_DEVICE_ID_SUPPORT_OFFSET                                                                   \
+    6 /* Additional support, see device capabilities in Management Controller record below*/
+#define IPMI_RPLY_IMSG2_GET_DEVICE_ID_MANUF_ID_OFFSET  7 /* Returned from Get Device ID Command */
+#define IPMI_RPLY_IPMI_VERS_OFFSET                     8 /* Returned from Get Device ID Command */
+#define IPMI_RPLY_IMSG2_GET_DEVICE_ID_IPMI_VERS_OFFSET 5 /* Returned from Get Device ID Command */
+#define IPMI_RPLY_MANUF_ID_LENGTH                      3
+#define IPMI_VER_LSD(x)  (x & 0xF0) >> 4 /* Extract IPMI version, least significant digit, eg 0x51 = version 1.5 */
+#define IPMI_VER_MSD(x)  x & 0x0F        /* Extract IPMI version, most significant digit */
+#define IPMI_MANUF_ID(x) x & 0x0FFFFF    /* Extract manufacturer ID */
+#define IPMI_DEVICE_PROVIDES_DEVICE_SDR(x) ((x & 1 << 7) >> 7)
+// #define IPMI_DEVICE_PROVIDES_FRU_INV_INFO(x) ((x&1<<3)>>3)
 
 /* SDR commands */
-#define IPMI_SDRREP_PARM_GET_SDR                  0
-#define IPMI_SDRREP_PARM_GET_DEV_SDR              1
+#define IPMI_SDRREP_PARM_GET_SDR     0
+#define IPMI_SDRREP_PARM_GET_DEV_SDR 1
 
 /* Get Device SDR Info message */
-#define IPMI_GET_DEV_SDR_INFO_LUN_SENS_COUNT      0
-#define IPMI_GET_DEV_SDR_INFO_SDR_COUNT           1
+#define IPMI_GET_DEV_SDR_INFO_LUN_SENS_COUNT 0
+#define IPMI_GET_DEV_SDR_INFO_SDR_COUNT      1
 
 /* Get SDR Repository Info message */
-#define IPMI_RPLY_IMSG2_SDRREP_VER_OFFSET              1     /* SDR Repository Info */    
-#define IPMI_RPLY_IMSG2_SDRREP_CNT_LSB_OFFSET          2     /* Number of records in repository, LSB */
-#define IPMI_RPLY_IMSG2_SDRREP_CNT_MSB_OFFSET          3     /* Number of records in repository, MSB */
-#define IPMI_RPLY_IMSG2_SDRREP_ADD_TS_OFFSET           6     /* Timestamp of most recent addition, LSB first */
-#define IPMI_RPLY_IMSG2_SDRREP_DEL_TS_OFFSET           10    /* Timestamp of most recent deletion, LSB first */
-#define IPMI_RPLY_IMSG2_DEV_SDR_INFO_CNT_OFFSET        1     /* Number of SDRs for device */
-#define IPMI_RPLY_IMSG2_DEV_SDR_INFO_FLAGS_OFFSET      2     /* SDR flags */
-#define IPMI_TS_LENGTH 4 /* Number of bytes in Timestamp */
+#define IPMI_RPLY_IMSG2_SDRREP_VER_OFFSET         1  /* SDR Repository Info */
+#define IPMI_RPLY_IMSG2_SDRREP_CNT_LSB_OFFSET     2  /* Number of records in repository, LSB */
+#define IPMI_RPLY_IMSG2_SDRREP_CNT_MSB_OFFSET     3  /* Number of records in repository, MSB */
+#define IPMI_RPLY_IMSG2_SDRREP_ADD_TS_OFFSET      6  /* Timestamp of most recent addition, LSB first */
+#define IPMI_RPLY_IMSG2_SDRREP_DEL_TS_OFFSET      10 /* Timestamp of most recent deletion, LSB first */
+#define IPMI_RPLY_IMSG2_DEV_SDR_INFO_CNT_OFFSET   1  /* Number of SDRs for device */
+#define IPMI_RPLY_IMSG2_DEV_SDR_INFO_FLAGS_OFFSET 2  /* SDR flags */
+#define IPMI_TS_LENGTH                            4  /* Number of bytes in Timestamp */
 
 /* Get SDR message */
-#define IPMI_RPLY_IMSG2_GET_SDR_NEXT_ID_LSB_OFFSET     1     /* ID of next sensor in repository, LSB */
-#define IPMI_RPLY_IMSG2_GET_SDR_NEXT_ID_MSB_OFFSET     2     /* ID of next sensor in repository, MSB */
-#define IPMI_RPLY_IMSG2_GET_SDR_DATA_OFFSET            3     /* Requested SDR data */
-#define SDR_MAX_READ_SIZE 22 /*not all systems can deliver full SDR in one message, ipmitool uses 22 for VT (and maybe others */
+#define IPMI_RPLY_IMSG2_GET_SDR_NEXT_ID_LSB_OFFSET 1 /* ID of next sensor in repository, LSB */
+#define IPMI_RPLY_IMSG2_GET_SDR_NEXT_ID_MSB_OFFSET 2 /* ID of next sensor in repository, MSB */
+#define IPMI_RPLY_IMSG2_GET_SDR_DATA_OFFSET        3 /* Requested SDR data */
+#define SDR_MAX_READ_SIZE                                                                                              \
+    22 /*not all systems can deliver full SDR in one message, ipmitool uses 22 for VT (and maybe others */
 
 /* Reserve SDR message */
-#define IPMI_RPLY_IMSG2_GET_SDR_RES_LSB_OFFSET         1     /* Reservation ID returned by Reserve SDR Rep */
-#define IPMI_RPLY_IMSG2_GET_SDR_RES_MSB_OFFSET         2     /* Reservation ID returned by Reserve SDR Rep */
+#define IPMI_RPLY_IMSG2_GET_SDR_RES_LSB_OFFSET 1 /* Reservation ID returned by Reserve SDR Rep */
+#define IPMI_RPLY_IMSG2_GET_SDR_RES_MSB_OFFSET 2 /* Reservation ID returned by Reserve SDR Rep */
 
 /* Get FRU Inventory Area Info message */
-#define IPMI_RPLY_IMSG2_FRU_AREA_SIZE_LSB_OFFSET       1     /* FRU inventory area size in bytes, LSB */
-#define IPMI_RPLY_IMSG2_FRU_AREA_SIZE_MSB_OFFSET       2     /* FRU inventory area size in bytes, MSB */
-#define IPMI_RPLY_IMSG2_FRU_AREA_ACCESS_OFFSET         3     /* Bit 0 indicates if device is accessed by bytes (0) or words (1) */
-#define IPMI_RPLY_IMSG2_FRU_DATA_READ_OFFSET           2     /* FRU data */
+#define IPMI_RPLY_IMSG2_FRU_AREA_SIZE_LSB_OFFSET 1 /* FRU inventory area size in bytes, LSB */
+#define IPMI_RPLY_IMSG2_FRU_AREA_SIZE_MSB_OFFSET 2 /* FRU inventory area size in bytes, MSB */
+#define IPMI_RPLY_IMSG2_FRU_AREA_ACCESS_OFFSET   3 /* Bit 0 indicates if device is accessed by bytes (0) or words (1) */
+#define IPMI_RPLY_IMSG2_FRU_DATA_READ_OFFSET     2 /* FRU data */
 
 /* Get Sensor Reading message */
-#define IPMI_RPLY_IMSG2_SENSOR_READING_OFFSET          1     /* Sensor reading (1 byte) */
-#define IPMI_RPLY_IMSG2_DISCRETE_SENSOR_READING_OFFSET 3     /* Discrete multi-state sensor value in threshold/assertions byte */
-#define IPMI_RPLY_IMSG2_SENSOR_ENABLE_BITS_OFFSET      2     /* Sensor enable bits: event msgs; scanning; reading/state */
-#define IPMI_RPLY_IMSG2_SENSOR_THRESH_MASK_OFFSET      1     /* Mask of readable thresholds */
-#define IPMI_RPLY_IMSG2_SENSOR_THRESH_LNC_OFFSET       2     /* Lower non-critical threshold */
-#define IPMI_RPLY_IMSG2_SENSOR_THRESH_LC_OFFSET        3     /* Lower critical threshold */
-#define IPMI_RPLY_IMSG2_SENSOR_THRESH_LNR_OFFSET       4     /* Lower non-recoverable threshold */
-#define IPMI_RPLY_IMSG2_SENSOR_THRESH_UNC_OFFSET       5     /* Upper non-critical threshold */
-#define IPMI_RPLY_IMSG2_SENSOR_THRESH_UC_OFFSET        6     /* Upper critical threshold */
-#define IPMI_RPLY_IMSG2_SENSOR_THRESH_UNR_OFFSET       7     /* Upper non-recoverable threshold */
+#define IPMI_RPLY_IMSG2_SENSOR_READING_OFFSET 1 /* Sensor reading (1 byte) */
+#define IPMI_RPLY_IMSG2_DISCRETE_SENSOR_READING_OFFSET                                                                 \
+    3                                               /* Discrete multi-state sensor value in threshold/assertions byte */
+#define IPMI_RPLY_IMSG2_SENSOR_ENABLE_BITS_OFFSET 2 /* Sensor enable bits: event msgs; scanning; reading/state */
+#define IPMI_RPLY_IMSG2_SENSOR_THRESH_MASK_OFFSET 1 /* Mask of readable thresholds */
+#define IPMI_RPLY_IMSG2_SENSOR_THRESH_LNC_OFFSET  2 /* Lower non-critical threshold */
+#define IPMI_RPLY_IMSG2_SENSOR_THRESH_LC_OFFSET   3 /* Lower critical threshold */
+#define IPMI_RPLY_IMSG2_SENSOR_THRESH_LNR_OFFSET  4 /* Lower non-recoverable threshold */
+#define IPMI_RPLY_IMSG2_SENSOR_THRESH_UNC_OFFSET  5 /* Upper non-critical threshold */
+#define IPMI_RPLY_IMSG2_SENSOR_THRESH_UC_OFFSET   6 /* Upper critical threshold */
+#define IPMI_RPLY_IMSG2_SENSOR_THRESH_UNR_OFFSET  7 /* Upper non-recoverable threshold */
 
 #define IPMI_DATA_LANG_CODE_ENGLISH1 0
 #define IPMI_DATA_LANG_CODE_ENGLISH2 25
 
 #define IPMI_DATA_TYPE(x)         (x & 0xC0) >> 6
-#define IPMI_DATA_LENGTH(x)        x & 0x3F
-#define IPMI_DATA_LANG_ENGLISH(x)  (x==IPMI_DATA_LANG_CODE_ENGLISH1) || (x==IPMI_DATA_LANG_CODE_ENGLISH2)             
+#define IPMI_DATA_LENGTH(x)       x & 0x3F
+#define IPMI_DATA_LANG_ENGLISH(x) (x == IPMI_DATA_LANG_CODE_ENGLISH1) || (x == IPMI_DATA_LANG_CODE_ENGLISH2)
 
 /* Completion codes, IPMI v2.0 Table 5-2 */
-#define IPMI_COMP_CODE_NORMAL                   0x00
-#define IPMI_COMP_CODE_NODE_BUSY                0xC0
-#define IPMI_COMP_CODE_INVALID_COMMAND          0xC1
-#define IPMI_COMP_CODE_INVALID_COMMAND_FOR_LUN  0xC2
-#define IPMI_COMP_CODE_TIMEOUT                  0xC3
-#define IPMI_COMP_CODE_OUT_OF_SPACE             0xC4
-#define IPMI_COMP_CODE_RESERVATION              0xC5
-#define IPMI_COMP_CODE_REQUEST_TRUNCATED        0xC6
-#define IPMI_COMP_CODE_REQUEST_LENGTH_INVALID   0xC7
-#define IPMI_COMP_CODE_REQUEST_LENGTH_LIMIT     0xC8
-#define IPMI_COMP_CODE_PARAMETER_RANGE          0xC9
-#define IPMI_COMP_CODE_REQUESTED_BYTES          0xCA
-#define IPMI_COMP_CODE_REQUESTED_DATA           0xCB
-#define IPMI_COMP_CODE_INVALID_FIELD            0xCC
-#define IPMI_COMP_CODE_COMMAND_ILLEGAL          0xCD
-#define IPMI_COMP_CODE_COMMAND_RESPONSE         0xCE
-#define IPMI_COMP_CODE_DUPLICATED_REQUEST       0xCF
-#define IPMI_COMP_CODE_SDR_REP_UPDATE           0xD0
-#define IPMI_COMP_CODE_DEVICE_FW_UPDATE         0xD1
-#define IPMI_COMP_CODE_BMC_INIT                 0xD2
-#define IPMI_COMP_CODE_DESTINATION_UNAVAIL      0xD3
-#define IPMI_COMP_CODE_PRIVILEGE                0xD4
-#define IPMI_COMP_CODE_NOT_SUPPORTED            0xD5
-#define IPMI_COMP_CODE_SUBFUNCTION_UNAVAIL      0xD6
-#define IPMI_COMP_CODE_DEVICE_SPECIFIC_MIN      0x01
-#define IPMI_COMP_CODE_DEVICE_SPECIFIC_MAX      0x7E
-#define IPMI_COMP_CODE_COMMAND_SPECIFIC_MIN     0x80
-#define IPMI_COMP_CODE_COMMAND_SPECIFIC_MAX     0xBE
-#define IPMI_COMP_CODE_UNSPECIFIED              0xFF
+#define IPMI_COMP_CODE_NORMAL                  0x00
+#define IPMI_COMP_CODE_NODE_BUSY               0xC0
+#define IPMI_COMP_CODE_INVALID_COMMAND         0xC1
+#define IPMI_COMP_CODE_INVALID_COMMAND_FOR_LUN 0xC2
+#define IPMI_COMP_CODE_TIMEOUT                 0xC3
+#define IPMI_COMP_CODE_OUT_OF_SPACE            0xC4
+#define IPMI_COMP_CODE_RESERVATION             0xC5
+#define IPMI_COMP_CODE_REQUEST_TRUNCATED       0xC6
+#define IPMI_COMP_CODE_REQUEST_LENGTH_INVALID  0xC7
+#define IPMI_COMP_CODE_REQUEST_LENGTH_LIMIT    0xC8
+#define IPMI_COMP_CODE_PARAMETER_RANGE         0xC9
+#define IPMI_COMP_CODE_REQUESTED_BYTES         0xCA
+#define IPMI_COMP_CODE_REQUESTED_DATA          0xCB
+#define IPMI_COMP_CODE_INVALID_FIELD           0xCC
+#define IPMI_COMP_CODE_COMMAND_ILLEGAL         0xCD
+#define IPMI_COMP_CODE_COMMAND_RESPONSE        0xCE
+#define IPMI_COMP_CODE_DUPLICATED_REQUEST      0xCF
+#define IPMI_COMP_CODE_SDR_REP_UPDATE          0xD0
+#define IPMI_COMP_CODE_DEVICE_FW_UPDATE        0xD1
+#define IPMI_COMP_CODE_BMC_INIT                0xD2
+#define IPMI_COMP_CODE_DESTINATION_UNAVAIL     0xD3
+#define IPMI_COMP_CODE_PRIVILEGE               0xD4
+#define IPMI_COMP_CODE_NOT_SUPPORTED           0xD5
+#define IPMI_COMP_CODE_SUBFUNCTION_UNAVAIL     0xD6
+#define IPMI_COMP_CODE_DEVICE_SPECIFIC_MIN     0x01
+#define IPMI_COMP_CODE_DEVICE_SPECIFIC_MAX     0x7E
+#define IPMI_COMP_CODE_COMMAND_SPECIFIC_MIN    0x80
+#define IPMI_COMP_CODE_COMMAND_SPECIFIC_MAX    0xBE
+#define IPMI_COMP_CODE_UNSPECIFIED             0xFF
 
 /* Command-specific completion codes */
-#define IPMI_COMP_CODE_GET_SESS_INVALID_USER    0x81
-#define IPMI_COMP_CODE_GET_SESS_NULL_USER       0x82
+#define IPMI_COMP_CODE_GET_SESS_INVALID_USER 0x81
+#define IPMI_COMP_CODE_GET_SESS_NULL_USER    0x82
 
 /* Sensor definitions and constants */
-#define IPMI_SENSOR_READING_DISABLED(x)   x & 1<<5
-#define IPMI_SENSOR_SCANNING_DISABLED(x) ~x & 1<<6
-#define IPMI_SDR_SENSOR_THRESH_ACCESS(x) (x & 0xC) >> 2
+#define IPMI_SENSOR_READING_DISABLED(x)          x & 1 << 5
+#define IPMI_SENSOR_SCANNING_DISABLED(x)         ~x & 1 << 6
+#define IPMI_SDR_SENSOR_THRESH_ACCESS(x)         (x & 0xC) >> 2
 #define IPMI_SDR_SENSOR_THRESH_NONE              0
 #define IPMI_SDR_SENSOR_THRESH_READABLE          1
 #define IPMI_SDR_SENSOR_THRESH_READABLE_SETTABLE 2
 #define IPMI_SDR_SENSOR_THRESH_FIXED_UNREADABLE  3
-#define IPMI_SENSOR_THRESH_IS_READABLE(x) ((x == IPMI_SDR_SENSOR_THRESH_READABLE) || (x == IPMI_SDR_SENSOR_THRESH_READABLE_SETTABLE))
-#define IPMI_SENSOR_THRESH_LNC_READABLE(x) x & 1<<0
-#define IPMI_SENSOR_THRESH_LC_READABLE(x)  x & 1<<1
-#define IPMI_SENSOR_THRESH_LNR_READABLE(x) x & 1<<2
-#define IPMI_SENSOR_THRESH_UNC_READABLE(x) x & 1<<3
-#define IPMI_SENSOR_THRESH_UC_READABLE(x)  x & 1<<4
-#define IPMI_SENSOR_THRESH_UNR_READABLE(x) x & 1<<5
+#define IPMI_SENSOR_THRESH_IS_READABLE(x)                                                                              \
+    ((x == IPMI_SDR_SENSOR_THRESH_READABLE) || (x == IPMI_SDR_SENSOR_THRESH_READABLE_SETTABLE))
+#define IPMI_SENSOR_THRESH_LNC_READABLE(x) x & 1 << 0
+#define IPMI_SENSOR_THRESH_LC_READABLE(x)  x & 1 << 1
+#define IPMI_SENSOR_THRESH_LNR_READABLE(x) x & 1 << 2
+#define IPMI_SENSOR_THRESH_UNC_READABLE(x) x & 1 << 3
+#define IPMI_SENSOR_THRESH_UC_READABLE(x)  x & 1 << 4
+#define IPMI_SENSOR_THRESH_UNR_READABLE(x) x & 1 << 5
 
 /* Sensor Data Record (SDR) types*/
 #define SDR_TYPE_FULL_SENSOR      0x01
@@ -617,23 +661,23 @@ extern size_t IPMI_MSG1_LENGTH;
 #define SDR_TYPE_OEM              0xC0
 
 /* SDR data */
-#define SDR_ID_LAST_SENSOR     0xFFFF
-#define SDR_MAX_LENGTH         64
-#define SDR_FRU_MAX_LENGTH     33
+#define SDR_ID_LAST_SENSOR 0xFFFF
+#define SDR_MAX_LENGTH     64
+#define SDR_FRU_MAX_LENGTH 33
 
 /* Common to all SDRs */
-#define SDR_HEADER_LENGTH      5
-#define SDR_ID_LSB_OFFSET      0  /* SDR Header */
-#define SDR_ID_MSB_OFFSET      1
-#define SDR_VER_OFFSET         2
-#define SDR_REC_TYPE_OFFSET    3
-#define SDR_LENGTH_OFFSET      4
+#define SDR_HEADER_LENGTH   5
+#define SDR_ID_LSB_OFFSET   0 /* SDR Header */
+#define SDR_ID_MSB_OFFSET   1
+#define SDR_VER_OFFSET      2
+#define SDR_REC_TYPE_OFFSET 3
+#define SDR_LENGTH_OFFSET   4
 
 /* SDR Full Sensor contents */
-#define SDR_OWNER_OFFSET        5  /* SDR Key Fields */
+#define SDR_OWNER_OFFSET        5 /* SDR Key Fields */
 #define SDR_LUN_OFFSET          6
-#define SDR_NUMBER_OFFSET       7     
-#define SDR_ENTITY_ID_OFFSET    8  /* SDR Body */
+#define SDR_NUMBER_OFFSET       7
+#define SDR_ENTITY_ID_OFFSET    8 /* SDR Body */
 #define SDR_ENTITY_INST_OFFSET  9
 #define SDR_INIT_OFFSET         10
 #define SDR_CAP_OFFSET          11
@@ -650,70 +694,74 @@ extern size_t IPMI_MSG1_LENGTH;
 #define SDR_UNITS3_OFFSET       22
 #define SDR_LINEAR_OFFSET       23
 #define SDR_M_OFFSET            24 /* LS 8 bits, 2's complement signed 10-bit 'M' value */
-#define SDR_M_TOL_OFFSET        25 /* [7:6] MS 2 bits, [5:0] Tolerance 6 bits, unsigned (in +/- 1/2 raw counts) */ 
-#define SDR_B_OFFSET            26 /* LS 8 bits, 2's complement signed 10-bit 'B' value */			   
-#define SDR_B_ACC_OFFSET        27 /* [7:6] MS 2 bits unsigned, 10-bit acc in 1/100 % scaled up by: [5:0] Accuracy LS 6 bits */ 
-#define SDR_ACC_OFFSET          28 /* [7:4] Accuracy MS 4 bits, [3:2] Accuracy exp: 2 bits unsigned, [1:0] sensor direction */
-#define SDR_EXP_OFFSET          29
-#define SDR_ANLG_CHAR_OFFSET    30
-#define SDR_NOMINAL_OFFSET      31
-#define SDR_NORM_MAX_OFFSET     32
-#define SDR_NORM_MIN_OFFSET     33
-#define SDR_STR_LENGTH_OFFSET   47
-#define SDR_STR_OFFSET          48
+#define SDR_M_TOL_OFFSET        25 /* [7:6] MS 2 bits, [5:0] Tolerance 6 bits, unsigned (in +/- 1/2 raw counts) */
+#define SDR_B_OFFSET            26 /* LS 8 bits, 2's complement signed 10-bit 'B' value */
+#define SDR_B_ACC_OFFSET                                                                                               \
+    27                    /* [7:6] MS 2 bits unsigned, 10-bit acc in 1/100 % scaled up by: [5:0] Accuracy LS 6 bits    \
+                           */
+#define SDR_ACC_OFFSET 28 /* [7:4] Accuracy MS 4 bits, [3:2] Accuracy exp: 2 bits unsigned, [1:0] sensor direction */
+#define SDR_EXP_OFFSET 29
+#define SDR_ANLG_CHAR_OFFSET  30
+#define SDR_NOMINAL_OFFSET    31
+#define SDR_NORM_MAX_OFFSET   32
+#define SDR_NORM_MIN_OFFSET   33
+#define SDR_STR_LENGTH_OFFSET 47
+#define SDR_STR_OFFSET        48
 /*...more...*/
 
 /* SDR Compact Sensor */
 #define SDR_COMPACT_STR_LENGTH_OFFSET 31
 #define SDR_COMPACT_STR_OFFSET        32
 
-#define SENSOR_LINEAR(x)           (x & 0x7F)
-#define SENSOR_CONV_M_B(x,y)       (x + ( (y & 0xC0) << 2))
-#define TWOS_COMP_SIGNED_NBIT(x,n) (x > (pow(2,n)/2 - 1)) ? x - pow(2,n) : x     /* Extract n-bit signed number stored as two's complement */
-#define ONES_COMP_SIGNED_NBIT(x,n) (x > (pow(2,n)/2 - 1)) ? x - pow(2,n) + 1 : x /* Extract n-bit signed number stored as one's complement */
-#define SENSOR_CONV_REXP(x)        ((x & 0xF0) >> 4)
-#define SENSOR_CONV_BEXP(x)        (x & 0xF)
-#define SENSOR_NOMINAL_GIVEN(x)    (x & (1<<0))
-#define SENSOR_NORM_MAX_GIVEN(x)   (x & (1<<1))
-#define SENSOR_NORM_MIN_GIVEN(x)   (x & (1<<2))
-#define SENSOR_NUMERIC_FORMAT(x)   ((x & 0xC0) >> 6)
-#define SDR_ENTITY_LOGICAL(x)      ((x & (1<<7)) >> 7) /* 1 if entity is logical entity; 0 if is physical entity */
+#define SENSOR_LINEAR(x)      (x & 0x7F)
+#define SENSOR_CONV_M_B(x, y) (x + ((y & 0xC0) << 2))
+#define TWOS_COMP_SIGNED_NBIT(x, n)                                                                                    \
+    (x > (pow(2, n) / 2 - 1)) ? x - pow(2, n) : x /* Extract n-bit signed number stored as two's complement */
+#define ONES_COMP_SIGNED_NBIT(x, n)                                                                                    \
+    (x > (pow(2, n) / 2 - 1)) ? x - pow(2, n) + 1 : x /* Extract n-bit signed number stored as one's complement */
+#define SENSOR_CONV_REXP(x)      ((x & 0xF0) >> 4)
+#define SENSOR_CONV_BEXP(x)      (x & 0xF)
+#define SENSOR_NOMINAL_GIVEN(x)  (x & (1 << 0))
+#define SENSOR_NORM_MAX_GIVEN(x) (x & (1 << 1))
+#define SENSOR_NORM_MIN_GIVEN(x) (x & (1 << 2))
+#define SENSOR_NUMERIC_FORMAT(x) ((x & 0xC0) >> 6)
+#define SDR_ENTITY_LOGICAL(x)    ((x & (1 << 7)) >> 7) /* 1 if entity is logical entity; 0 if is physical entity */
 
-#define SENSOR_UNITS_UNSPEC        0
-#define SENSOR_UNITS_DEGC          1
-#define SENSOR_UNITS_DEGF          2
-#define SENSOR_UNITS_DEGK          3
-#define SENSOR_UNITS_VOLTS         4
-#define SENSOR_UNITS_AMPS          5
-#define SENSOR_UNITS_WATTS         6
-#define SENSOR_UNITS_JOULES        7
-#define SENSOR_UNITS_COULOMBS      8
-#define SENSOR_UNITS_RPM           18
+#define SENSOR_UNITS_UNSPEC   0
+#define SENSOR_UNITS_DEGC     1
+#define SENSOR_UNITS_DEGF     2
+#define SENSOR_UNITS_DEGK     3
+#define SENSOR_UNITS_VOLTS    4
+#define SENSOR_UNITS_AMPS     5
+#define SENSOR_UNITS_WATTS    6
+#define SENSOR_UNITS_JOULES   7
+#define SENSOR_UNITS_COULOMBS 8
+#define SENSOR_UNITS_RPM      18
 /* more... */
 
-#define SENSOR_CONV_LINEAR         0
-#define SENSOR_CONV_LN             1
-#define SENSOR_CONV_LOG10          2
-#define SENSOR_CONV_LOG2           3
-#define SENSOR_CONV_E              4
-#define SENSOR_CONV_EXP10          5
-#define SENSOR_CONV_EXP2           6
-#define SENSOR_CONV_1_X            7
-#define SENSOR_CONV_SQR            8
-#define SENSOR_CONV_CUBE           9
-#define SENSOR_CONV_SQRT           10
-#define SENSOR_CONV_CUBE_NEG1      11
+#define SENSOR_CONV_LINEAR    0
+#define SENSOR_CONV_LN        1
+#define SENSOR_CONV_LOG10     2
+#define SENSOR_CONV_LOG2      3
+#define SENSOR_CONV_E         4
+#define SENSOR_CONV_EXP10     5
+#define SENSOR_CONV_EXP2      6
+#define SENSOR_CONV_1_X       7
+#define SENSOR_CONV_SQR       8
+#define SENSOR_CONV_CUBE      9
+#define SENSOR_CONV_SQRT      10
+#define SENSOR_CONV_CUBE_NEG1 11
 
-#define SENSOR_NUMERIC_FORMAT_UNSIGNED    0
-#define SENSOR_NUMERIC_FORMAT_ONES_COMP   1
-#define SENSOR_NUMERIC_FORMAT_TWOS_COMP   2
-#define SENSOR_NUMERIC_FORMAT_NONNUMERIC  3
+#define SENSOR_NUMERIC_FORMAT_UNSIGNED   0
+#define SENSOR_NUMERIC_FORMAT_ONES_COMP  1
+#define SENSOR_NUMERIC_FORMAT_TWOS_COMP  2
+#define SENSOR_NUMERIC_FORMAT_NONNUMERIC 3
 
 /* SDR FRU Device contents */
-#define SDR_FRU_ADDR_OFFSET        5  /* SDR Body */
+#define SDR_FRU_ADDR_OFFSET        5 /* SDR Body */
 #define SDR_FRU_ID_OFFSET          6
-#define SDR_FRU_LUN_OFFSET         7     
-#define SDR_FRU_CHAN_OFFSET        8 
+#define SDR_FRU_LUN_OFFSET         7
+#define SDR_FRU_CHAN_OFFSET        8
 #define SDR_FRU_TYPE_OFFSET        10
 #define SDR_FRU_TYPE_MOD_OFFSET    11
 #define SDR_FRU_ENTITY_ID_OFFSET   12
@@ -722,97 +770,100 @@ extern size_t IPMI_MSG1_LENGTH;
 #define SDR_FRU_STR_OFFSET         16
 
 /* SDR Management Device contents */
-#define SDR_MGMT_ADDR_OFFSET       5  /* SDR Body */
-#define SDR_MGMT_CHAN_OFFSET       6
-#define SDR_MGMT_PWR_OFFSET        7     
-#define SDR_MGMT_CAP_OFFSET        8     
-#define SDR_MGMT_ENTITY_ID_OFFSET  12     
-#define SDR_MGMT_ENTITY_INST_OFFSET  13
-#define SDR_MGMT_STR_LENGTH_OFFSET 14     
-#define SDR_MGMT_STR_OFFSET        15     
+#define SDR_MGMT_ADDR_OFFSET        5 /* SDR Body */
+#define SDR_MGMT_CHAN_OFFSET        6
+#define SDR_MGMT_PWR_OFFSET         7
+#define SDR_MGMT_CAP_OFFSET         8
+#define SDR_MGMT_ENTITY_ID_OFFSET   12
+#define SDR_MGMT_ENTITY_INST_OFFSET 13
+#define SDR_MGMT_STR_LENGTH_OFFSET  14
+#define SDR_MGMT_STR_OFFSET         15
 /*...Device Capabilities */
-#define IPMI_DEVICE_SLAVE_ADDR(x) ((x&0xFE)>>1) /* 7-bit I2C slave address of device on channel */
-#define IPMI_CHAN_NUMBER(x)       (x&0xF)       /* Chan number mgmt controller is on; 0 for BMC */
-#define IPMI_DEV_CAP_CHASSIS(x)   ((x&1<<7)>>7) /* Device functions as chassis device, per ICMB spec) */
-#define IPMI_DEV_CAP_BRIDGE(x)    ((x&1<<6)>>6) /* Responds to Bridge NetFn commands */		      
-#define IPMI_DEV_CAP_IPMB_EVG(x)  ((x&1<<5)>>5)	/* Generates event messages on IPMB */                
-#define IPMI_DEV_CAP_IPMB_EVR(x)  ((x&1<<4)>>4) /* Accepts event messages on IPMB */
-#define IPMI_DEV_CAP_FRU_INV(x)   ((x&1<<3)>>3) /* Accepts FRU commands to FRU Device #0 at LUN 00b */
-#define IPMI_DEV_CAP_SEL(x)       ((x&1<<2)>>2) /* Provides interface to SEL */
-#define IPMI_DEV_CAP_SDRREP(x)    ((x&1<<1)>>1) /* For BMC, indicates provides interface to 1b = SDR Rep; else accepts Device SDR commands */
-#define IPMI_DEV_CAP_SENSOR(x)    (x&1)         /* Accepts sensor commands (see Table 37-11 IPMB/I2C Device Type Codes) */
-     
-#define SENSOR_OWNER_ID(x)        (x & 0xFE)
-#define SENSOR_OWNER_ID_TYPE(x)   (x & 0x1)
-#define SENSOR_OWNER_CHAN(x)      (x & 0xF0)
-#define SENSOR_OWNER_LUN(x)       (x & 0x3)
+#define IPMI_DEVICE_SLAVE_ADDR(x) ((x & 0xFE) >> 1)   /* 7-bit I2C slave address of device on channel */
+#define IPMI_CHAN_NUMBER(x)       (x & 0xF)           /* Chan number mgmt controller is on; 0 for BMC */
+#define IPMI_DEV_CAP_CHASSIS(x)   ((x & 1 << 7) >> 7) /* Device functions as chassis device, per ICMB spec) */
+#define IPMI_DEV_CAP_BRIDGE(x)    ((x & 1 << 6) >> 6) /* Responds to Bridge NetFn commands */
+#define IPMI_DEV_CAP_IPMB_EVG(x)  ((x & 1 << 5) >> 5) /* Generates event messages on IPMB */
+#define IPMI_DEV_CAP_IPMB_EVR(x)  ((x & 1 << 4) >> 4) /* Accepts event messages on IPMB */
+#define IPMI_DEV_CAP_FRU_INV(x)   ((x & 1 << 3) >> 3) /* Accepts FRU commands to FRU Device #0 at LUN 00b */
+#define IPMI_DEV_CAP_SEL(x)       ((x & 1 << 2) >> 2) /* Provides interface to SEL */
+#define IPMI_DEV_CAP_SDRREP(x)                                                                                         \
+    ((x & 1 << 1) >> 1) /* For BMC, indicates provides interface to 1b = SDR Rep; else accepts Device SDR commands */
+#define IPMI_DEV_CAP_SENSOR(x) (x & 1) /* Accepts sensor commands (see Table 37-11 IPMB/I2C Device Type Codes) */
 
-#define DEV_SENSOR_DYNAMIC(x)     (x & 0x80)
-#define DEV_SENSOR_LUN0(x)        (x & 0x1)
-#define DEV_SENSOR_LUN1(x)        (x & 0x2)
-#define DEV_SENSOR_LUN2(x)        (x & 0x4)
-#define DEV_SENSOR_LUN3(x)        (x & 0x8)
+#define SENSOR_OWNER_ID(x)      (x & 0xFE)
+#define SENSOR_OWNER_ID_TYPE(x) (x & 0x1)
+#define SENSOR_OWNER_CHAN(x)    (x & 0xF0)
+#define SENSOR_OWNER_LUN(x)     (x & 0x3)
+
+#define DEV_SENSOR_DYNAMIC(x) (x & 0x80)
+#define DEV_SENSOR_LUN0(x)    (x & 0x1)
+#define DEV_SENSOR_LUN1(x)    (x & 0x2)
+#define DEV_SENSOR_LUN2(x)    (x & 0x4)
+#define DEV_SENSOR_LUN3(x)    (x & 0x8)
 
 /* SDR Entity Association and Device-relative Entity Association common contents */
-#define SDR_CNTNR_ENTITY_ID_OFFSET        5   /* SDR Body */
-#define SDR_CNTNR_ENTITY_INST_OFFSET      6 
+#define SDR_CNTNR_ENTITY_ID_OFFSET   5 /* SDR Body */
+#define SDR_CNTNR_ENTITY_INST_OFFSET 6
 
 /* SDR Entity Assocation contents */
-#define SDR_ENTITY_ASSOC_FLAGS_OFFSET     7
-#define SDR_CNTND_ENTITY_ID1_OFFSET       8
-#define SDR_CNTND_ENTITY_INST1_OFFSET     9
-#define SDR_CNTND_ENTITY_ID2_OFFSET       10
-#define SDR_CNTND_ENTITY_INST2_OFFSET     11
-#define SDR_CNTND_ENTITY_ID3_OFFSET       12
-#define SDR_CNTND_ENTITY_INST3_OFFSET     13
-#define SDR_CNTND_ENTITY_ID4_OFFSET       14
-#define SDR_CNTND_ENTITY_INST4_OFFSET     15
+#define SDR_ENTITY_ASSOC_FLAGS_OFFSET 7
+#define SDR_CNTND_ENTITY_ID1_OFFSET   8
+#define SDR_CNTND_ENTITY_INST1_OFFSET 9
+#define SDR_CNTND_ENTITY_ID2_OFFSET   10
+#define SDR_CNTND_ENTITY_INST2_OFFSET 11
+#define SDR_CNTND_ENTITY_ID3_OFFSET   12
+#define SDR_CNTND_ENTITY_INST3_OFFSET 13
+#define SDR_CNTND_ENTITY_ID4_OFFSET   14
+#define SDR_CNTND_ENTITY_INST4_OFFSET 15
 
 /* SDR Device-relative Entity Assocation contents */
-#define SDR_DEV_CNTNR_ADDR_OFFSET             7
-#define SDR_DEV_CNTNR_CHAN_OFFSET             8
-#define SDR_DEV_ENTITY_ASSOC_FLAGS_OFFSET     9
-#define SDR_DEV_CNTND_ADDR1_OFFSET            10
-#define SDR_DEV_CNTND_CHAN1_OFFSET            11
-#define SDR_DEV_CNTND_ENTITY_ID1_OFFSET       12
-#define SDR_DEV_CNTND_ENTITY_INST1_OFFSET     13
-#define SDR_DEV_CNTND_ADDR2_OFFSET            14
-#define SDR_DEV_CNTND_CHAN2_OFFSET            15
-#define SDR_DEV_CNTND_ENTITY_ID2_OFFSET       16
-#define SDR_DEV_CNTND_ENTITY_INST2_OFFSET     17
-#define SDR_DEV_CNTND_ADDR3_OFFSET            18
-#define SDR_DEV_CNTND_CHAN3_OFFSET            19
-#define SDR_DEV_CNTND_ENTITY_ID3_OFFSET       20
-#define SDR_DEV_CNTND_ENTITY_INST3_OFFSET     21
-#define SDR_DEV_CNTND_ADDR4_OFFSET            22
-#define SDR_DEV_CNTND_CHAN4_OFFSET            23
-#define SDR_DEV_CNTND_ENTITY_ID4_OFFSET       24
-#define SDR_DEV_CNTND_ENTITY_INST4_OFFSET     25
+#define SDR_DEV_CNTNR_ADDR_OFFSET         7
+#define SDR_DEV_CNTNR_CHAN_OFFSET         8
+#define SDR_DEV_ENTITY_ASSOC_FLAGS_OFFSET 9
+#define SDR_DEV_CNTND_ADDR1_OFFSET        10
+#define SDR_DEV_CNTND_CHAN1_OFFSET        11
+#define SDR_DEV_CNTND_ENTITY_ID1_OFFSET   12
+#define SDR_DEV_CNTND_ENTITY_INST1_OFFSET 13
+#define SDR_DEV_CNTND_ADDR2_OFFSET        14
+#define SDR_DEV_CNTND_CHAN2_OFFSET        15
+#define SDR_DEV_CNTND_ENTITY_ID2_OFFSET   16
+#define SDR_DEV_CNTND_ENTITY_INST2_OFFSET 17
+#define SDR_DEV_CNTND_ADDR3_OFFSET        18
+#define SDR_DEV_CNTND_CHAN3_OFFSET        19
+#define SDR_DEV_CNTND_ENTITY_ID3_OFFSET   20
+#define SDR_DEV_CNTND_ENTITY_INST3_OFFSET 21
+#define SDR_DEV_CNTND_ADDR4_OFFSET        22
+#define SDR_DEV_CNTND_CHAN4_OFFSET        23
+#define SDR_DEV_CNTND_ENTITY_ID4_OFFSET   24
+#define SDR_DEV_CNTND_ENTITY_INST4_OFFSET 25
 
 /* Information stored in entity assocation records */
-#define ENTITY_ASSOC_FLAGS_RANGE(x)    ((x&(1<<7))>>7) /* If 1 contained entities provided as range; if 0 provided as list */
-#define ENTITY_ASSOC_FLAGS_LINK(x)     ((x&(1<<6))>>6) /* If 1 linked assocation records exist */
-#define ENTITY_ASSOC_FLAGS_PRESSENS(x) ((x&(1<<5))>>5) /* If 1 presence sensor should always be accessible; 
-							  if 0 absense of sensor indicates container/contained entitites are absent */
+#define ENTITY_ASSOC_FLAGS_RANGE(x)                                                                                    \
+    ((x & (1 << 7)) >> 7) /* If 1 contained entities provided as range; if 0 provided as list */
+#define ENTITY_ASSOC_FLAGS_LINK(x) ((x & (1 << 6)) >> 6) /* If 1 linked assocation records exist */
+#define ENTITY_ASSOC_FLAGS_PRESSENS(x)                                                                                 \
+    ((x & (1 << 5)) >> 5) /* If 1 presence sensor should always be accessible;                                         \
+if 0 absense of sensor indicates container/contained entitites are absent */
 
 /* Sensor types */
-#define MAX_SENSOR_TYPE            0xFF
-#define SENSOR_TYPE_TEMP           0x01
-#define SENSOR_TYPE_VOLTAGE        0x02
-#define SENSOR_TYPE_CURRENT        0x03
-#define SENSOR_TYPE_FAN            0x04
-#define SENSOR_TYPE_PHYS_SECURITY  0x05
-#define SENSOR_TYPE_PLAT_SECURITY  0x06
-#define SENSOR_TYPE_PROCESSOR      0x07
-#define SENSOR_TYPE_POWER_SUPPPLY  0x08
-#define SENSOR_TYPE_POWER_UNIT     0x09
-#define SENSOR_TYPE_COOLING_DEV    0x0A
-#define SENSOR_TYPE_OTHER          0x0B
-#define SENSOR_TYPE_MEMORY         0x0C
-#define SENSOR_TYPE_DRIVE_SLOT     0x0D
-#define SENSOR_TYPE_POST_MEMORY    0x0E
-#define SENSOR_TYPE_SYS_FW         0x0F
-#define SENSOR_TYPE_FRU_STATE      0x2C
+#define MAX_SENSOR_TYPE           0xFF
+#define SENSOR_TYPE_TEMP          0x01
+#define SENSOR_TYPE_VOLTAGE       0x02
+#define SENSOR_TYPE_CURRENT       0x03
+#define SENSOR_TYPE_FAN           0x04
+#define SENSOR_TYPE_PHYS_SECURITY 0x05
+#define SENSOR_TYPE_PLAT_SECURITY 0x06
+#define SENSOR_TYPE_PROCESSOR     0x07
+#define SENSOR_TYPE_POWER_SUPPPLY 0x08
+#define SENSOR_TYPE_POWER_UNIT    0x09
+#define SENSOR_TYPE_COOLING_DEV   0x0A
+#define SENSOR_TYPE_OTHER         0x0B
+#define SENSOR_TYPE_MEMORY        0x0C
+#define SENSOR_TYPE_DRIVE_SLOT    0x0D
+#define SENSOR_TYPE_POST_MEMORY   0x0E
+#define SENSOR_TYPE_SYS_FW        0x0F
+#define SENSOR_TYPE_FRU_STATE     0x2C
 /* more... */
 
 /* Entity instance ranges:
@@ -820,12 +871,12 @@ extern size_t IPMI_MSG1_LENGTH;
  *                  must be unique within the system
  * device-relative: that combination must be unique relative
  *                  to the management controller providing access
- *                  to the entity 
+ *                  to the entity
  */
-#define ENTITY_INST_SYS_REL_MIN       0x00
-#define ENTITY_INST_SYS_REL_MAX       0x5F
-#define ENTITY_INST_DEV_REL_MIN       0x60
-#define ENTITY_INST_DEV_REL_MAX       0x7F
+#define ENTITY_INST_SYS_REL_MIN 0x00
+#define ENTITY_INST_SYS_REL_MAX 0x5F
+#define ENTITY_INST_DEV_REL_MIN 0x60
+#define ENTITY_INST_DEV_REL_MAX 0x7F
 
 /* Entity IDs */
 #define ENTITY_ID_UNSPEC               0x00
@@ -882,91 +933,91 @@ extern size_t IPMI_MSG1_LENGTH;
 #define ENTITY_ID_SATA_SAS_BUS         0x33
 #define ENTITY_ID_PROCESSOR_FRONT_BUS  0x34
 
-/* FRU data storage, specified in IPMI Platform Management FRU 
+/* FRU data storage, specified in IPMI Platform Management FRU
  * Information Storage Definition V1.0, Document Revision 1.1
  */
 
 /* Number of bytes stored in 6 bits, so 2^6 = 64 max bytes */
 #define MAX_FRU_FIELD_RAW_LENGTH 64
 /* Based on how FRU field data is stored, actual length may be up to 2 x raw length */
-#define MAX_FRU_FIELD_LENGTH (MAX_FRU_FIELD_RAW_LENGTH*2)
+#define MAX_FRU_FIELD_LENGTH (MAX_FRU_FIELD_RAW_LENGTH * 2)
 
 #define FRU_FIELD_LENGTH_TYPE_RAW       0
 #define FRU_FIELD_LENGTH_TYPE_CONVERTED 1
 
 typedef struct FruFieldRec_ {
-	uint8_t     type;         /* Type of data */
-	uint8_t     rlength;      /* Length of raw data (bytes) */
-	uint8_t     rdata[MAX_FRU_FIELD_RAW_LENGTH]; /* Raw data */
-	uint8_t     length;       /* Length of data after converted to ASCII (bytes) */
-	uint8_t     data[MAX_FRU_FIELD_LENGTH]; /* Data */
+    uint8_t type;                            /* Type of data */
+    uint8_t rlength;                         /* Length of raw data (bytes) */
+    uint8_t rdata[MAX_FRU_FIELD_RAW_LENGTH]; /* Raw data */
+    uint8_t length;                          /* Length of data after converted to ASCII (bytes) */
+    uint8_t data[MAX_FRU_FIELD_LENGTH];      /* Data */
 } FruFieldRec, *FruField;
 
 /* Chassis area doesn't have a language field
  * Serial number always encoded in English
  */
 typedef struct FruChassisRec_ {
-	uint8_t      offset;       /* Offset into FRU storage */
-	uint8_t      ver;          /* Format version (0x01) */
-	uint8_t      length;       /* Length of FRU area */
-	uint8_t      type;         /* Chassis type */
-	FruFieldRec  part;         /* Part number */
-	FruFieldRec  sn;           /* Serial number */
-        /* optional custom fields */	
+    uint8_t     offset; /* Offset into FRU storage */
+    uint8_t     ver;    /* Format version (0x01) */
+    uint8_t     length; /* Length of FRU area */
+    uint8_t     type;   /* Chassis type */
+    FruFieldRec part;   /* Part number */
+    FruFieldRec sn;     /* Serial number */
+                        /* optional custom fields */
 } FruChassisRec, *FruChassis;
 
 typedef struct FruBoardRec_ {
-	uint8_t      offset;       /* Offset into FRU storage */
-	uint8_t      ver;          /* Format version (0x01) */
-	uint8_t      length;       /* Length of FRU area */
-	uint8_t      lang;         /* Language code */
-	uint8_t      date;         /* Manufacturer date/time (minutes from 00:00 1/1/96) */
-	FruFieldRec  manuf;        /* Manufacturer */
-	FruFieldRec  prod;         /* Product name */
-	FruFieldRec  sn;           /* Serial number */
-	FruFieldRec  part;         /* Part number */
-        /* more */	
+    uint8_t     offset; /* Offset into FRU storage */
+    uint8_t     ver;    /* Format version (0x01) */
+    uint8_t     length; /* Length of FRU area */
+    uint8_t     lang;   /* Language code */
+    uint8_t     date;   /* Manufacturer date/time (minutes from 00:00 1/1/96) */
+    FruFieldRec manuf;  /* Manufacturer */
+    FruFieldRec prod;   /* Product name */
+    FruFieldRec sn;     /* Serial number */
+    FruFieldRec part;   /* Part number */
+                        /* more */
 } FruBoardRec, *FruBoard;
 
 typedef struct FruProdRec_ {
-	uint8_t      offset;       /* Offset into FRU storage */
-	uint8_t      ver;          /* Format version (0x01) */
-	uint8_t      length;       /* Length of FRU area */
-        uint8_t      lang;         /* Language code */
-	FruFieldRec  manuf;        /* Manufacturer */
-	FruFieldRec  prod;         /* Product name */
-	FruFieldRec  part;         /* Part number */
-	FruFieldRec  version;      /* Version number */
-	FruFieldRec  sn;           /* Serial number */
-        /* more */	
+    uint8_t     offset;  /* Offset into FRU storage */
+    uint8_t     ver;     /* Format version (0x01) */
+    uint8_t     length;  /* Length of FRU area */
+    uint8_t     lang;    /* Language code */
+    FruFieldRec manuf;   /* Manufacturer */
+    FruFieldRec prod;    /* Product name */
+    FruFieldRec part;    /* Part number */
+    FruFieldRec version; /* Version number */
+    FruFieldRec sn;      /* Serial number */
+                         /* more */
 } FruProdRec, *FruProd;
 
 /* FRU data */
 #define MSG_FRU_DATA_READ_SIZE 0x10
 
 /* Common header (mandatory) */
-#define FRU_DATA_COMMON_HEADER_OFFSET 0
+#define FRU_DATA_COMMON_HEADER_OFFSET               0
 #define FRU_DATA_COMMON_HEADER_INTERNAL_AREA_OFFSET 1
-#define FRU_DATA_COMMON_HEADER_CHASSIS_AREA_OFFSET  2 
-#define FRU_DATA_COMMON_HEADER_BOARD_AREA_OFFSET    3 
-#define FRU_DATA_COMMON_HEADER_PROD_AREA_OFFSET     4 
-#define FRU_DATA_COMMON_HEADER_MULTIREC_AREA_OFFSET 5 
-#define FRU_DATA_COMMON_HEADER_PAD                  6 
-#define FRU_DATA_COMMON_HEADER_CS                   7 
+#define FRU_DATA_COMMON_HEADER_CHASSIS_AREA_OFFSET  2
+#define FRU_DATA_COMMON_HEADER_BOARD_AREA_OFFSET    3
+#define FRU_DATA_COMMON_HEADER_PROD_AREA_OFFSET     4
+#define FRU_DATA_COMMON_HEADER_MULTIREC_AREA_OFFSET 5
+#define FRU_DATA_COMMON_HEADER_PAD                  6
+#define FRU_DATA_COMMON_HEADER_CS                   7
 
 /* Internal use area (we don't use it) */
-#define FRU_DATA_INTERNAL_AREA_VERSION_OFFSET       0
-#define FRU_DATA_INTERNAL_DATA_OFFSET               1
+#define FRU_DATA_INTERNAL_AREA_VERSION_OFFSET 0
+#define FRU_DATA_INTERNAL_DATA_OFFSET         1
 
 /* Chassis area (optional); language always english */
-#define FRU_DATA_CHASSIS_AREA_VERSION_OFFSET        0
-#define FRU_DATA_CHASSIS_AREA_LENGTH_OFFSET         1
-#define FRU_DATA_CHASSIS_TYPE_OFFSET                2
-#define FRU_DATA_CHASSIS_AREA_PART_LENGTH_OFFSET    3
-#define FRU_DATA_CHASSIS_AREA_PART_OFFSET           4
+#define FRU_DATA_CHASSIS_AREA_VERSION_OFFSET     0
+#define FRU_DATA_CHASSIS_AREA_LENGTH_OFFSET      1
+#define FRU_DATA_CHASSIS_TYPE_OFFSET             2
+#define FRU_DATA_CHASSIS_AREA_PART_LENGTH_OFFSET 3
+#define FRU_DATA_CHASSIS_AREA_PART_OFFSET        4
 /* Offsets vary:
  * serial number length
- * serial number 
+ * serial number
  * custom fields
  * byte to indicate if more fields
  * remaining space ( 0x00 )
@@ -974,12 +1025,12 @@ typedef struct FruProdRec_ {
  */
 
 /* Board area (optional) */
-#define FRU_DATA_BOARD_AREA_VERSION_OFFSET          0
-#define FRU_DATA_BOARD_AREA_LENGTH_OFFSET           1
-#define FRU_DATA_BOARD_AREA_LANG_OFFSET             2
-#define FRU_DATA_BOARD_AREA_MANUF_TIME_OFFSET       3
-#define FRU_DATA_BOARD_AREA_MANUF_LENGTH_OFFSET     6
-#define FRU_DATA_BOARD_AREA_MANUF_OFFSET            7
+#define FRU_DATA_BOARD_AREA_VERSION_OFFSET      0
+#define FRU_DATA_BOARD_AREA_LENGTH_OFFSET       1
+#define FRU_DATA_BOARD_AREA_LANG_OFFSET         2
+#define FRU_DATA_BOARD_AREA_MANUF_TIME_OFFSET   3
+#define FRU_DATA_BOARD_AREA_MANUF_LENGTH_OFFSET 6
+#define FRU_DATA_BOARD_AREA_MANUF_OFFSET        7
 /* Offsets vary:
  * product name length
  * product name
@@ -994,11 +1045,11 @@ typedef struct FruProdRec_ {
  */
 
 /* Product area (optional) */
-#define FRU_DATA_PROD_AREA_VERSION_OFFSET           0
-#define FRU_DATA_PROD_AREA_LENGTH_OFFSET            1
-#define FRU_DATA_PROD_AREA_LANG_OFFSET              2
-#define FRU_DATA_PROD_AREA_MANUF_LENGTH_OFFSET      3
-#define FRU_DATA_PROD_AREA_MANUF_OFFSET             4
+#define FRU_DATA_PROD_AREA_VERSION_OFFSET      0
+#define FRU_DATA_PROD_AREA_LENGTH_OFFSET       1
+#define FRU_DATA_PROD_AREA_LANG_OFFSET         2
+#define FRU_DATA_PROD_AREA_MANUF_LENGTH_OFFSET 3
+#define FRU_DATA_PROD_AREA_MANUF_OFFSET        4
 /* Offsets vary:
  * product name length
  * product name
@@ -1019,44 +1070,44 @@ typedef struct FruProdRec_ {
  */
 
 /* MultiRecord area (optional) */
-#define FRU_DATA_MULTIREC_AREA_HEADER_RECORD_TYPE_OFFSET     0
-#define FRU_DATA_MULTIREC_AREA_HEADER_END_OF_LIST_OFFSET     1
-#define FRU_DATA_MULTIREC_AREA_HEADER_RECORD_LENGTH_OFFSET   2
-#define FRU_DATA_MULTIREC_AREA_HEADER_RECORD_CS_OFFSET       3
-#define FRU_DATA_MULTIREC_AREA_HEADER_HEADER_CS_OFFSET       4
-#define FRU_DATA_MULTIREC_END_OF_LIST(x) (x & 0x80) >> 7
+#define FRU_DATA_MULTIREC_AREA_HEADER_RECORD_TYPE_OFFSET   0
+#define FRU_DATA_MULTIREC_AREA_HEADER_END_OF_LIST_OFFSET   1
+#define FRU_DATA_MULTIREC_AREA_HEADER_RECORD_LENGTH_OFFSET 2
+#define FRU_DATA_MULTIREC_AREA_HEADER_RECORD_CS_OFFSET     3
+#define FRU_DATA_MULTIREC_AREA_HEADER_HEADER_CS_OFFSET     4
+#define FRU_DATA_MULTIREC_END_OF_LIST(x)                   (x & 0x80) >> 7
 
 /* FRU info field data types */
-#define FRU_DATA_TYPE_BINARY    0    /* binary or unspecified */
+#define FRU_DATA_TYPE_BINARY    0 /* binary or unspecified */
 #define FRU_DATA_TYPE_BCDPLUS   1
 #define FRU_DATA_TYPE_6BITASCII 2
-#define FRU_DATA_TYPE_LANG      3    /* 8-bit ASCII + Latin 1 if language is English;
-                                      * otherwise 2-byte UNICODE with LS byte first. 
-                                      */
+#define FRU_DATA_TYPE_LANG                                                                                             \
+    3 /* 8-bit ASCII + Latin 1 if language is English;                                                                 \
+       * otherwise 2-byte UNICODE with LS byte first. */
 /* Chassis types */
-#define FRU_DATA_CHASSIS_TYPE_OTHER            0x01
-#define FRU_DATA_CHASSIS_TYPE_UNKNOWN          0x02
-#define FRU_DATA_CHASSIS_TYPE_DESKTOP          0x03
-#define FRU_DATA_CHASSIS_TYPE_LPDESKTOP        0x04
-#define FRU_DATA_CHASSIS_TYPE_PIZZABOX         0x05
-#define FRU_DATA_CHASSIS_TYPE_MINITOWER        0x06
-#define FRU_DATA_CHASSIS_TYPE_TOWER            0x07
-#define FRU_DATA_CHASSIS_TYPE_PORTABLE         0x08
-#define FRU_DATA_CHASSIS_TYPE_LAPTOP           0x09
-#define FRU_DATA_CHASSIS_TYPE_NOTEBOOK         0x0A
-#define FRU_DATA_CHASSIS_TYPE_HANDHELD         0x0B
-#define FRU_DATA_CHASSIS_TYPE_DOCKINGSTATION   0x0C
-#define FRU_DATA_CHASSIS_TYPE_ALLINONE         0x0D
-#define FRU_DATA_CHASSIS_TYPE_SUBNOTEBOOK      0x0E
-#define FRU_DATA_CHASSIS_TYPE_SPACESAVING      0x0F
-#define FRU_DATA_CHASSIS_TYPE_LUNCHBOX         0x10
-#define FRU_DATA_CHASSIS_TYPE_MAINSERVER       0x11
-#define FRU_DATA_CHASSIS_TYPE_EXPANSION        0x12
-#define FRU_DATA_CHASSIS_TYPE_SUBCHASSIS       0x13
-#define FRU_DATA_CHASSIS_TYPE_BUSEXPANSION     0x14
-#define FRU_DATA_CHASSIS_TYPE_PERIPHERAL       0x15
-#define FRU_DATA_CHASSIS_TYPE_RAID             0x16
-#define FRU_DATA_CHASSIS_TYPE_RACKMOUNT        0x17
+#define FRU_DATA_CHASSIS_TYPE_OTHER          0x01
+#define FRU_DATA_CHASSIS_TYPE_UNKNOWN        0x02
+#define FRU_DATA_CHASSIS_TYPE_DESKTOP        0x03
+#define FRU_DATA_CHASSIS_TYPE_LPDESKTOP      0x04
+#define FRU_DATA_CHASSIS_TYPE_PIZZABOX       0x05
+#define FRU_DATA_CHASSIS_TYPE_MINITOWER      0x06
+#define FRU_DATA_CHASSIS_TYPE_TOWER          0x07
+#define FRU_DATA_CHASSIS_TYPE_PORTABLE       0x08
+#define FRU_DATA_CHASSIS_TYPE_LAPTOP         0x09
+#define FRU_DATA_CHASSIS_TYPE_NOTEBOOK       0x0A
+#define FRU_DATA_CHASSIS_TYPE_HANDHELD       0x0B
+#define FRU_DATA_CHASSIS_TYPE_DOCKINGSTATION 0x0C
+#define FRU_DATA_CHASSIS_TYPE_ALLINONE       0x0D
+#define FRU_DATA_CHASSIS_TYPE_SUBNOTEBOOK    0x0E
+#define FRU_DATA_CHASSIS_TYPE_SPACESAVING    0x0F
+#define FRU_DATA_CHASSIS_TYPE_LUNCHBOX       0x10
+#define FRU_DATA_CHASSIS_TYPE_MAINSERVER     0x11
+#define FRU_DATA_CHASSIS_TYPE_EXPANSION      0x12
+#define FRU_DATA_CHASSIS_TYPE_SUBCHASSIS     0x13
+#define FRU_DATA_CHASSIS_TYPE_BUSEXPANSION   0x14
+#define FRU_DATA_CHASSIS_TYPE_PERIPHERAL     0x15
+#define FRU_DATA_CHASSIS_TYPE_RAID           0x16
+#define FRU_DATA_CHASSIS_TYPE_RACKMOUNT      0x17
 /* More to come... */
 
 #endif

--- a/src/ipmiMsg.c
+++ b/src/ipmiMsg.c
@@ -1,16 +1,16 @@
 //////////////////////////////////////////////////////////////////////////////
 // This file is part of 'ipmiComm'.
-// It is subject to the license terms in the LICENSE.txt file found in the 
-// top-level directory of this distribution and at: 
-//    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
-// No part of 'ipmiComm', including this file, 
-// may be copied, modified, propagated, or distributed except according to 
+// It is subject to the license terms in the LICENSE.txt file found in the
+// top-level directory of this distribution and at:
+//    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+// No part of 'ipmiComm', including this file,
+// may be copied, modified, propagated, or distributed except according to
 // the terms contained in the LICENSE.txt file.
 //////////////////////////////////////////////////////////////////////////////
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
-#include <math.h>    /* pow */
+#include <math.h> /* pow */
 
 #include <errlog.h>
 #include <epicsMutex.h>
@@ -23,509 +23,498 @@
 #include <ipmiDef.h>
 #include <picmgDef.h>
 
-/* 
- * Convert 2-element uint8_t array (which stores LS byte first) to 16-bit integer 
+/*
+ * Convert 2-element uint8_t array (which stores LS byte first) to 16-bit integer
  */
-uint16_t 
-arrayToUint16(uint8_t *data)
-{
-unsigned i;
-uint16_t value = 0;
+uint16_t arrayToUint16(uint8_t* data) {
+    unsigned i;
+    uint16_t value = 0;
 
-	for ( i = 0 ; i < 2 ; i++)		
-			value |= *data++ << i*8;
+    for (i = 0; i < 2; i++) {
+        value |= *data++ << i * 8;
+    }
 
-	return value;
+    return value;
 }
 
-/* 
+/*
  * Increment value of 2-element uint8_t array (which stores LS byte first)
  * Roll over to 0 when max possible value is reached.
  */
-void 
-incr2Uint8Array(uint8_t *data, int incr) 
-{    
-unsigned i, nBytes = 2;
-uint16_t value = 0;
+void incr2Uint8Array(uint8_t* data, int incr) {
+    unsigned i, nBytes = 2;
+    uint16_t value = 0;
 
-	value = arrayToUint16( data );
+    value = arrayToUint16(data);
 
-	if ( value >= (pow(2,8*nBytes) - incr) ) 
-		value = 0;
-	else
-		value += incr; 
-	/* Copy incremented value to array */
-	for ( i = 0 ; i < nBytes ; i++) 
-		*data++ = (value >> i*8) & 0xFF;	
+    if (value >= (pow(2, 8 * nBytes) - incr)) {
+        value = 0;
+    } else {
+        value += incr;
+    }
+    /* Copy incremented value to array */
+    for (i = 0; i < nBytes; i++) {
+        *data++ = (value >> i * 8) & 0xFF;
+    }
 }
 
-/* 
- * Convert 4-element uint8_t array (which stores LS byte first) to 32-bit integer 
+/*
+ * Convert 4-element uint8_t array (which stores LS byte first) to 32-bit integer
  */
-uint32_t 
-arrayToUint32(uint8_t *data)
-{
-unsigned i;
-uint32_t value = 0;
+uint32_t arrayToUint32(uint8_t* data) {
+    unsigned i;
+    uint32_t value = 0;
 
-	for ( i = 0 ; i < 4 ; i++)			
-			value |= *data++ << i*8;
+    for (i = 0; i < 4; i++) {
+        value |= *data++ << i * 8;
+    }
 
-	return value;
+    return value;
 }
 
-/* 
+/*
  * Increment value of 4-element uint8_t array (which stores LS byte first)
  * Roll over to 0 when max possible value is reached.
  */
-void 
-incr4Uint8Array(uint8_t *data, int incr) 
-{    
-unsigned i, nBytes = 4;
-uint32_t    value  = 0;
+void incr4Uint8Array(uint8_t* data, int incr) {
+    unsigned i, nBytes = 4;
+    uint32_t value = 0;
 
-	value = arrayToUint32( data );
+    value = arrayToUint32(data);
 
-/* test rollover */
-	if ( value >= (pow(2,8*nBytes) - incr) ) 
-		value = 0;
-	else
-		value += incr; 
+    /* test rollover */
+    if (value >= (pow(2, 8 * nBytes) - incr)) {
+        value = 0;
+    } else {
+        value += incr;
+    }
 
-	/* Copy incremented value to array */
-	for ( i = 0 ; i < nBytes ; i++)
-		*data++ = (value >> i*8) & 0xFF;	
+    /* Copy incremented value to array */
+    for (i = 0; i < nBytes; i++) {
+        *data++ = (value >> i * 8) & 0xFF;
+    }
 }
 
 /*
  * Given pointer to uint8_t data array and size of array,
  * calculate and return the two's complement checksum
  */
-static uint8_t
-calcTwosComplementChecksum(uint8_t *data, unsigned n)
-{
-unsigned i;
-uint32_t cs = 0;   
+static uint8_t calcTwosComplementChecksum(uint8_t* data, unsigned n) {
+    unsigned i;
+    uint32_t cs = 0;
 
-	n--;
- 
-	for ( i = 0; i < n ; i++) {
-		cs += *data++;
-	}
+    n--;
 
-	return ( 0x100 - (cs & 0xFF) );	
+    for (i = 0; i < n; i++) {
+        cs += *data++;
+    }
+
+    return (0x100 - (cs & 0xFF));
 }
 
 /* Print command description and response completion code */
-void
-ipmiCompletionCode(const char *name, uint8_t code, uint8_t cmd, uint8_t netfn)
-{
-char cmdStr[50];
-char codeStr[100];
+void ipmiCompletionCode(const char* name, uint8_t code, uint8_t cmd, uint8_t netfn) {
+    char cmdStr[50];
+    char codeStr[100];
 
-	switch ( code ) {
+    switch (code) {
 
-		default:
-			sprintf( codeStr, "Unspecified completion code" );
-			goto codeDone;
+        default:
+            sprintf(codeStr, "Unspecified completion code");
+            goto codeDone;
 
-		case IPMI_COMP_CODE_NORMAL:                
-			sprintf( codeStr, "Command completed normally" );
-			goto codeDone;
+        case IPMI_COMP_CODE_NORMAL:
+            sprintf(codeStr, "Command completed normally");
+            goto codeDone;
 
-		case IPMI_COMP_CODE_NODE_BUSY:               
-			sprintf( codeStr, "Node busy" );
-			goto codeDone;
+        case IPMI_COMP_CODE_NODE_BUSY:
+            sprintf(codeStr, "Node busy");
+            goto codeDone;
 
-		case IPMI_COMP_CODE_INVALID_COMMAND:         
-			sprintf( codeStr, "Invalid command" );
-			goto codeDone;
+        case IPMI_COMP_CODE_INVALID_COMMAND:
+            sprintf(codeStr, "Invalid command");
+            goto codeDone;
 
-		case IPMI_COMP_CODE_INVALID_COMMAND_FOR_LUN: 
-			sprintf( codeStr, "Invalid command for given LUN" );
-			goto codeDone;
+        case IPMI_COMP_CODE_INVALID_COMMAND_FOR_LUN:
+            sprintf(codeStr, "Invalid command for given LUN");
+            goto codeDone;
 
-		case IPMI_COMP_CODE_TIMEOUT:                 
-			sprintf( codeStr, "Timeout while processing command" );
-			goto codeDone;
+        case IPMI_COMP_CODE_TIMEOUT:
+            sprintf(codeStr, "Timeout while processing command");
+            goto codeDone;
 
-		case IPMI_COMP_CODE_OUT_OF_SPACE:            
-			sprintf( codeStr, "Out of space" );
-			goto codeDone;
+        case IPMI_COMP_CODE_OUT_OF_SPACE:
+            sprintf(codeStr, "Out of space");
+            goto codeDone;
 
-		case IPMI_COMP_CODE_RESERVATION:   
-			sprintf( codeStr, "Reservation cancelled or invalid reservation ID" );
-			goto codeDone;
-          
-		case IPMI_COMP_CODE_REQUEST_TRUNCATED:       
-			sprintf( codeStr, "Request data truncated" );
-			goto codeDone;
+        case IPMI_COMP_CODE_RESERVATION:
+            sprintf(codeStr, "Reservation cancelled or invalid reservation ID");
+            goto codeDone;
 
-		case IPMI_COMP_CODE_REQUEST_LENGTH_INVALID:  
-			sprintf( codeStr, "Request data length invalid" );
-			goto codeDone;
+        case IPMI_COMP_CODE_REQUEST_TRUNCATED:
+            sprintf(codeStr, "Request data truncated");
+            goto codeDone;
 
-		case IPMI_COMP_CODE_REQUEST_LENGTH_LIMIT:    
-			sprintf( codeStr, "Request data field length exceeded" );
-			goto codeDone;
+        case IPMI_COMP_CODE_REQUEST_LENGTH_INVALID:
+            sprintf(codeStr, "Request data length invalid");
+            goto codeDone;
 
-		case IPMI_COMP_CODE_PARAMETER_RANGE: 
-			sprintf( codeStr, "Parameter out of range" );
-			goto codeDone;
-        
-		case IPMI_COMP_CODE_REQUESTED_BYTES:    
-			sprintf( codeStr, "Cannot return number of requested data bytes" );
-			goto codeDone;
-     
-		case IPMI_COMP_CODE_REQUESTED_DATA:  
-			sprintf( codeStr, "Requested sensor, data, or record not present" );
-			goto codeDone;
-        
-		case IPMI_COMP_CODE_INVALID_FIELD: 
-			sprintf( codeStr, "Invalid data field in request" );
-			goto codeDone;
-          
-		case IPMI_COMP_CODE_COMMAND_ILLEGAL:        
-			sprintf( codeStr, "Command illegal for specified sensor or record type" );
-			goto codeDone;
- 
-		case IPMI_COMP_CODE_COMMAND_RESPONSE:        
-			sprintf( codeStr, "Command response could not be provided" );
-			goto codeDone;
+        case IPMI_COMP_CODE_REQUEST_LENGTH_LIMIT:
+            sprintf(codeStr, "Request data field length exceeded");
+            goto codeDone;
 
-		case IPMI_COMP_CODE_DUPLICATED_REQUEST:  
-			sprintf( codeStr, "Cannot execute duplicated request" );
-			goto codeDone;
-    
-		case IPMI_COMP_CODE_SDR_REP_UPDATE:        
-			sprintf( codeStr, "Response could not be provided. SDR repository in update mode" );
-			goto codeDone;
-  
-		case IPMI_COMP_CODE_DEVICE_FW_UPDATE:        
-			sprintf( codeStr, "Response could not be provided. Device in firmware update mode" );
-			goto codeDone;
+        case IPMI_COMP_CODE_PARAMETER_RANGE:
+            sprintf(codeStr, "Parameter out of range");
+            goto codeDone;
 
-		case IPMI_COMP_CODE_BMC_INIT:    
-			sprintf( codeStr, "Response could not be provided. BMC initialization in progress" );
-			goto codeDone;
-            
-		case IPMI_COMP_CODE_DESTINATION_UNAVAIL:   
-			sprintf( codeStr, "Destination unavailable" );
-			goto codeDone;
-  
-		case IPMI_COMP_CODE_PRIVILEGE:     
-			sprintf( codeStr, "Insufficient privilege level or other security-based restriction" );
-			goto codeDone;
-          
-		case IPMI_COMP_CODE_NOT_SUPPORTED:     
-			sprintf( codeStr, "Command or request parameter not supported in present state" );
-			goto codeDone;
-      
-		case IPMI_COMP_CODE_SUBFUNCTION_UNAVAIL:     
-			sprintf( codeStr, "Parameter is illegal because sub-function is unavailable" );
-			goto codeDone;
+        case IPMI_COMP_CODE_REQUESTED_BYTES:
+            sprintf(codeStr, "Cannot return number of requested data bytes");
+            goto codeDone;
 
-	}
+        case IPMI_COMP_CODE_REQUESTED_DATA:
+            sprintf(codeStr, "Requested sensor, data, or record not present");
+            goto codeDone;
 
+        case IPMI_COMP_CODE_INVALID_FIELD:
+            sprintf(codeStr, "Invalid data field in request");
+            goto codeDone;
 
-	if ( (code >= IPMI_COMP_CODE_DEVICE_SPECIFIC_MIN) && (code <= IPMI_COMP_CODE_DEVICE_SPECIFIC_MAX) ) 
-		sprintf( codeStr, "Device-specific completion code %02x", code );
+        case IPMI_COMP_CODE_COMMAND_ILLEGAL:
+            sprintf(codeStr, "Command illegal for specified sensor or record type");
+            goto codeDone;
 
-	else if ( (code >= IPMI_COMP_CODE_COMMAND_SPECIFIC_MIN) && (code <= IPMI_COMP_CODE_DEVICE_SPECIFIC_MAX) ) {
+        case IPMI_COMP_CODE_COMMAND_RESPONSE:
+            sprintf(codeStr, "Command response could not be provided");
+            goto codeDone;
 
-		switch ( cmd ) {
+        case IPMI_COMP_CODE_DUPLICATED_REQUEST:
+            sprintf(codeStr, "Cannot execute duplicated request");
+            goto codeDone;
 
-			default: 
-				sprintf( codeStr, "Command-specific completion code %02x", code );
-				goto codeDone;
+        case IPMI_COMP_CODE_SDR_REP_UPDATE:
+            sprintf(codeStr, "Response could not be provided. SDR repository in update mode");
+            goto codeDone;
 
-			case IPMI_MSG_CMD_SEND_MSG:
+        case IPMI_COMP_CODE_DEVICE_FW_UPDATE:
+            sprintf(codeStr, "Response could not be provided. Device in firmware update mode");
+            goto codeDone;
 
-				switch ( code ) {
+        case IPMI_COMP_CODE_BMC_INIT:
+            sprintf(codeStr, "Response could not be provided. BMC initialization in progress");
+            goto codeDone;
 
-					default: 
-					sprintf( codeStr, "Send Message completion code %02x", code );
-						goto codeDone;
+        case IPMI_COMP_CODE_DESTINATION_UNAVAIL:
+            sprintf(codeStr, "Destination unavailable");
+            goto codeDone;
 
-					case 0x80:
-						sprintf( codeStr, "Invalid session handle" );
-						goto codeDone;
-				}
-		}
-	}
+        case IPMI_COMP_CODE_PRIVILEGE:
+            sprintf(codeStr, "Insufficient privilege level or other security-based restriction");
+            goto codeDone;
+
+        case IPMI_COMP_CODE_NOT_SUPPORTED:
+            sprintf(codeStr, "Command or request parameter not supported in present state");
+            goto codeDone;
+
+        case IPMI_COMP_CODE_SUBFUNCTION_UNAVAIL:
+            sprintf(codeStr, "Parameter is illegal because sub-function is unavailable");
+            goto codeDone;
+    }
+
+    if ((code >= IPMI_COMP_CODE_DEVICE_SPECIFIC_MIN) && (code <= IPMI_COMP_CODE_DEVICE_SPECIFIC_MAX)) {
+        sprintf(codeStr, "Device-specific completion code %02x", code);
+    }
+
+    else if ((code >= IPMI_COMP_CODE_COMMAND_SPECIFIC_MIN) && (code <= IPMI_COMP_CODE_DEVICE_SPECIFIC_MAX)) {
+
+        switch (cmd) {
+
+            default:
+                sprintf(codeStr, "Command-specific completion code %02x", code);
+                goto codeDone;
+
+            case IPMI_MSG_CMD_SEND_MSG:
+
+                switch (code) {
+
+                    default:
+                        sprintf(codeStr, "Send Message completion code %02x", code);
+                        goto codeDone;
+
+                    case 0x80:
+                        sprintf(codeStr, "Invalid session handle");
+                        goto codeDone;
+                }
+        }
+    }
 
 codeDone:
 
-	switch ( netfn ) {
+    switch (netfn) {
 
-		default:
-			break;
+        default:
+            break;
 
-		case IPMI_MSG_NETFN_CHASSIS:
+        case IPMI_MSG_NETFN_CHASSIS:
 
-			switch ( cmd ) {
+            switch (cmd) {
 
-				default:
-					sprintf( cmdStr, "NetFn Chassis command %02x", cmd );
-					break;
+                default:
+                    sprintf(cmdStr, "NetFn Chassis command %02x", cmd);
+                    break;
 
-				case IPMI_MSG_CMD_GET_CHAS_STATUS:       
-					sprintf( cmdStr, "Get Chassis Status" );
-					break;
+                case IPMI_MSG_CMD_GET_CHAS_STATUS:
+                    sprintf(cmdStr, "Get Chassis Status");
+                    break;
 
-				case IPMI_MSG_CMD_CHAS_CTRL:             
-					sprintf( cmdStr, "Chassis Control" );
-					break;
-			}
-			break;
+                case IPMI_MSG_CMD_CHAS_CTRL:
+                    sprintf(cmdStr, "Chassis Control");
+                    break;
+            }
+            break;
 
-		case IPMI_MSG_NETFN_APP_REQUEST:
+        case IPMI_MSG_NETFN_APP_REQUEST:
 
-			switch ( cmd ) {
+            switch (cmd) {
 
-				default:
-					sprintf( cmdStr, "NetFn App Request command %02x", cmd );
-					break;
-				
-				case IPMI_MSG_CMD_GET_CHAN_AUTH:         
-					sprintf( cmdStr, "Get Channel Authentication Capabilities" );
-					break;
+                default:
+                    sprintf(cmdStr, "NetFn App Request command %02x", cmd);
+                    break;
 
-				case IPMI_MSG_CMD_GET_SESSION_CHALLENGE: 
-					sprintf( cmdStr, "Get Session Challenge" );
+                case IPMI_MSG_CMD_GET_CHAN_AUTH:
+                    sprintf(cmdStr, "Get Channel Authentication Capabilities");
+                    break;
 
-					switch ( code ) {
+                case IPMI_MSG_CMD_GET_SESSION_CHALLENGE:
+                    sprintf(cmdStr, "Get Session Challenge");
 
-						default:
-							break;
-						case IPMI_COMP_CODE_GET_SESS_INVALID_USER:                
-							sprintf( codeStr, "Invalid user name" );
-							break;
-						case IPMI_COMP_CODE_GET_SESS_NULL_USER:                
-							sprintf( codeStr, "Null user name" );
-							break;
-					}
-					break;
+                    switch (code) {
 
-				case IPMI_MSG_CMD_ACTIVATE_SESSION:      
-					sprintf( cmdStr, "Activate Session" );
+                        default:
+                            break;
+                        case IPMI_COMP_CODE_GET_SESS_INVALID_USER:
+                            sprintf(codeStr, "Invalid user name");
+                            break;
+                        case IPMI_COMP_CODE_GET_SESS_NULL_USER:
+                            sprintf(codeStr, "Null user name");
+                            break;
+                    }
+                    break;
 
-					switch ( code ) {
+                case IPMI_MSG_CMD_ACTIVATE_SESSION:
+                    sprintf(cmdStr, "Activate Session");
 
-						default:
-							break;
-						case 0x81:                
-							sprintf( codeStr, "No session slot available" );
-							break;
-						case 0x82:                
-							sprintf( codeStr, "No slot available for user" );
-							break;
-						case 0x83:                
-							sprintf( codeStr, "No slot available for privilege" );
-							break;
-						case 0x84:                
-							sprintf( codeStr, "Session sequence number out of range" );
-							break;
-						case 0x85:                
-							sprintf( codeStr, "Invalid session ID in request" );
-							break;
-						case 0x86:                
-							sprintf( codeStr, "Requested privilege exceeds user/channel limit" );
-							break;
-					}
-					break;
+                    switch (code) {
 
-				case IPMI_MSG_CMD_SET_PRIV_LEVEL:        
-					sprintf( cmdStr, "Set Privilege Level" );
-					break;
+                        default:
+                            break;
+                        case 0x81:
+                            sprintf(codeStr, "No session slot available");
+                            break;
+                        case 0x82:
+                            sprintf(codeStr, "No slot available for user");
+                            break;
+                        case 0x83:
+                            sprintf(codeStr, "No slot available for privilege");
+                            break;
+                        case 0x84:
+                            sprintf(codeStr, "Session sequence number out of range");
+                            break;
+                        case 0x85:
+                            sprintf(codeStr, "Invalid session ID in request");
+                            break;
+                        case 0x86:
+                            sprintf(codeStr, "Requested privilege exceeds user/channel limit");
+                            break;
+                    }
+                    break;
 
-				case IPMI_MSG_CMD_CLOSE_SESSION:         
-					sprintf( cmdStr, "Close Session" );
-					break;
+                case IPMI_MSG_CMD_SET_PRIV_LEVEL:
+                    sprintf(cmdStr, "Set Privilege Level");
+                    break;
 
-				case IPMI_MSG_CMD_SEND_MSG:              
-					sprintf( cmdStr, "Send Message" );
-					break;
+                case IPMI_MSG_CMD_CLOSE_SESSION:
+                    sprintf(cmdStr, "Close Session");
+                    break;
 
-				case IPMI_MSG_CMD_COLD_RESET:            
-					sprintf( cmdStr, "Cold Reset" );
-					break;
-				case IPMI_MSG_CMD_GET_DEVICE_ID:         
-					sprintf( cmdStr, "Get Device ID" );
-					break;
+                case IPMI_MSG_CMD_SEND_MSG:
+                    sprintf(cmdStr, "Send Message");
+                    break;
 
-			}
-			break;
+                case IPMI_MSG_CMD_COLD_RESET:
+                    sprintf(cmdStr, "Cold Reset");
+                    break;
+                case IPMI_MSG_CMD_GET_DEVICE_ID:
+                    sprintf(cmdStr, "Get Device ID");
+                    break;
+            }
+            break;
 
-		case IPMI_MSG_NETFN_SENSOR_EVENT:
+        case IPMI_MSG_NETFN_SENSOR_EVENT:
 
-			switch ( cmd ) {
+            switch (cmd) {
 
-				default:
-					sprintf( cmdStr, "NetFn Sensor/Event command %02x", cmd );
-					break;
+                default:
+                    sprintf(cmdStr, "NetFn Sensor/Event command %02x", cmd);
+                    break;
 
-				case IPMI_MSG_CMD_SENSOR_READ:           
-					sprintf( cmdStr, "Get Sensor Reading" );
-					break;
+                case IPMI_MSG_CMD_SENSOR_READ:
+                    sprintf(cmdStr, "Get Sensor Reading");
+                    break;
 
-				case IPMI_MSG_CMD_GET_DEV_SDR_INFO:      
-					sprintf( cmdStr, "Get Device SDR Info" );
-					break;
+                case IPMI_MSG_CMD_GET_DEV_SDR_INFO:
+                    sprintf(cmdStr, "Get Device SDR Info");
+                    break;
 
-				case IPMI_MSG_CMD_GET_DEV_SDR:           
-					sprintf( cmdStr, "Get Device SDR" );
-					break;
-			}
-			break;
+                case IPMI_MSG_CMD_GET_DEV_SDR:
+                    sprintf(cmdStr, "Get Device SDR");
+                    break;
+            }
+            break;
 
-		case IPMI_MSG_NETFN_STORAGE:
+        case IPMI_MSG_NETFN_STORAGE:
 
-			switch ( cmd ) {
+            switch (cmd) {
 
-				default:
-					sprintf( cmdStr, "NetFn Storage command %02x", cmd );
-					break;
+                default:
+                    sprintf(cmdStr, "NetFn Storage command %02x", cmd);
+                    break;
 
-				case IPMI_MSG_CMD_GET_FRU_INFO:          
-					sprintf( cmdStr, "Get FRU Inventory Area Info" );
-					break;
+                case IPMI_MSG_CMD_GET_FRU_INFO:
+                    sprintf(cmdStr, "Get FRU Inventory Area Info");
+                    break;
 
-				case IPMI_MSG_CMD_READ_FRU_DATA:         
-					sprintf( cmdStr, "Read FRU Data" );
-					break;
+                case IPMI_MSG_CMD_READ_FRU_DATA:
+                    sprintf(cmdStr, "Read FRU Data");
+                    break;
 
-				case IPMI_MSG_CMD_WRITE_FRU_DATA:        
-					sprintf( cmdStr, "Write FRU Data" );
-					break;
+                case IPMI_MSG_CMD_WRITE_FRU_DATA:
+                    sprintf(cmdStr, "Write FRU Data");
+                    break;
 
-				case IPMI_MSG_CMD_GET_SDRREP_INFO:       
-					sprintf( cmdStr, "Get SDR Repository Info" );
-					break;
+                case IPMI_MSG_CMD_GET_SDRREP_INFO:
+                    sprintf(cmdStr, "Get SDR Repository Info");
+                    break;
 
-				case IPMI_MSG_CMD_RESERVE_SDRREP:        
-					sprintf( cmdStr, "Reserve SDR Repository" );
-					break;
+                case IPMI_MSG_CMD_RESERVE_SDRREP:
+                    sprintf(cmdStr, "Reserve SDR Repository");
+                    break;
 
-				case IPMI_MSG_CMD_GET_SDR:               
-					sprintf( cmdStr, "Get SDR" );
-					break;
-			}
-			break;
+                case IPMI_MSG_CMD_GET_SDR:
+                    sprintf(cmdStr, "Get SDR");
+                    break;
+            }
+            break;
 
-		case IPMI_MSG_NETFN_PICMG:
+        case IPMI_MSG_NETFN_PICMG:
 
-			switch ( cmd ) {
+            switch (cmd) {
 
-				default:
-					sprintf( cmdStr, "NetFn PICMG command %02x", cmd );
-					break;
+                default:
+                    sprintf(cmdStr, "NetFn PICMG command %02x", cmd);
+                    break;
 
-				case IPMI_MSG_CMD_SET_FRU_POLICY:        
-					sprintf( cmdStr, "Set FRU Activation Policy" );
-					break;
+                case IPMI_MSG_CMD_SET_FRU_POLICY:
+                    sprintf(cmdStr, "Set FRU Activation Policy");
+                    break;
 
-				case IPMI_MSG_CMD_SET_FRU_ACT:           
-					sprintf( cmdStr, "Set FRU Activation" );
-					break;
+                case IPMI_MSG_CMD_SET_FRU_ACT:
+                    sprintf(cmdStr, "Set FRU Activation");
+                    break;
 
-				case IPMI_MSG_CMD_GET_ADDR_INFO:
-					sprintf( cmdStr, "Get Address Info" );
-					break;
+                case IPMI_MSG_CMD_GET_ADDR_INFO:
+                    sprintf(cmdStr, "Get Address Info");
+                    break;
 
-				case IPMI_MSG_CMD_GET_POWER_LEVEL:       
-					sprintf( cmdStr, "Get FRU Power Level" );
-					break;
+                case IPMI_MSG_CMD_GET_POWER_LEVEL:
+                    sprintf(cmdStr, "Get FRU Power Level");
+                    break;
 
-				case IPMI_MSG_CMD_GET_FAN_PROP:          
-					sprintf( cmdStr, "Get Fan Properties" );
-					break;
+                case IPMI_MSG_CMD_GET_FAN_PROP:
+                    sprintf(cmdStr, "Get Fan Properties");
+                    break;
 
-				case IPMI_MSG_CMD_GET_FAN_LEVEL:         
-					sprintf( cmdStr, "Get Fan Level" );
-					break;
+                case IPMI_MSG_CMD_GET_FAN_LEVEL:
+                    sprintf(cmdStr, "Get Fan Level");
+                    break;
 
-				case IPMI_MSG_CMD_SET_FAN_LEVEL:         
-					sprintf( cmdStr, "Set Fan Level" );
-					break;
-			}
-	}
+                case IPMI_MSG_CMD_SET_FAN_LEVEL:
+                    sprintf(cmdStr, "Set Fan Level");
+                    break;
+            }
+    }
 
-       	printf("%s %s: %s\n", name, cmdStr, codeStr);
-}
-
-/* 
- * Set authentication type based on message type and set
- * some message parameters based on auth type 
- */
-static void
-ipmiMsgSetImsg1Auth(IpmiSess sess, uint8_t cmd, uint8_t *auth, size_t *iwrapperSize, int *offset_nbytes)
-{
-	/* Get Channel Authentication and Get Session Challenge messages use
-         * authentication type none in message header even if session will use
-         * another type
-         */
-	if ( (cmd == IPMI_MSG_CMD_GET_CHAN_AUTH) || (cmd == IPMI_MSG_CMD_GET_SESSION_CHALLENGE) 
-		|| (sess->authReq == IPMI_MSG_AUTH_TYPE_NONE) ) {
-		*auth          = IPMI_MSG_AUTH_TYPE_NONE;
-		*iwrapperSize   = IPMI_WRAPPER_LENGTH;
-		*offset_nbytes = /*RMCP_MSG_HEADER_LENGTH +*/ IPMI_WRAPPER_NBYTES_OFFSET;
-	}
-	else {
-		*auth          = sess->authReq;
-		*iwrapperSize   = IPMI_WRAPPER_AUTH_LENGTH;
-		*offset_nbytes = /*RMCP_MSG_HEADER_LENGTH +*/ IPMI_WRAPPER_AUTH_NBYTES_OFFSET;
-	}
-}
-
-/* 
- * Set session sequence number and session ID for IPMI message,
- * depending on message type. Copy to header.
- */
-static void
-ipmiMsgSetSeqId(IpmiSess sess, uint8_t *message, uint8_t cmd)
-{
-int i;
-	/* Session sequence number is not incremented (or used) for messages outside of a session */
-	if ( cmd != IPMI_MSG_CMD_GET_CHAN_AUTH && cmd != IPMI_MSG_CMD_GET_SESSION_CHALLENGE && 
-	    cmd != IPMI_MSG_CMD_ACTIVATE_SESSION && cmd != IPMI_MSG_CMD_SET_PRIV_LEVEL && cmd != 0 )
-		incr4Uint8Array( sess->seqSend , 1 );
-
-	/* Close Session command contains the session ID */
-	if ( cmd == IPMI_MSG_CMD_CLOSE_SESSION ) {
-		for ( i = 0; i < IPMI_MSG2_ID_LENGTH ; i++)
-			message[IPMI_MSG2_ID_OFFSET + i] = sess->id[i];
-	}
-
-	/* Copy data to IPMI wrapper */
-	for ( i = 0; i < IPMI_WRAPPER_SEQ_LENGTH ; i++)
-		message[IPMI_WRAPPER_SEQ_OFFSET + i] = sess->seqSend[i];
-
-	for ( i = 0; i < IPMI_WRAPPER_ID_LENGTH ; i++)
-		message[IPMI_WRAPPER_ID_OFFSET + i]  = sess->id[i];
+    printf("%s %s: %s\n", name, cmdStr, codeStr);
 }
 
 /*
+ * Set authentication type based on message type and set
+ * some message parameters based on auth type
+ */
+static void ipmiMsgSetImsg1Auth(IpmiSess sess, uint8_t cmd, uint8_t* auth, size_t* iwrapperSize, int* offset_nbytes) {
+    /* Get Channel Authentication and Get Session Challenge messages use
+     * authentication type none in message header even if session will use
+     * another type
+     */
+    if ((cmd == IPMI_MSG_CMD_GET_CHAN_AUTH) || (cmd == IPMI_MSG_CMD_GET_SESSION_CHALLENGE) ||
+        (sess->authReq == IPMI_MSG_AUTH_TYPE_NONE)) {
+        *auth          = IPMI_MSG_AUTH_TYPE_NONE;
+        *iwrapperSize  = IPMI_WRAPPER_LENGTH;
+        *offset_nbytes = /*RMCP_MSG_HEADER_LENGTH +*/ IPMI_WRAPPER_NBYTES_OFFSET;
+    } else {
+        *auth          = sess->authReq;
+        *iwrapperSize  = IPMI_WRAPPER_AUTH_LENGTH;
+        *offset_nbytes = /*RMCP_MSG_HEADER_LENGTH +*/ IPMI_WRAPPER_AUTH_NBYTES_OFFSET;
+    }
+}
+
+/*
+ * Set session sequence number and session ID for IPMI message,
+ * depending on message type. Copy to header.
+ */
+static void ipmiMsgSetSeqId(IpmiSess sess, uint8_t* message, uint8_t cmd) {
+    int i;
+    /* Session sequence number is not incremented (or used) for messages outside of a session */
+    if (cmd != IPMI_MSG_CMD_GET_CHAN_AUTH && cmd != IPMI_MSG_CMD_GET_SESSION_CHALLENGE &&
+        cmd != IPMI_MSG_CMD_ACTIVATE_SESSION && cmd != IPMI_MSG_CMD_SET_PRIV_LEVEL && cmd != 0) {
+        incr4Uint8Array(sess->seqSend, 1);
+    }
+
+    /* Close Session command contains the session ID */
+    if (cmd == IPMI_MSG_CMD_CLOSE_SESSION) {
+        for (i = 0; i < IPMI_MSG2_ID_LENGTH; i++) {
+            message[IPMI_MSG2_ID_OFFSET + i] = sess->id[i];
+        }
+    }
+
+    /* Copy data to IPMI wrapper */
+    for (i = 0; i < IPMI_WRAPPER_SEQ_LENGTH; i++) {
+        message[IPMI_WRAPPER_SEQ_OFFSET + i] = sess->seqSend[i];
+    }
+
+    for (i = 0; i < IPMI_WRAPPER_ID_LENGTH; i++) {
+        message[IPMI_WRAPPER_ID_OFFSET + i] = sess->id[i];
+    }
+}
+
+// clang-format off
+/*
  *
- * Build IPMI outgoing message. 
+ * Build IPMI outgoing message.
  *
  * Message structure (see ipmiMsg.h for more details):
- * 
+ *
  * cs = checksum
  *
- * {RMCP header}{IPMI wrapper}{IPMI msg 1(cs)}{IPMI msg 2 [Bridged msg part1(cs)][Bridged msg part2 [Bridged msg part1(cs)][Bridged msg part2(cs)](checksum)] (checksum)}      		 
- *                                                        |_______________________________________||____________________________________________|      |	 |		  	 
- *                                                                            |                                          |                             |	 |		  	 
- *                                                            First optional bridged message              Second optional bridged message            cs for	 cs for IPMI msg part2	  	 
- *                                                                                                                                                   optional	     (does not include 	 
+ *  * {RMCP header}{IPMI wrapper}{IPMI msg 1(cs)}{IPMI msg 2 [Bridged msg part1(cs)][Bridged msg part2 [Bridged msg part1(cs)][Bridged msg part2(cs)](checksum)] (checksum)}
+ *                                                        |_______________________________________||____________________________________________|      |         |
+ *                                                                            |                                          |                             |         |
+ *                                                            First optional bridged message              Second optional bridged message            cs for      cs for IPMI msg part2
+ *                                                                                                                                                   optional        (does not include
  *                                                                                                                                                   first bridged   bridged msgs)
  *                                                                                                                                                   msg part2
- *                                                                                                                                                  (does not         
- *                                                                                                                                                   include second 
+ *                                                                                                                                                  (does not
+ *                                                                                                                                                   include second
  *                                                                                                                                                   bridged msg)
- *   RETURNS:
- *            number of bytes in message
- *
  *
  *   Arguments:
  *                sess       - Pointer to IPMI session data structure
@@ -540,304 +529,301 @@ int i;
  *                b2msg1     - Pointer to IPMI message 1 of optional second bridged message; 0 if not used
  *                b2msg2     - Pointer to IPMI message 2 of optional second bridged message; 0 if not used
  *                b2msg2Size - Size    of IPMI message 2 of optional second bridged message; 0 if not used
- *                auth       - Authentication type to use for message wrapper (depending on msg type, may be different from the type specified in imsg2)
+ *                auth       - Authentication type to use for message wrapper (depending on msg type, may be different
+ * from the type specified in imsg2)
  */
-int			                    
-ipmiMsgBuild(IpmiSess sess, uint8_t *message, uint8_t cmd, uint8_t imsg1netfn, uint8_t *imsg2, size_t imsg2Size, uint8_t *b1msg1, uint8_t *b1msg2, size_t b1msg2Size, uint8_t *b2msg1, uint8_t *b2msg2, size_t b2msg2Size)
-{
-size_t   iwrapperSize;
-int      offset_nbytes;
-uint8_t  auth;
-size_t   imsg1Size   = sizeof(IPMI_MSG1);
-uint8_t  imsg1[imsg1Size];
-int      n, i, offset = 0;
-uint8_t  cs2, b1cs2; /* imsg2 and b1msg2 checksums */
-	
-	ipmiMsgSetImsg1Auth( sess, cmd, &auth, &iwrapperSize, &offset_nbytes );
+// clang-format on
+int ipmiMsgBuild(IpmiSess sess, uint8_t* message, uint8_t cmd, uint8_t imsg1netfn, uint8_t* imsg2, size_t imsg2Size,
+                 uint8_t* b1msg1, uint8_t* b1msg2, size_t b1msg2Size, uint8_t* b2msg1, uint8_t* b2msg2,
+                 size_t b2msg2Size) {
+    size_t  iwrapperSize;
+    int     offset_nbytes;
+    uint8_t auth;
+    size_t  imsg1Size = sizeof(IPMI_MSG1);
+    uint8_t imsg1[imsg1Size];
+    int     n, i, offset = 0;
+    uint8_t cs2, b1cs2; /* imsg2 and b1msg2 checksums */
 
-/* Must be called after ipmiMsgSetImsg1Auth unless we change this to malloc later */
-uint8_t  iwrapper[iwrapperSize];
+    ipmiMsgSetImsg1Auth(sess, cmd, &auth, &iwrapperSize, &offset_nbytes);
 
-	switch ( auth ) {
+    /* Must be called after ipmiMsgSetImsg1Auth unless we change this to malloc later */
+    uint8_t iwrapper[iwrapperSize];
 
-		default:
-			printf("ipmiMsgBuild: unsupported authentication type %i\n", auth );
-			return 0;
+    switch (auth) {
 
-		case IPMI_MSG_AUTH_TYPE_NONE:
-			memcpy( iwrapper, IPMI_WRAPPER, iwrapperSize );
-			break;
+        default:
+            printf("ipmiMsgBuild: unsupported authentication type %i\n", auth);
+            return 0;
 
-		case IPMI_MSG_AUTH_TYPE_PWD_KEY:
-			memcpy( iwrapper, IPMI_WRAPPER_PWD_KEY, iwrapperSize );
-			break;
-	}
+        case IPMI_MSG_AUTH_TYPE_NONE:
+            memcpy(iwrapper, IPMI_WRAPPER, iwrapperSize);
+            break;
 
-	memcpy( imsg1, IPMI_MSG1, imsg1Size );
+        case IPMI_MSG_AUTH_TYPE_PWD_KEY:
+            memcpy(iwrapper, IPMI_WRAPPER_PWD_KEY, iwrapperSize);
+            break;
+    }
 
-	imsg1[IPMI_MSG1_NETFNLUN_OFFSET] = imsg1netfn << 2;
+    memcpy(imsg1, IPMI_MSG1, imsg1Size);
 
-	ipmiMsgSetSeqId( sess, iwrapper, cmd );
+    imsg1[IPMI_MSG1_NETFNLUN_OFFSET] = imsg1netfn << 2;
 
-	/* Activate Session command echoes the challenge string */
-	if ( cmd == IPMI_MSG_CMD_ACTIVATE_SESSION ) {
-		for ( i = 0; i < IPMI_MSG2_STR_LENGTH ; i++)
-			imsg2[IPMI_MSG2_STR_OFFSET + i] = sess->str[i];
-	}
+    ipmiMsgSetSeqId(sess, iwrapper, cmd);
 
-	/* Number of bytes in message */
-	iwrapper[offset_nbytes] = (b1msg1 && b2msg1) ? 3*imsg1Size + imsg2Size + b1msg2Size + b2msg2Size 
-	    : (b1msg1) ? 2*imsg1Size + imsg2Size + b1msg2Size : imsg1Size + imsg2Size;
+    /* Activate Session command echoes the challenge string */
+    if (cmd == IPMI_MSG_CMD_ACTIVATE_SESSION) {
+        for (i = 0; i < IPMI_MSG2_STR_LENGTH; i++) {
+            imsg2[IPMI_MSG2_STR_OFFSET + i] = sess->str[i];
+        }
+    }
 
-	n = sizeof(RMCP_HEADER) + iwrapperSize + iwrapper[offset_nbytes];
+    /* Number of bytes in message */
+    iwrapper[offset_nbytes] = (b1msg1 && b2msg1) ? 3 * imsg1Size + imsg2Size + b1msg2Size + b2msg2Size
+                              : (b1msg1)         ? 2 * imsg1Size + imsg2Size + b1msg2Size
+                                                 : imsg1Size + imsg2Size;
 
-	/* Build message */
-	memcpy( message, RMCP_HEADER, sizeof(RMCP_HEADER) );
+    n = sizeof(RMCP_HEADER) + iwrapperSize + iwrapper[offset_nbytes];
 
-	offset += sizeof(RMCP_HEADER);
+    /* Build message */
+    memcpy(message, RMCP_HEADER, sizeof(RMCP_HEADER));
 
-	memcpy( message + offset, iwrapper, iwrapperSize );
+    offset += sizeof(RMCP_HEADER);
 
-	/* Set IPMI sequence number */
-       	if ( sess->seq >= 0x3F )
-       		sess->seq = 1;
-       	else
-       		sess->seq++;
+    memcpy(message + offset, iwrapper, iwrapperSize);
 
-       	imsg2[IPMI_MSG2_SEQLUN_OFFSET] |= (sess->seq << 2);
+    /* Set IPMI sequence number */
+    if (sess->seq >= 0x3F) {
+        sess->seq = 1;
+    } else {
+        sess->seq++;
+    }
 
-	/* Calculate checksums */
-	imsg1[imsg1Size - 1] = calcTwosComplementChecksum( (uint8_t *)imsg1, imsg1Size );
-	cs2 = imsg2[imsg2Size - 1] = calcTwosComplementChecksum( (uint8_t *)imsg2, imsg2Size );
+    imsg2[IPMI_MSG2_SEQLUN_OFFSET] |= (sess->seq << 2);
 
-	offset += iwrapperSize;
-	memcpy( message + offset, imsg1, imsg1Size );
+    /* Calculate checksums */
+    imsg1[imsg1Size - 1] = calcTwosComplementChecksum((uint8_t*)imsg1, imsg1Size);
+    cs2 = imsg2[imsg2Size - 1] = calcTwosComplementChecksum((uint8_t*)imsg2, imsg2Size);
 
-	offset += imsg1Size;
+    offset += iwrapperSize;
+    memcpy(message + offset, imsg1, imsg1Size);
 
-	/* Copy optional bridged messages and checksums to message array */
-	if ( b1msg1 ) {
+    offset += imsg1Size;
 
-		b1msg1[imsg1Size - 1]  = calcTwosComplementChecksum( (uint8_t *)b1msg1, imsg1Size );
-		b1cs2 = b1msg2[b1msg2Size - 1] = calcTwosComplementChecksum( (uint8_t *)b1msg2, b1msg2Size );
+    /* Copy optional bridged messages and checksums to message array */
+    if (b1msg1) {
 
-		memcpy( message + offset, imsg2, imsg2Size - 1 );
+        b1msg1[imsg1Size - 1] = calcTwosComplementChecksum((uint8_t*)b1msg1, imsg1Size);
+        b1cs2 = b1msg2[b1msg2Size - 1] = calcTwosComplementChecksum((uint8_t*)b1msg2, b1msg2Size);
 
-		offset += imsg2Size - 1;
-		memcpy( message + offset, b1msg1, imsg1Size );
+        memcpy(message + offset, imsg2, imsg2Size - 1);
 
-		offset += imsg1Size;
+        offset += imsg2Size - 1;
+        memcpy(message + offset, b1msg1, imsg1Size);
 
-		if ( b2msg1 ) {
+        offset += imsg1Size;
 
-			b2msg1[imsg1Size - 1]  = calcTwosComplementChecksum( (uint8_t *)b2msg1, imsg1Size );
-			b2msg2[b2msg2Size - 1] = calcTwosComplementChecksum( (uint8_t *)b2msg2, b2msg2Size );
+        if (b2msg1) {
 
-			memcpy( message + offset, b1msg2, b1msg2Size - 1 );
+            b2msg1[imsg1Size - 1]  = calcTwosComplementChecksum((uint8_t*)b2msg1, imsg1Size);
+            b2msg2[b2msg2Size - 1] = calcTwosComplementChecksum((uint8_t*)b2msg2, b2msg2Size);
 
-			offset += b1msg2Size - 1;
-			memcpy( message + offset, b2msg1, imsg1Size );
+            memcpy(message + offset, b1msg2, b1msg2Size - 1);
 
-			offset += imsg1Size;
-			memcpy( message + offset, b2msg2, b2msg2Size );
+            offset += b1msg2Size - 1;
+            memcpy(message + offset, b2msg1, imsg1Size);
 
-			offset += b2msg2Size;	
-			memcpy( message + offset, &b1cs2, 1 );
-			offset++;
-					
-		}
-		else {
-			memcpy( message + offset, b1msg2, b1msg2Size );
-			offset += b1msg2Size;
-		}
+            offset += imsg1Size;
+            memcpy(message + offset, b2msg2, b2msg2Size);
 
-		memcpy( message + offset, &cs2, 1 );
-	}
-	else
-		memcpy( message + offset, imsg2, imsg2Size );
+            offset += b2msg2Size;
+            memcpy(message + offset, &b1cs2, 1);
+            offset++;
+        } else {
+            memcpy(message + offset, b1msg2, b1msg2Size);
+            offset += b1msg2Size;
+        }
 
-	return n;
+        memcpy(message + offset, &cs2, 1);
+    } else {
+        memcpy(message + offset, imsg2, imsg2Size);
+    }
+
+    return n;
 }
 
 /*
  * Send message and read response
- * 
+ *
  * responseSize is the expected response length. It is 0 if the response length is not known.
- * In that case, set it to MSG_MAX_LENGTH.  When we don't know the response length, 
+ * In that case, set it to MSG_MAX_LENGTH.  When we don't know the response length,
  * asyn may return status 'timeout', which we ignore.
  *
  *   RETURNS: asyn status from write/read
  */
-int
-ipmiMsgWriteRead(const char *name, uint8_t *message, size_t messageSize, uint8_t *response, size_t *responseSize, double timeout, size_t *responseLen)
-{
-size_t     numSent;
-int        eomReason;
-asynStatus status;
-asynUser  *pasynUser;
+int ipmiMsgWriteRead(const char* name, uint8_t* message, size_t messageSize, uint8_t* response, size_t* responseSize,
+                     double timeout, size_t* responseLen) {
+    size_t     numSent;
+    int        eomReason;
+    asynStatus status;
+    asynUser*  pasynUser;
 
-	if ( (status = pasynOctetSyncIO->connect(name, 0, &pasynUser, NULL)) ) {
-		return status;
-	}
+    if ((status = pasynOctetSyncIO->connect(name, 0, &pasynUser, NULL))) {
+        return status;
+    }
 
-	if ( *responseSize == 0 )
-		*responseSize = MSG_MAX_LENGTH;
+    if (*responseSize == 0) {
+        *responseSize = MSG_MAX_LENGTH;
+    }
 
-       	memset( response, 0, *responseSize ); /* Initialize response to 0s in order to detect empty bytes ? */
+    memset(response, 0, *responseSize); /* Initialize response to 0s in order to detect empty bytes ? */
 
-	status = pasynOctetSyncIO->writeRead( pasynUser, (const char *)message, messageSize, 
-	    (char *)response, *responseSize, timeout, &numSent, responseLen, &eomReason );
+    status = pasynOctetSyncIO->writeRead(pasynUser, (const char*)message, messageSize, (char*)response, *responseSize,
+                                         timeout, &numSent, responseLen, &eomReason);
 
-	pasynOctetSyncIO->disconnect( pasynUser );
+    pasynOctetSyncIO->disconnect(pasynUser);
 
-	return status;
+    return status;
 }
 
 /*
  * To start a session, perform the following sequence of messages:
- * 
+ *
  *    Get Channel Authentication Capabilities
  *    Get Session Challenge
  *    Activate Session
  *    Set Session Privilege
  *
- * Messages sent outside of a session or to close a session 
+ * Messages sent outside of a session or to close a session
  * use ipmiMsgWriteRead directly, which does not try to start a new session.
  */
 
 /* Get Channel Authentication Capabilities */
-int
-ipmiMsgGetChanAuth(void *device, IpmiSess sess, uint8_t *data, size_t *responseSize, size_t roffs)
-{
-uint8_t  message[MSG_MAX_LENGTH] = { 0 };
-uint8_t *imsg2        = GET_AUTH_MSG;
-size_t   imsg2Size    = sizeof( GET_AUTH_MSG );
-uint8_t  cmd          = IPMI_MSG_CMD_GET_CHAN_AUTH;
-size_t   messageSize  = ipmiMsgBuild( sess, message, cmd, IPMI_MSG_NETFN_APP_REQUEST, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0 );
+int ipmiMsgGetChanAuth(void* device, IpmiSess sess, uint8_t* data, size_t* responseSize, size_t roffs) {
+    uint8_t  message[MSG_MAX_LENGTH] = {0};
+    uint8_t* imsg2                   = GET_AUTH_MSG;
+    size_t   imsg2Size               = sizeof(GET_AUTH_MSG);
+    uint8_t  cmd                     = IPMI_MSG_CMD_GET_CHAN_AUTH;
+    size_t   messageSize =
+        ipmiMsgBuild(sess, message, cmd, IPMI_MSG_NETFN_APP_REQUEST, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0);
 
-	return sess->wrf( device, sess, message, messageSize, data, responseSize, cmd, IPMI_MSG_NETFN_APP_REQUEST, roffs, 1 );
+    return sess->wrf(device, sess, message, messageSize, data, responseSize, cmd, IPMI_MSG_NETFN_APP_REQUEST, roffs, 1);
 }
 
 /* Get Session Challenge */
-int
-ipmiMsgGetSess(void *device, IpmiSess sess, uint8_t *data, size_t *responseSize, uint8_t *msg, size_t roffs)
-{
-uint8_t  message[MSG_MAX_LENGTH] = { 0 };
-uint8_t *imsg2        = msg; // temporary - GET_SESS_MSG;
-size_t   imsg2Size    = sizeof( GET_SESS_MSG ); /* If we keep drvMchGetSess, then it should pass message size here */
-uint8_t  cmd          = IPMI_MSG_CMD_GET_SESSION_CHALLENGE;
-size_t   messageSize  = ipmiMsgBuild( sess, message, cmd, IPMI_MSG_NETFN_APP_REQUEST, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0 );
+int ipmiMsgGetSess(void* device, IpmiSess sess, uint8_t* data, size_t* responseSize, uint8_t* msg, size_t roffs) {
+    uint8_t  message[MSG_MAX_LENGTH] = {0};
+    uint8_t* imsg2                   = msg;    // temporary - GET_SESS_MSG;
+    size_t   imsg2Size = sizeof(GET_SESS_MSG); /* If we keep drvMchGetSess, then it should pass message size here */
+    uint8_t  cmd       = IPMI_MSG_CMD_GET_SESSION_CHALLENGE;
+    size_t   messageSize =
+        ipmiMsgBuild(sess, message, cmd, IPMI_MSG_NETFN_APP_REQUEST, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0);
 
-	/* Set authentication method */
-	imsg2[IPMI_MSG2_AUTH_TYPE_OFFSET] = sess->authReq;
+    /* Set authentication method */
+    imsg2[IPMI_MSG2_AUTH_TYPE_OFFSET] = sess->authReq;
 
-	return sess->wrf( device, sess, message, messageSize, data, responseSize, cmd, IPMI_MSG_NETFN_APP_REQUEST, roffs, 1 );
+    return sess->wrf(device, sess, message, messageSize, data, responseSize, cmd, IPMI_MSG_NETFN_APP_REQUEST, roffs, 1);
 }
 
 /* Activate Session */
-int
-ipmiMsgActSess(void *device, IpmiSess sess, uint8_t *data, size_t *responseSize, size_t roffs)
-{
-uint8_t  message[MSG_MAX_LENGTH] = { 0 };
-uint8_t *imsg2        = ACT_SESS_MSG;
-size_t   imsg2Size    = sizeof( ACT_SESS_MSG );
-uint8_t  cmd          = IPMI_MSG_CMD_ACTIVATE_SESSION;
-size_t   messageSize;
-int      i;
+int ipmiMsgActSess(void* device, IpmiSess sess, uint8_t* data, size_t* responseSize, size_t roffs) {
+    uint8_t  message[MSG_MAX_LENGTH] = {0};
+    uint8_t* imsg2                   = ACT_SESS_MSG;
+    size_t   imsg2Size               = sizeof(ACT_SESS_MSG);
+    uint8_t  cmd                     = IPMI_MSG_CMD_ACTIVATE_SESSION;
+    size_t   messageSize;
+    int      i;
 
-	/* Copy challenge string */
-	for ( i = 0; i < IPMI_MSG2_STR_LENGTH ; i++)
-		imsg2[IPMI_MSG2_STR_OFFSET + i] = sess->str[i];
+    /* Copy challenge string */
+    for (i = 0; i < IPMI_MSG2_STR_LENGTH; i++) {
+        imsg2[IPMI_MSG2_STR_OFFSET + i] = sess->str[i];
+    }
 
-	/* Set authentication method */
-	imsg2[IPMI_MSG2_AUTH_TYPE_OFFSET] = sess->authReq;
+    /* Set authentication method */
+    imsg2[IPMI_MSG2_AUTH_TYPE_OFFSET] = sess->authReq;
 
-	messageSize = ipmiMsgBuild( sess, message, cmd, IPMI_MSG_NETFN_APP_REQUEST, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0 );
+    messageSize = ipmiMsgBuild(sess, message, cmd, IPMI_MSG_NETFN_APP_REQUEST, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0);
 
-	return sess->wrf( device, sess, message, messageSize, data, responseSize, cmd, IPMI_MSG_NETFN_APP_REQUEST, roffs, 1 );
+    return sess->wrf(device, sess, message, messageSize, data, responseSize, cmd, IPMI_MSG_NETFN_APP_REQUEST, roffs, 1);
 }
 
 /* Set Privilege Level */
-int
-ipmiMsgSetPriv(void *device, IpmiSess sess, uint8_t *data, size_t *responseSize, uint8_t level, size_t roffs)
-{
-uint8_t  message[MSG_MAX_LENGTH] = { 0 };
-uint8_t *imsg2        = SET_PRIV_MSG;
-size_t   imsg2Size    = sizeof( SET_PRIV_MSG );
-size_t   messageSize;
-uint8_t  cmd          = IPMI_MSG_CMD_SET_PRIV_LEVEL;
+int ipmiMsgSetPriv(void* device, IpmiSess sess, uint8_t* data, size_t* responseSize, uint8_t level, size_t roffs) {
+    uint8_t  message[MSG_MAX_LENGTH] = {0};
+    uint8_t* imsg2                   = SET_PRIV_MSG;
+    size_t   imsg2Size               = sizeof(SET_PRIV_MSG);
+    size_t   messageSize;
+    uint8_t  cmd = IPMI_MSG_CMD_SET_PRIV_LEVEL;
 
-	imsg2[IPMI_MSG2_PRIV_LEVEL_OFFSET] = IPMI_MSG_PRIV_LEVEL_OPER; // temporary override ... level;
+    imsg2[IPMI_MSG2_PRIV_LEVEL_OFFSET] = IPMI_MSG_PRIV_LEVEL_OPER; // temporary override ... level;
 
-  	messageSize = ipmiMsgBuild( sess, message, cmd, IPMI_MSG_NETFN_APP_REQUEST, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0 );
+    messageSize = ipmiMsgBuild(sess, message, cmd, IPMI_MSG_NETFN_APP_REQUEST, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0);
 
-	return sess->wrf( device, sess, message, messageSize, data, responseSize, cmd, IPMI_MSG_NETFN_APP_REQUEST, roffs, 1 );
+    return sess->wrf(device, sess, message, messageSize, data, responseSize, cmd, IPMI_MSG_NETFN_APP_REQUEST, roffs, 1);
 }
 
 /* Close Session - test for NAT and determine reply offset*/
-int
-ipmiMsgCloseSess(void *device, IpmiSess sess, uint8_t *data, size_t *responseSize)
-{
-uint8_t  message[MSG_MAX_LENGTH];
-uint8_t *imsg2        = CLOSE_SESS_MSG;
-size_t   imsg2Size    = sizeof( CLOSE_SESS_MSG );
-uint8_t  cmd          = IPMI_MSG_CMD_CLOSE_SESSION;
-size_t   messageSize  = ipmiMsgBuild( sess, message, cmd, IPMI_MSG_NETFN_APP_REQUEST, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0 );
+int ipmiMsgCloseSess(void* device, IpmiSess sess, uint8_t* data, size_t* responseSize) {
+    uint8_t  message[MSG_MAX_LENGTH];
+    uint8_t* imsg2     = CLOSE_SESS_MSG;
+    size_t   imsg2Size = sizeof(CLOSE_SESS_MSG);
+    uint8_t  cmd       = IPMI_MSG_CMD_CLOSE_SESSION;
+    size_t   messageSize =
+        ipmiMsgBuild(sess, message, cmd, IPMI_MSG_NETFN_APP_REQUEST, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0);
 
-	return sess->wrf( device, sess, message, messageSize, data, responseSize, cmd, IPMI_MSG_NETFN_APP_REQUEST, 0/*roffs*/, 1 );
+    return sess->wrf(device, sess, message, messageSize, data, responseSize, cmd, IPMI_MSG_NETFN_APP_REQUEST,
+                     0 /*roffs*/, 1);
 }
 
-/* 
+/*
  * Cold Reset. Do not reconnect; next request message will handle reconnection
- * 
- *   RETURNS: status from sess->wrf
- *            0 on success
- *            non-zero for error
- */
-int
-ipmiMsgColdReset(void *device, IpmiSess sess, uint8_t *data)
-{
-uint8_t  message[MSG_MAX_LENGTH] = { 0 };
-uint8_t *imsg2     = BASIC_MSG;
-size_t   imsg2Size = sizeof( BASIC_MSG );
-size_t   messageSize;
-size_t   responseSize = 0;
-uint8_t  cmd = IPMI_MSG_CMD_COLD_RESET;
-
-	imsg2[IPMI_MSG2_CMD_OFFSET] = cmd;
-
-	messageSize = ipmiMsgBuild( sess, message, cmd, IPMI_MSG_NETFN_APP_REQUEST, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0 );
-
-	return sess->wrf( device, sess, message, messageSize, data, /* need to update this */&responseSize, cmd, IPMI_MSG_NETFN_APP_REQUEST, 0, 0 );
-}
-
-/* Chassis Control 
  *
  *   RETURNS: status from sess->wrf
  *            0 on success
  *            non-zero for error
  */
-int
-ipmiMsgChassisControl(void *device, IpmiSess sess,  uint8_t *data, int bridged, uint8_t rsAddr, uint8_t rqAddr, uint8_t parm, size_t *responseSize, int roffs)
-{
-uint8_t  message[MSG_MAX_LENGTH] = { 0 };
-uint8_t  imsg2Size = sizeof( CHAS_CTRL_MSG );
-uint8_t  imsg2[imsg2Size];
-size_t   messageSize;
-uint8_t  cmd   = IPMI_MSG_CMD_CHAS_CTRL;
-uint8_t  netfn = IPMI_MSG_NETFN_CHASSIS;
+int ipmiMsgColdReset(void* device, IpmiSess sess, uint8_t* data) {
+    uint8_t  message[MSG_MAX_LENGTH] = {0};
+    uint8_t* imsg2                   = BASIC_MSG;
+    size_t   imsg2Size               = sizeof(BASIC_MSG);
+    size_t   messageSize;
+    size_t   responseSize = 0;
+    uint8_t  cmd          = IPMI_MSG_CMD_COLD_RESET;
 
-	memcpy( imsg2, CHAS_CTRL_MSG, imsg2Size );
-	imsg2[IPMI_MSG2_CMD_OFFSET] = cmd;
+    imsg2[IPMI_MSG2_CMD_OFFSET] = cmd;
 
-	imsg2[IPMI_MSG2_SENSOR_OFFSET] = parm;
+    messageSize = ipmiMsgBuild(sess, message, cmd, IPMI_MSG_NETFN_APP_REQUEST, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0);
 
-	if ( bridged ) // may need to distinguish between once and twice-bridged messages
-		ipmiBuildSendMsg( sess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0 );
-	else
-		messageSize = ipmiMsgBuild( sess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0 );
+    return sess->wrf(device, sess, message, messageSize, data, /* need to update this */ &responseSize, cmd,
+                     IPMI_MSG_NETFN_APP_REQUEST, 0, 0);
+}
 
-	return sess->wrf( device, sess, message, messageSize, data, responseSize, cmd, netfn, roffs, 0 );
+/* Chassis Control
+ *
+ *   RETURNS: status from sess->wrf
+ *            0 on success
+ *            non-zero for error
+ */
+int ipmiMsgChassisControl(void* device, IpmiSess sess, uint8_t* data, int bridged, uint8_t rsAddr, uint8_t rqAddr,
+                          uint8_t parm, size_t* responseSize, int roffs) {
+    uint8_t message[MSG_MAX_LENGTH] = {0};
+    uint8_t imsg2Size               = sizeof(CHAS_CTRL_MSG);
+    uint8_t imsg2[imsg2Size];
+    size_t  messageSize;
+    uint8_t cmd   = IPMI_MSG_CMD_CHAS_CTRL;
+    uint8_t netfn = IPMI_MSG_NETFN_CHASSIS;
+
+    memcpy(imsg2, CHAS_CTRL_MSG, imsg2Size);
+    imsg2[IPMI_MSG2_CMD_OFFSET] = cmd;
+
+    imsg2[IPMI_MSG2_SENSOR_OFFSET] = parm;
+
+    if (bridged) { // may need to distinguish between once and twice-bridged messages
+        ipmiBuildSendMsg(sess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0);
+    } else {
+        messageSize = ipmiMsgBuild(sess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0);
+    }
+
+    return sess->wrf(device, sess, message, messageSize, data, responseSize, cmd, netfn, roffs, 0);
 }
 
 /* Get Chassis Status
@@ -846,97 +832,98 @@ uint8_t  netfn = IPMI_MSG_NETFN_CHASSIS;
  *            0 on success
  *            non-zero for error
  */
-int
-ipmiMsgGetChassisStatus(void *device, IpmiSess sess,  uint8_t *data, int bridged, uint8_t rsAddr, uint8_t rqAddr, size_t *responseSize, int roffs)
-{
-uint8_t  message[MSG_MAX_LENGTH] = { 0 };
-uint8_t  imsg2Size = sizeof( BASIC_MSG );
-uint8_t  imsg2[imsg2Size];
-size_t   messageSize;
-uint8_t  cmd   = IPMI_MSG_CMD_GET_CHAS_STATUS;
-uint8_t  netfn = IPMI_MSG_NETFN_CHASSIS;
+int ipmiMsgGetChassisStatus(void* device, IpmiSess sess, uint8_t* data, int bridged, uint8_t rsAddr, uint8_t rqAddr,
+                            size_t* responseSize, int roffs) {
+    uint8_t message[MSG_MAX_LENGTH] = {0};
+    uint8_t imsg2Size               = sizeof(BASIC_MSG);
+    uint8_t imsg2[imsg2Size];
+    size_t  messageSize;
+    uint8_t cmd   = IPMI_MSG_CMD_GET_CHAS_STATUS;
+    uint8_t netfn = IPMI_MSG_NETFN_CHASSIS;
 
-	memcpy( imsg2, BASIC_MSG, imsg2Size );
-	imsg2[IPMI_MSG2_CMD_OFFSET] = cmd;
+    memcpy(imsg2, BASIC_MSG, imsg2Size);
+    imsg2[IPMI_MSG2_CMD_OFFSET] = cmd;
 
-	if ( bridged ) // may need to distinguish between once and twice-bridged messages
-		ipmiBuildSendMsg( sess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0 );
-	else
-		messageSize = ipmiMsgBuild( sess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0 );
+    if (bridged) { // may need to distinguish between once and twice-bridged messages
+        ipmiBuildSendMsg(sess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0);
+    } else {
+        messageSize = ipmiMsgBuild(sess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0);
+    }
 
-	return sess->wrf( device, sess, message, messageSize, data, responseSize, cmd, netfn, roffs, 0 );
+    return sess->wrf(device, sess, message, messageSize, data, responseSize, cmd, netfn, roffs, 0);
 }
 
-/* Get FRU Inventory Info 
+/* Get FRU Inventory Info
  *
  *   RETURNS: status from sess->wrf
  *            0 on success
  *            non-zero for error
  */
-int
-ipmiMsgGetFruInvInfo(void *device, IpmiSess sess, uint8_t *data, int bridged, uint8_t rsAddr, uint8_t rqAddr, uint8_t id, size_t *responseSize, int roffs)
-{
-uint8_t  message[MSG_MAX_LENGTH] = { 0 };
-uint8_t  imsg2Size = sizeof( SENS_READ_MSG );
-uint8_t  imsg2[imsg2Size];
-size_t   messageSize;
-uint8_t  cmd   = IPMI_MSG_CMD_GET_FRU_INFO;
-uint8_t  netfn = IPMI_MSG_NETFN_STORAGE;
+int ipmiMsgGetFruInvInfo(void* device, IpmiSess sess, uint8_t* data, int bridged, uint8_t rsAddr, uint8_t rqAddr,
+                         uint8_t id, size_t* responseSize, int roffs) {
+    uint8_t message[MSG_MAX_LENGTH] = {0};
+    uint8_t imsg2Size               = sizeof(SENS_READ_MSG);
+    uint8_t imsg2[imsg2Size];
+    size_t  messageSize;
+    uint8_t cmd   = IPMI_MSG_CMD_GET_FRU_INFO;
+    uint8_t netfn = IPMI_MSG_NETFN_STORAGE;
 
-	memcpy( imsg2, SENS_READ_MSG, imsg2Size );
-	imsg2[IPMI_MSG2_CMD_OFFSET] = cmd;
+    memcpy(imsg2, SENS_READ_MSG, imsg2Size);
+    imsg2[IPMI_MSG2_CMD_OFFSET] = cmd;
 
-	imsg2[IPMI_MSG2_SENSOR_OFFSET] = id;
+    imsg2[IPMI_MSG2_SENSOR_OFFSET] = id;
 
-	if ( bridged ) // may need to distinguish between once and twice-bridged messages
-		ipmiBuildSendMsg( sess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0 );
-	else
-		messageSize = ipmiMsgBuild( sess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0 );
+    if (bridged) { // may need to distinguish between once and twice-bridged messages
+        ipmiBuildSendMsg(sess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0);
+    } else {
+        messageSize = ipmiMsgBuild(sess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0);
+    }
 
-	return sess->wrf( device, sess, message, messageSize, data, responseSize, cmd, netfn, roffs, 0 );
+    return sess->wrf(device, sess, message, messageSize, data, responseSize, cmd, netfn, roffs, 0);
 }
 
-/* Read FRU data 
+/* Read FRU data
  *
  *   RETURNS: status from sess->wrf
  *            0 on success
  *            non-zero for error
  */
-int
-ipmiMsgReadFru(void *device, IpmiSess sess, uint8_t *data, int bridged, uint8_t rsAddr, uint8_t rqAddr, uint8_t id, uint8_t *readOffset, uint8_t readSize, size_t *responseSize, int roffs)
-{
-uint8_t  message[MSG_MAX_LENGTH] = { 0 };
-uint8_t  imsg2Size = sizeof( FRU_READ_MSG );
-uint8_t  imsg2[imsg2Size];
-size_t   messageSize;
-uint8_t  cmd   = IPMI_MSG_CMD_READ_FRU_DATA;
-uint8_t  netfn = IPMI_MSG_NETFN_STORAGE;
+int ipmiMsgReadFru(void* device, IpmiSess sess, uint8_t* data, int bridged, uint8_t rsAddr, uint8_t rqAddr, uint8_t id,
+                   uint8_t* readOffset, uint8_t readSize, size_t* responseSize, int roffs) {
+    uint8_t message[MSG_MAX_LENGTH] = {0};
+    uint8_t imsg2Size               = sizeof(FRU_READ_MSG);
+    uint8_t imsg2[imsg2Size];
+    size_t  messageSize;
+    uint8_t cmd   = IPMI_MSG_CMD_READ_FRU_DATA;
+    uint8_t netfn = IPMI_MSG_NETFN_STORAGE;
 
-	memcpy( imsg2, FRU_READ_MSG, imsg2Size );
-	imsg2[IPMI_MSG2_CMD_OFFSET] = cmd;
+    memcpy(imsg2, FRU_READ_MSG, imsg2Size);
+    imsg2[IPMI_MSG2_CMD_OFFSET] = cmd;
 
-	imsg2[IPMI_MSG2_CMD_OFFSET]          = cmd;
-	imsg2[IPMI_MSG2_READ_FRU_ID_OFFSET]  = id;
-	imsg2[IPMI_MSG2_READ_FRU_LSB_OFFSET] = readOffset[0];
-	imsg2[IPMI_MSG2_READ_FRU_MSB_OFFSET] = readOffset[1];
-	imsg2[IPMI_MSG2_READ_FRU_CNT_OFFSET] = readSize;
+    imsg2[IPMI_MSG2_CMD_OFFSET]          = cmd;
+    imsg2[IPMI_MSG2_READ_FRU_ID_OFFSET]  = id;
+    imsg2[IPMI_MSG2_READ_FRU_LSB_OFFSET] = readOffset[0];
+    imsg2[IPMI_MSG2_READ_FRU_MSB_OFFSET] = readOffset[1];
+    imsg2[IPMI_MSG2_READ_FRU_CNT_OFFSET] = readSize;
 
-	if ( bridged ) // may need to distinguish between once and twice-bridged messages
-		ipmiBuildSendMsg( sess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0 );
-	else
-		messageSize = ipmiMsgBuild( sess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0 );
+    if (bridged) { // may need to distinguish between once and twice-bridged messages
+        ipmiBuildSendMsg(sess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0);
+    } else {
+        messageSize = ipmiMsgBuild(sess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0);
+    }
 
-	return sess->wrf( device, sess, message, messageSize, data, responseSize, cmd, netfn, roffs, 0 );
+    return sess->wrf(device, sess, message, messageSize, data, responseSize, cmd, netfn, roffs, 0);
 }
 
-/* Get device, sess Sensor Data Record (SDR) Info 
+/* Get device, sess Sensor Data Record (SDR) Info
  *
  *   RETURNS: status from sess->wrf
  *            0 on success
  *            non-zero for error
  *
 int
-ipmiMsgGetDevSdrInfo(void *device, IpmiSess sess, uint8_t *data, int bridged, uint8_t rsAddr, uint8_t rqAddr, uint8_t parm, size_t *responseSize, int roffs)
+ipmiMsgGetDevSdrInfo(void *device, IpmiSess sess, uint8_t *data, int bridged, uint8_t rsAddr, uint8_t rqAddr, uint8_t
+parm, size_t *responseSize, int roffs)
 {
 uint8_t  message[MSG_MAX_LENGTH] = { 0 };
 uint8_t  imsg2Size = sizeof( GET_DEV_SDR_INFO_MSG );
@@ -945,207 +932,208 @@ size_t   messageSize;
 uint8_t  cmd   = IPMI_MSG_CMD_GET_DEV_SDR_INFO;
 uint8_t  netfn = IPMI_MSG_NETFN_SENSOR_EVENT;
 
-	memcpy( imsg2, GET_DEV_SDR_INFO_MSG, imsg2Size );
-	imsg2[IPMI_MSG2_CMD_OFFSET] = cmd;
+    memcpy( imsg2, GET_DEV_SDR_INFO_MSG, imsg2Size );
+    imsg2[IPMI_MSG2_CMD_OFFSET] = cmd;
 
-	if ( bridged ) / may need to distinguish between once and twice-bridged messages
-		ipmiBuildSendMsg( sess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0 );
-	else
-		messageSize = ipmiMsgBuild( sess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0 );
+    if ( bridged ) / may need to distinguish between once and twice-bridged messages
+        ipmiBuildSendMsg( sess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0 );
+    else
+        messageSize = ipmiMsgBuild( sess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0 );
 
-	return sess->wrf( device, sess, message, messageSize, data, responseSize, cmd, netfn, roffs, 0 );
+    return sess->wrf( device, sess, message, messageSize, data, responseSize, cmd, netfn, roffs, 0 );
 }
 */
 
-/* Get SDR (Sensor Data Record) Repository Info 
+/* Get SDR (Sensor Data Record) Repository Info
  *
- * Used for both Get SDR (parm = 0) and Get device, sess SDR (parm = 1). 
+ * Used for both Get SDR (parm = 0) and Get device, sess SDR (parm = 1).
  * Only differences in the message are the network function and command code.
  *
  *   RETURNS: status from sess->wrf
  *            0 on success
  *            non-zero for error
  */
-int
-ipmiMsgGetSdrRepInfo(void *device, IpmiSess sess, uint8_t *data, int bridged, uint8_t rsAddr, uint8_t rqAddr, size_t *responseSize, int roffs, uint8_t parm)
-{
-uint8_t  message[MSG_MAX_LENGTH] = { 0 };
-uint8_t  imsg2Size = (parm == IPMI_SDRREP_PARM_GET_DEV_SDR) ? sizeof( GET_DEV_SDR_INFO_MSG ) : sizeof( BASIC_MSG );
-uint8_t  imsg2[imsg2Size];
-size_t   messageSize;
-uint8_t  cmd   = (parm==IPMI_SDRREP_PARM_GET_DEV_SDR) ? IPMI_MSG_CMD_GET_DEV_SDR_INFO : IPMI_MSG_CMD_GET_SDRREP_INFO;
-uint8_t  netfn = (parm==IPMI_SDRREP_PARM_GET_DEV_SDR) ? IPMI_MSG_NETFN_SENSOR_EVENT   : IPMI_MSG_NETFN_STORAGE;
+int ipmiMsgGetSdrRepInfo(void* device, IpmiSess sess, uint8_t* data, int bridged, uint8_t rsAddr, uint8_t rqAddr,
+                         size_t* responseSize, int roffs, uint8_t parm) {
+    uint8_t message[MSG_MAX_LENGTH] = {0};
+    uint8_t imsg2Size = (parm == IPMI_SDRREP_PARM_GET_DEV_SDR) ? sizeof(GET_DEV_SDR_INFO_MSG) : sizeof(BASIC_MSG);
+    uint8_t imsg2[imsg2Size];
+    size_t  messageSize;
+    uint8_t cmd = (parm == IPMI_SDRREP_PARM_GET_DEV_SDR) ? IPMI_MSG_CMD_GET_DEV_SDR_INFO : IPMI_MSG_CMD_GET_SDRREP_INFO;
+    uint8_t netfn = (parm == IPMI_SDRREP_PARM_GET_DEV_SDR) ? IPMI_MSG_NETFN_SENSOR_EVENT : IPMI_MSG_NETFN_STORAGE;
 
-	if ( parm == IPMI_SDRREP_PARM_GET_DEV_SDR )
-		memcpy( imsg2, GET_DEV_SDR_INFO_MSG, imsg2Size );
-	else
-		memcpy( imsg2, BASIC_MSG, imsg2Size );
-	imsg2[IPMI_MSG2_CMD_OFFSET] = cmd;
+    if (parm == IPMI_SDRREP_PARM_GET_DEV_SDR) {
+        memcpy(imsg2, GET_DEV_SDR_INFO_MSG, imsg2Size);
+    } else {
+        memcpy(imsg2, BASIC_MSG, imsg2Size);
+    }
+    imsg2[IPMI_MSG2_CMD_OFFSET] = cmd;
 
-	if ( bridged ) // may need to distinguish between once and twice-bridged messages
-		ipmiBuildSendMsg( sess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0 );
-	else
-		messageSize = ipmiMsgBuild( sess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0 );
+    if (bridged) { // may need to distinguish between once and twice-bridged messages
+        ipmiBuildSendMsg(sess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0);
+    } else {
+        messageSize = ipmiMsgBuild(sess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0);
+    }
 
-	return sess->wrf( device, sess, message, messageSize, data, responseSize, cmd, netfn, roffs, 0 );
+    return sess->wrf(device, sess, message, messageSize, data, responseSize, cmd, netfn, roffs, 0);
 }
 
-/* Reserve SDR (Sensor Data Record) Repository 
+/* Reserve SDR (Sensor Data Record) Repository
  *
- * Used for both Get SDR (parm = 0) and Get device, sess SDR (parm = 1). 
+ * Used for both Get SDR (parm = 0) and Get device, sess SDR (parm = 1).
  * Only differences in the message are the network function and command code.
  *
  *   RETURNS: status from sess->wrf
  *            0 on success
  *            non-zero for error
  */
-int
-ipmiMsgReserveSdrRep(void *device, IpmiSess sess, uint8_t *data, int bridged, uint8_t rsAddr, uint8_t rqAddr, size_t *responseSize, int roffs, uint8_t parm)
-{
-uint8_t  message[MSG_MAX_LENGTH] = { 0 };
-uint8_t  imsg2Size = sizeof( BASIC_MSG );
-uint8_t  imsg2[imsg2Size];
-size_t   messageSize;
-uint8_t  cmd   = (parm==IPMI_SDRREP_PARM_GET_DEV_SDR) ? IPMI_MSG_CMD_RESERVE_DEV_SDRREP : IPMI_MSG_CMD_RESERVE_SDRREP;
-uint8_t  netfn = (parm==IPMI_SDRREP_PARM_GET_DEV_SDR) ? IPMI_MSG_NETFN_SENSOR_EVENT     : IPMI_MSG_NETFN_STORAGE;
+int ipmiMsgReserveSdrRep(void* device, IpmiSess sess, uint8_t* data, int bridged, uint8_t rsAddr, uint8_t rqAddr,
+                         size_t* responseSize, int roffs, uint8_t parm) {
+    uint8_t message[MSG_MAX_LENGTH] = {0};
+    uint8_t imsg2Size               = sizeof(BASIC_MSG);
+    uint8_t imsg2[imsg2Size];
+    size_t  messageSize;
+    uint8_t cmd =
+        (parm == IPMI_SDRREP_PARM_GET_DEV_SDR) ? IPMI_MSG_CMD_RESERVE_DEV_SDRREP : IPMI_MSG_CMD_RESERVE_SDRREP;
+    uint8_t netfn = (parm == IPMI_SDRREP_PARM_GET_DEV_SDR) ? IPMI_MSG_NETFN_SENSOR_EVENT : IPMI_MSG_NETFN_STORAGE;
 
-	memcpy( imsg2, BASIC_MSG, imsg2Size );
-	imsg2[IPMI_MSG2_CMD_OFFSET] = cmd;
+    memcpy(imsg2, BASIC_MSG, imsg2Size);
+    imsg2[IPMI_MSG2_CMD_OFFSET] = cmd;
 
-	if ( bridged ) // may need to distinguish between once and twice-bridged messages
-		ipmiBuildSendMsg( sess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0 );
-	else
-		messageSize = ipmiMsgBuild( sess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0 );
+    if (bridged) { // may need to distinguish between once and twice-bridged messages
+        ipmiBuildSendMsg(sess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0);
+    } else {
+        messageSize = ipmiMsgBuild(sess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0);
+    }
 
-	return sess->wrf( device, sess, message, messageSize, data, responseSize, cmd, netfn, roffs, 0 );
+    return sess->wrf(device, sess, message, messageSize, data, responseSize, cmd, netfn, roffs, 0);
 }
 
-/* 
+/*
  * Get SDR (Sensor Data Record)
- * 
- * Offset and reservation ID are 0 unless doing partial read that begins at an 
+ *
+ * Offset and reservation ID are 0 unless doing partial read that begins at an
  * offset into the SDR other than 0.
  *
- * Used for both Get SDR (parm = 0) and Get device, sess SDR (parm = 1). 
+ * Used for both Get SDR (parm = 0) and Get device, sess SDR (parm = 1).
  * Only differences in the message are the network function and command code.
  *
  *   RETURNS: status from sess->wrf
  *            0 on success
  *            non-zero for error
  */
-int
-ipmiMsgGetSdr(void *device, IpmiSess sess, uint8_t *data, int bridged, uint8_t rsAddr, uint8_t rqAddr, uint8_t *id, uint8_t *res, uint8_t offset, uint8_t readSize, size_t *responseSize, int roffs, uint8_t parm)
-{
-uint8_t  message[MSG_MAX_LENGTH] = { 0 };
-uint8_t  imsg2Size = sizeof( GET_SDR_MSG );
-uint8_t  imsg2[imsg2Size];
-size_t   messageSize;
-uint8_t  cmd   = (parm==IPMI_SDRREP_PARM_GET_DEV_SDR) ? IPMI_MSG_CMD_GET_DEV_SDR    : IPMI_MSG_CMD_GET_SDR;
-uint8_t  netfn = (parm==IPMI_SDRREP_PARM_GET_DEV_SDR) ? IPMI_MSG_NETFN_SENSOR_EVENT : IPMI_MSG_NETFN_STORAGE;
+int ipmiMsgGetSdr(void* device, IpmiSess sess, uint8_t* data, int bridged, uint8_t rsAddr, uint8_t rqAddr, uint8_t* id,
+                  uint8_t* res, uint8_t offset, uint8_t readSize, size_t* responseSize, int roffs, uint8_t parm) {
+    uint8_t message[MSG_MAX_LENGTH] = {0};
+    uint8_t imsg2Size               = sizeof(GET_SDR_MSG);
+    uint8_t imsg2[imsg2Size];
+    size_t  messageSize;
+    uint8_t cmd   = (parm == IPMI_SDRREP_PARM_GET_DEV_SDR) ? IPMI_MSG_CMD_GET_DEV_SDR : IPMI_MSG_CMD_GET_SDR;
+    uint8_t netfn = (parm == IPMI_SDRREP_PARM_GET_DEV_SDR) ? IPMI_MSG_NETFN_SENSOR_EVENT : IPMI_MSG_NETFN_STORAGE;
 
-	memcpy( imsg2, GET_SDR_MSG, imsg2Size );
-	imsg2[IPMI_MSG2_CMD_OFFSET] = cmd;
+    memcpy(imsg2, GET_SDR_MSG, imsg2Size);
+    imsg2[IPMI_MSG2_CMD_OFFSET] = cmd;
 
-	imsg2[IPMI_MSG2_CMD_OFFSET] = cmd;
-	imsg2[IPMI_MSG2_GET_SDR_RES_LSB_OFFSET] = res[0];
-	imsg2[IPMI_MSG2_GET_SDR_RES_MSB_OFFSET] = res[1];
-	imsg2[IPMI_MSG2_GET_SDR_ID_LSB_OFFSET]  = id[0];
-	imsg2[IPMI_MSG2_GET_SDR_ID_MSB_OFFSET]  = id[1];
-	imsg2[IPMI_MSG2_GET_SDR_OFFSET_OFFSET]  = offset;
-	imsg2[IPMI_MSG2_GET_SDR_CNT_OFFSET]     = readSize;
+    imsg2[IPMI_MSG2_CMD_OFFSET]             = cmd;
+    imsg2[IPMI_MSG2_GET_SDR_RES_LSB_OFFSET] = res[0];
+    imsg2[IPMI_MSG2_GET_SDR_RES_MSB_OFFSET] = res[1];
+    imsg2[IPMI_MSG2_GET_SDR_ID_LSB_OFFSET]  = id[0];
+    imsg2[IPMI_MSG2_GET_SDR_ID_MSB_OFFSET]  = id[1];
+    imsg2[IPMI_MSG2_GET_SDR_OFFSET_OFFSET]  = offset;
+    imsg2[IPMI_MSG2_GET_SDR_CNT_OFFSET]     = readSize;
 
-	if ( bridged ) // may need to distinguish between once and twice-bridged messages
-		ipmiBuildSendMsg( sess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0 );
-	else
-		messageSize = ipmiMsgBuild( sess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0 );
+    if (bridged) { // may need to distinguish between once and twice-bridged messages
+        ipmiBuildSendMsg(sess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0);
+    } else {
+        messageSize = ipmiMsgBuild(sess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0);
+    }
 
-	return sess->wrf( device, sess, message, messageSize, data, responseSize, cmd, netfn, roffs, 0 );
+    return sess->wrf(device, sess, message, messageSize, data, responseSize, cmd, netfn, roffs, 0);
 }
-	
-/* Get Sensor Reading. Caller specifies expected message response length. 
+
+/* Get Sensor Reading. Caller specifies expected message response length.
  *
  *   RETURNS: status from sess->wrf
  *            0 on success
  *            non-zero for error
  */
-int
-ipmiMsgReadSensor(void *device, IpmiSess sess, uint8_t *data, uint8_t bridged, uint8_t rsAddr, uint8_t rqAddr, uint8_t sens, uint8_t lun, size_t *responseSize, int roffs)
-{
-uint8_t  message[MSG_MAX_LENGTH] = { 0 };
-uint8_t  imsg2Size = sizeof( SENS_READ_MSG );
-uint8_t  imsg2[imsg2Size];
-size_t   messageSize;
-uint8_t  cmd   = IPMI_MSG_CMD_SENSOR_READ;
-uint8_t  netfn = IPMI_MSG_NETFN_SENSOR_EVENT;
+int ipmiMsgReadSensor(void* device, IpmiSess sess, uint8_t* data, uint8_t bridged, uint8_t rsAddr, uint8_t rqAddr,
+                      uint8_t sens, uint8_t lun, size_t* responseSize, int roffs) {
+    uint8_t message[MSG_MAX_LENGTH] = {0};
+    uint8_t imsg2Size               = sizeof(SENS_READ_MSG);
+    uint8_t imsg2[imsg2Size];
+    size_t  messageSize;
+    uint8_t cmd   = IPMI_MSG_CMD_SENSOR_READ;
+    uint8_t netfn = IPMI_MSG_NETFN_SENSOR_EVENT;
 
-	memcpy( imsg2, SENS_READ_MSG, imsg2Size );
-	imsg2[IPMI_MSG2_CMD_OFFSET] = cmd;
+    memcpy(imsg2, SENS_READ_MSG, imsg2Size);
+    imsg2[IPMI_MSG2_CMD_OFFSET] = cmd;
 
-	imsg2[IPMI_MSG2_SENSOR_OFFSET] = sens;
+    imsg2[IPMI_MSG2_SENSOR_OFFSET] = sens;
 
-	if ( bridged ) // may need to distinguish between once and twice-bridged messages
-		ipmiBuildSendMsg( sess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, lun );
-	else
-		messageSize = ipmiMsgBuild( sess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0 );
+    if (bridged) { // may need to distinguish between once and twice-bridged messages
+        ipmiBuildSendMsg(sess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, lun);
+    } else {
+        messageSize = ipmiMsgBuild(sess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0);
+    }
 
-	return sess->wrf( device, sess, message, messageSize, data, responseSize, cmd, netfn, roffs, 0 );
+    return sess->wrf(device, sess, message, messageSize, data, responseSize, cmd, netfn, roffs, 0);
 }
 
-/* Get Sensor Thresholds 
+/* Get Sensor Thresholds
  *
  *   RETURNS: status from sess->wrf
  *            0 on success
  *            non-zero for error
  */
-int 
-ipmiMsgGetSensorThresholds(void *device, IpmiSess sess, uint8_t *data, uint8_t bridged, uint8_t rsAddr, uint8_t rqAddr, uint8_t sens, uint8_t lun, size_t *responseSize, int roffs)
-{
-uint8_t  message[MSG_MAX_LENGTH] = { 0 };
-uint8_t  imsg2Size = sizeof( GET_SENSOR_THRESH_MSG );
-uint8_t  imsg2[imsg2Size];
-size_t   messageSize;
-uint8_t  cmd   = IPMI_MSG_CMD_GET_SENSOR_THRESH;
-uint8_t  netfn = IPMI_MSG_NETFN_SENSOR_EVENT;
+int ipmiMsgGetSensorThresholds(void* device, IpmiSess sess, uint8_t* data, uint8_t bridged, uint8_t rsAddr,
+                               uint8_t rqAddr, uint8_t sens, uint8_t lun, size_t* responseSize, int roffs) {
+    uint8_t message[MSG_MAX_LENGTH] = {0};
+    uint8_t imsg2Size               = sizeof(GET_SENSOR_THRESH_MSG);
+    uint8_t imsg2[imsg2Size];
+    size_t  messageSize;
+    uint8_t cmd   = IPMI_MSG_CMD_GET_SENSOR_THRESH;
+    uint8_t netfn = IPMI_MSG_NETFN_SENSOR_EVENT;
 
-	memcpy( imsg2, GET_SENSOR_THRESH_MSG, imsg2Size );
-	imsg2[IPMI_MSG2_CMD_OFFSET] = cmd;
+    memcpy(imsg2, GET_SENSOR_THRESH_MSG, imsg2Size);
+    imsg2[IPMI_MSG2_CMD_OFFSET] = cmd;
 
-	imsg2[IPMI_MSG2_SENSOR_OFFSET] = sens;
+    imsg2[IPMI_MSG2_SENSOR_OFFSET] = sens;
 
-	if ( bridged ) // may need to distinguish between once and twice-bridged messages
-		ipmiBuildSendMsg( sess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, lun );
-	else
-		messageSize = ipmiMsgBuild( sess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0 );
+    if (bridged) { // may need to distinguish between once and twice-bridged messages
+        ipmiBuildSendMsg(sess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, lun);
+    } else {
+        messageSize = ipmiMsgBuild(sess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0);
+    }
 
-	return sess->wrf( device, sess, message, messageSize, data, responseSize, cmd, netfn, roffs, 0 );
+    return sess->wrf(device, sess, message, messageSize, data, responseSize, cmd, netfn, roffs, 0);
 }
 
-
-/* Get device, sess ID 
+/* Get device, sess ID
  *
  *   RETURNS: status from sess->wrf
  *            0 on success
  *            non-zero for error
  */
-int
-ipmiMsgGetDeviceId(void *device, IpmiSess sess, uint8_t *data, int bridged, uint8_t rsAddr, uint8_t rqAddr, size_t *responseSize, int roffs)
-{
-uint8_t  message[MSG_MAX_LENGTH] = { 0 };
-uint8_t  imsg2Size = sizeof( BASIC_MSG );
-uint8_t  imsg2[imsg2Size];
-size_t   messageSize;
-uint8_t  cmd   = IPMI_MSG_CMD_GET_DEVICE_ID;
-uint8_t  netfn = IPMI_MSG_NETFN_APP_REQUEST;
+int ipmiMsgGetDeviceId(void* device, IpmiSess sess, uint8_t* data, int bridged, uint8_t rsAddr, uint8_t rqAddr,
+                       size_t* responseSize, int roffs) {
+    uint8_t message[MSG_MAX_LENGTH] = {0};
+    uint8_t imsg2Size               = sizeof(BASIC_MSG);
+    uint8_t imsg2[imsg2Size];
+    size_t  messageSize;
+    uint8_t cmd   = IPMI_MSG_CMD_GET_DEVICE_ID;
+    uint8_t netfn = IPMI_MSG_NETFN_APP_REQUEST;
 
-	memcpy( imsg2, BASIC_MSG, imsg2Size );
-	imsg2[IPMI_MSG2_CMD_OFFSET] = cmd;
+    memcpy(imsg2, BASIC_MSG, imsg2Size);
+    imsg2[IPMI_MSG2_CMD_OFFSET] = cmd;
 
-	if ( bridged ) // may need to distinguish between once and twice-bridged messages
-		ipmiBuildSendMsg( sess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0 );
-	else
-		messageSize = ipmiMsgBuild( sess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0 );
+    if (bridged) { // may need to distinguish between once and twice-bridged messages
+        ipmiBuildSendMsg(sess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0);
+    } else {
+        messageSize = ipmiMsgBuild(sess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0);
+    }
 
-	return sess->wrf( device, sess, message, messageSize, data, responseSize, cmd, netfn, roffs, 0 );
+    return sess->wrf(device, sess, message, messageSize, data, responseSize, cmd, netfn, roffs, 0);
 }
 /* Get device, sess ID
  *
@@ -1153,25 +1141,25 @@ uint8_t  netfn = IPMI_MSG_NETFN_APP_REQUEST;
  *            0 on success
  *            non-zero for error
  */
-int
-ipmiMsgBroadcastGetDeviceId(void *device, IpmiSess sess, uint8_t *data, int bridged, uint8_t rsAddr, uint8_t rqAddr, size_t *responseSize, int roffs)
-{
-uint8_t  message[MSG_MAX_LENGTH] = { 0 };
-uint8_t  imsg2Size = sizeof( BASIC_MSG );
-uint8_t  imsg2[imsg2Size];
-size_t   messageSize;
-uint8_t  cmd   = IPMI_MSG_CMD_GET_DEVICE_ID;
-uint8_t  netfn = IPMI_MSG_NETFN_APP_REQUEST;
+int ipmiMsgBroadcastGetDeviceId(void* device, IpmiSess sess, uint8_t* data, int bridged, uint8_t rsAddr, uint8_t rqAddr,
+                                size_t* responseSize, int roffs) {
+    uint8_t message[MSG_MAX_LENGTH] = {0};
+    uint8_t imsg2Size               = sizeof(BASIC_MSG);
+    uint8_t imsg2[imsg2Size];
+    size_t  messageSize;
+    uint8_t cmd   = IPMI_MSG_CMD_GET_DEVICE_ID;
+    uint8_t netfn = IPMI_MSG_NETFN_APP_REQUEST;
 
-        memcpy( imsg2, BASIC_MSG, imsg2Size );
-        imsg2[IPMI_MSG2_CMD_OFFSET] = cmd;
-   
-        if ( bridged ) // may need to distinguish between once and twice-bridged messages
-                ipmiBuildSendMsg( sess, message+1, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0 );
-        else
-                messageSize = ipmiMsgBuild( sess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0 );
+    memcpy(imsg2, BASIC_MSG, imsg2Size);
+    imsg2[IPMI_MSG2_CMD_OFFSET] = cmd;
 
-        return sess->wrf( device, sess, message, messageSize, data, responseSize, cmd, netfn, roffs, 0 );
+    if (bridged) { // may need to distinguish between once and twice-bridged messages
+        ipmiBuildSendMsg(sess, message + 1, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0);
+    } else {
+        messageSize = ipmiMsgBuild(sess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0);
+    }
+
+    return sess->wrf(device, sess, message, messageSize, data, responseSize, cmd, netfn, roffs, 0);
 }
 
 /* Name this PICMG? */
@@ -1182,33 +1170,32 @@ uint8_t  netfn = IPMI_MSG_NETFN_APP_REQUEST;
  *            0 on success
  *            non-zero for error
  */
-int
-ipmiMsgGetAddressInfoIpmb0(void *device, IpmiSess sess, uint8_t *data, int bridged, uint8_t rsAddr, uint8_t rqAddr, size_t *responseSize, int roffs, 
-			     uint8_t fru, uint8_t key)
-{
-uint8_t  message[MSG_MAX_LENGTH] = { 0 };
-uint8_t  imsg2Size = sizeof( GET_ADDR_INFO_MSG );
-uint8_t  imsg2[imsg2Size];
-size_t   messageSize;
-uint8_t  cmd   = IPMI_MSG_CMD_GET_ADDR_INFO;
-uint8_t  netfn = IPMI_MSG_NETFN_PICMG;
+int ipmiMsgGetAddressInfoIpmb0(void* device, IpmiSess sess, uint8_t* data, int bridged, uint8_t rsAddr, uint8_t rqAddr,
+                               size_t* responseSize, int roffs, uint8_t fru, uint8_t key) {
+    uint8_t message[MSG_MAX_LENGTH] = {0};
+    uint8_t imsg2Size               = sizeof(GET_ADDR_INFO_MSG);
+    uint8_t imsg2[imsg2Size];
+    size_t  messageSize;
+    uint8_t cmd   = IPMI_MSG_CMD_GET_ADDR_INFO;
+    uint8_t netfn = IPMI_MSG_NETFN_PICMG;
 
-	memcpy( imsg2, GET_ADDR_INFO_MSG, imsg2Size );
-	imsg2[IPMI_MSG2_RQADDR_OFFSET] = IPMI_MSG_ADDR_SW;
-	imsg2[IPMI_MSG2_CMD_OFFSET]    = cmd;
+    memcpy(imsg2, GET_ADDR_INFO_MSG, imsg2Size);
+    imsg2[IPMI_MSG2_RQADDR_OFFSET] = IPMI_MSG_ADDR_SW;
+    imsg2[IPMI_MSG2_CMD_OFFSET]    = cmd;
 
-	imsg2[PICMG_IMSG2_GET_ADDR_INFO_FRUID_OFFSET]     = fru;
-	imsg2[PICMG_IMSG2_GET_ADDR_INFO_KEY_TYPE_OFFSET]  = PICMG_ADDR_KEY_TYPE_IPMB0;
-	imsg2[PICMG_IMSG2_GET_ADDR_INFO_KEY_OFFSET]       = key;
-// if using different routines for different types of get hw address requests, may not need to pass these
-// values as arguments; can be hard-coded in routine
+    imsg2[PICMG_IMSG2_GET_ADDR_INFO_FRUID_OFFSET]    = fru;
+    imsg2[PICMG_IMSG2_GET_ADDR_INFO_KEY_TYPE_OFFSET] = PICMG_ADDR_KEY_TYPE_IPMB0;
+    imsg2[PICMG_IMSG2_GET_ADDR_INFO_KEY_OFFSET]      = key;
+    // if using different routines for different types of get hw address requests, may not need to pass these
+    // values as arguments; can be hard-coded in routine
 
-	if ( bridged ) // may need to distinguish between once and twice-bridged messages
-		ipmiBuildSendMsg( sess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0 );
-	else
-		messageSize = ipmiMsgBuild( sess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0 );
+    if (bridged) { // may need to distinguish between once and twice-bridged messages
+        ipmiBuildSendMsg(sess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0);
+    } else {
+        messageSize = ipmiMsgBuild(sess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0);
+    }
 
-	return sess->wrf( device, sess, message, messageSize, data, responseSize, cmd, netfn, roffs, 0 );
+    return sess->wrf(device, sess, message, messageSize, data, responseSize, cmd, netfn, roffs, 0);
 }
 
 /* Name this PICMG? */
@@ -1219,34 +1206,34 @@ uint8_t  netfn = IPMI_MSG_NETFN_PICMG;
  *            0 on success
  *            non-zero for error
  */
-int
-ipmiMsgGetAddressInfoHwAddr(void *device, IpmiSess sess, uint8_t *data, int bridged, uint8_t rsAddr, uint8_t rqAddr, size_t *responseSize, int roffs, 
-			     uint8_t fru, uint8_t keytype, uint8_t key, uint8_t sitetype)
-{
-uint8_t  message[MSG_MAX_LENGTH] = { 0 };
-uint8_t  imsg2Size = sizeof( GET_ADDR_INFO_MSG );
-uint8_t  imsg2[imsg2Size];
-size_t   messageSize;
-uint8_t  cmd   = IPMI_MSG_CMD_GET_ADDR_INFO;
-uint8_t  netfn = IPMI_MSG_NETFN_PICMG;
+int ipmiMsgGetAddressInfoHwAddr(void* device, IpmiSess sess, uint8_t* data, int bridged, uint8_t rsAddr, uint8_t rqAddr,
+                                size_t* responseSize, int roffs, uint8_t fru, uint8_t keytype, uint8_t key,
+                                uint8_t sitetype) {
+    uint8_t message[MSG_MAX_LENGTH] = {0};
+    uint8_t imsg2Size               = sizeof(GET_ADDR_INFO_MSG);
+    uint8_t imsg2[imsg2Size];
+    size_t  messageSize;
+    uint8_t cmd   = IPMI_MSG_CMD_GET_ADDR_INFO;
+    uint8_t netfn = IPMI_MSG_NETFN_PICMG;
 
-	memcpy( imsg2, GET_ADDR_INFO_MSG, imsg2Size );
-	imsg2[IPMI_MSG2_RQADDR_OFFSET] = IPMI_MSG_ADDR_SW;
-	imsg2[IPMI_MSG2_CMD_OFFSET]    = cmd;
+    memcpy(imsg2, GET_ADDR_INFO_MSG, imsg2Size);
+    imsg2[IPMI_MSG2_RQADDR_OFFSET] = IPMI_MSG_ADDR_SW;
+    imsg2[IPMI_MSG2_CMD_OFFSET]    = cmd;
 
-	imsg2[PICMG_IMSG2_GET_ADDR_INFO_FRUID_OFFSET]     = fru;
-	imsg2[PICMG_IMSG2_GET_ADDR_INFO_KEY_TYPE_OFFSET]  = keytype;
-	imsg2[PICMG_IMSG2_GET_ADDR_INFO_KEY_OFFSET]       = key;
-	imsg2[PICMG_IMSG2_GET_ADDR_INFO_SITE_TYPE_OFFSET] = sitetype;
-// if using different routines for different types of get hw address requests, may not need to pass these
-// values as arguments; can be hard-coded in routine
+    imsg2[PICMG_IMSG2_GET_ADDR_INFO_FRUID_OFFSET]     = fru;
+    imsg2[PICMG_IMSG2_GET_ADDR_INFO_KEY_TYPE_OFFSET]  = keytype;
+    imsg2[PICMG_IMSG2_GET_ADDR_INFO_KEY_OFFSET]       = key;
+    imsg2[PICMG_IMSG2_GET_ADDR_INFO_SITE_TYPE_OFFSET] = sitetype;
+    // if using different routines for different types of get hw address requests, may not need to pass these
+    // values as arguments; can be hard-coded in routine
 
-	if ( bridged ) // may need to distinguish between once and twice-bridged messages
-		ipmiBuildSendMsg( sess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0 );
-	else
-		messageSize = ipmiMsgBuild( sess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0 );
+    if (bridged) { // may need to distinguish between once and twice-bridged messages
+        ipmiBuildSendMsg(sess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0);
+    } else {
+        messageSize = ipmiMsgBuild(sess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0);
+    }
 
-	return sess->wrf( device, sess, message, messageSize, data, responseSize, cmd, netfn, roffs, 0 );
+    return sess->wrf(device, sess, message, messageSize, data, responseSize, cmd, netfn, roffs, 0);
 }
 
 /* Name this PICMG? */
@@ -1257,26 +1244,26 @@ uint8_t  netfn = IPMI_MSG_NETFN_PICMG;
  *            0 on success
  *            non-zero for error
  */
-int
-ipmiMsgGetAddressInfoIpmc(void *device, IpmiSess sess, uint8_t *data, int bridged, uint8_t rsAddr, uint8_t rqAddr, size_t *responseSize, int roffs)
-{
-uint8_t  message[MSG_MAX_LENGTH] = { 0 };
-uint8_t  imsg2Size = sizeof( GET_PICMG_PROP_MSG );
-uint8_t  imsg2[imsg2Size];
-size_t   messageSize;
-uint8_t  cmd   = IPMI_MSG_CMD_GET_ADDR_INFO;
-uint8_t  netfn = IPMI_MSG_NETFN_PICMG;
+int ipmiMsgGetAddressInfoIpmc(void* device, IpmiSess sess, uint8_t* data, int bridged, uint8_t rsAddr, uint8_t rqAddr,
+                              size_t* responseSize, int roffs) {
+    uint8_t message[MSG_MAX_LENGTH] = {0};
+    uint8_t imsg2Size               = sizeof(GET_PICMG_PROP_MSG);
+    uint8_t imsg2[imsg2Size];
+    size_t  messageSize;
+    uint8_t cmd   = IPMI_MSG_CMD_GET_ADDR_INFO;
+    uint8_t netfn = IPMI_MSG_NETFN_PICMG;
 
-	memcpy( imsg2, GET_PICMG_PROP_MSG, imsg2Size );
-	imsg2[IPMI_MSG2_RQADDR_OFFSET] = IPMI_MSG_ADDR_SW;
-	imsg2[IPMI_MSG2_CMD_OFFSET]    = cmd;
+    memcpy(imsg2, GET_PICMG_PROP_MSG, imsg2Size);
+    imsg2[IPMI_MSG2_RQADDR_OFFSET] = IPMI_MSG_ADDR_SW;
+    imsg2[IPMI_MSG2_CMD_OFFSET]    = cmd;
 
-	if ( bridged ) // may need to distinguish between once and twice-bridged messages
-		ipmiBuildSendMsg( sess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0 );
-	else
-		messageSize = ipmiMsgBuild( sess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0 );
+    if (bridged) { // may need to distinguish between once and twice-bridged messages
+        ipmiBuildSendMsg(sess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0);
+    } else {
+        messageSize = ipmiMsgBuild(sess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0);
+    }
 
-	return sess->wrf( device, sess, message, messageSize, data, responseSize, cmd, netfn, roffs, 0 );
+    return sess->wrf(device, sess, message, messageSize, data, responseSize, cmd, netfn, roffs, 0);
 }
 
 /* Get PICMG properties
@@ -1285,26 +1272,26 @@ uint8_t  netfn = IPMI_MSG_NETFN_PICMG;
  *            0 on success
  *            non-zero for error
  */
-int
-ipmiMsgGetPicmgProp(void *device, IpmiSess sess, uint8_t *data, int bridged, uint8_t rsAddr, uint8_t rqAddr, size_t *responseSize, int roffs)
-{
-uint8_t  message[MSG_MAX_LENGTH] = { 0 };
-uint8_t  imsg2Size = sizeof( GET_PICMG_PROP_MSG );
-uint8_t  imsg2[imsg2Size];
-size_t   messageSize;
-uint8_t  cmd   = IPMI_MSG_CMD_GET_PICMG_PROP;
-uint8_t  netfn = IPMI_MSG_NETFN_PICMG;
+int ipmiMsgGetPicmgProp(void* device, IpmiSess sess, uint8_t* data, int bridged, uint8_t rsAddr, uint8_t rqAddr,
+                        size_t* responseSize, int roffs) {
+    uint8_t message[MSG_MAX_LENGTH] = {0};
+    uint8_t imsg2Size               = sizeof(GET_PICMG_PROP_MSG);
+    uint8_t imsg2[imsg2Size];
+    size_t  messageSize;
+    uint8_t cmd   = IPMI_MSG_CMD_GET_PICMG_PROP;
+    uint8_t netfn = IPMI_MSG_NETFN_PICMG;
 
-	memcpy( imsg2, GET_PICMG_PROP_MSG, imsg2Size );
-	imsg2[IPMI_MSG2_RQADDR_OFFSET] = IPMI_MSG_ADDR_SW;
-	imsg2[IPMI_MSG2_CMD_OFFSET]    = cmd;
+    memcpy(imsg2, GET_PICMG_PROP_MSG, imsg2Size);
+    imsg2[IPMI_MSG2_RQADDR_OFFSET] = IPMI_MSG_ADDR_SW;
+    imsg2[IPMI_MSG2_CMD_OFFSET]    = cmd;
 
-	if ( bridged ) // may need to distinguish between once and twice-bridged messages
-		ipmiBuildSendMsg( sess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0 );
-	else
-		messageSize = ipmiMsgBuild( sess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0 );
+    if (bridged) { // may need to distinguish between once and twice-bridged messages
+        ipmiBuildSendMsg(sess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0);
+    } else {
+        messageSize = ipmiMsgBuild(sess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0);
+    }
 
-	return sess->wrf( device, sess, message, messageSize, data, responseSize, cmd, netfn, roffs, 0 );
+    return sess->wrf(device, sess, message, messageSize, data, responseSize, cmd, netfn, roffs, 0);
 }
 
 /* Get power level - PICMG command
@@ -1313,28 +1300,28 @@ uint8_t  netfn = IPMI_MSG_NETFN_PICMG;
  *            0 on success
  *            non-zero for error
  */
-int
-ipmiMsgGetPowerLevel(void *device, IpmiSess sess, uint8_t *data, int bridged, uint8_t rsAddr, uint8_t rqAddr, size_t *responseSize, int roffs, uint8_t fruId, uint8_t parm )
-{
-uint8_t  message[MSG_MAX_LENGTH] = { 0 };
-uint8_t  imsg2Size = sizeof( GET_POWER_LEVEL_MSG );
-uint8_t  imsg2[imsg2Size];
-size_t   messageSize;
-uint8_t  cmd   = IPMI_MSG_CMD_GET_POWER_LEVEL;
-uint8_t  netfn = IPMI_MSG_NETFN_PICMG;
+int ipmiMsgGetPowerLevel(void* device, IpmiSess sess, uint8_t* data, int bridged, uint8_t rsAddr, uint8_t rqAddr,
+                         size_t* responseSize, int roffs, uint8_t fruId, uint8_t parm) {
+    uint8_t message[MSG_MAX_LENGTH] = {0};
+    uint8_t imsg2Size               = sizeof(GET_POWER_LEVEL_MSG);
+    uint8_t imsg2[imsg2Size];
+    size_t  messageSize;
+    uint8_t cmd   = IPMI_MSG_CMD_GET_POWER_LEVEL;
+    uint8_t netfn = IPMI_MSG_NETFN_PICMG;
 
-	memcpy( imsg2, GET_POWER_LEVEL_MSG, imsg2Size );
-	imsg2[IPMI_MSG2_RQADDR_OFFSET] = IPMI_MSG_ADDR_SW;
-	imsg2[IPMI_MSG2_CMD_OFFSET]    = cmd;
-	imsg2[IPMI_MSG2_SET_FRU_ACT_FRU_OFFSET] = fruId;
-	imsg2[PICMG_RPLY_IMSG2_GET_POWER_LEVEL_TYPE_OFFSET] = parm;
+    memcpy(imsg2, GET_POWER_LEVEL_MSG, imsg2Size);
+    imsg2[IPMI_MSG2_RQADDR_OFFSET]                      = IPMI_MSG_ADDR_SW;
+    imsg2[IPMI_MSG2_CMD_OFFSET]                         = cmd;
+    imsg2[IPMI_MSG2_SET_FRU_ACT_FRU_OFFSET]             = fruId;
+    imsg2[PICMG_RPLY_IMSG2_GET_POWER_LEVEL_TYPE_OFFSET] = parm;
 
-	if ( bridged ) // may need to distinguish between once and twice-bridged messages
-		ipmiBuildSendMsg( sess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0 );
-	else
-		messageSize = ipmiMsgBuild( sess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0 );
+    if (bridged) { // may need to distinguish between once and twice-bridged messages
+        ipmiBuildSendMsg(sess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0);
+    } else {
+        messageSize = ipmiMsgBuild(sess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0);
+    }
 
-	return sess->wrf( device, sess, message, messageSize, data, responseSize, cmd, netfn, roffs, 0 );
+    return sess->wrf(device, sess, message, messageSize, data, responseSize, cmd, netfn, roffs, 0);
 }
 
 /* Get fan level - PICMG command
@@ -1344,27 +1331,27 @@ uint8_t  netfn = IPMI_MSG_NETFN_PICMG;
  *            non-zero for error
  */
 
-int
-ipmiMsgGetFanLevel(void *device, IpmiSess sess, uint8_t *data, int bridged, uint8_t rsAddr, uint8_t rqAddr, size_t *responseSize, int roffs, uint8_t fruId)
-{
-uint8_t  message[MSG_MAX_LENGTH] = { 0 };
-uint8_t  imsg2Size = sizeof( GET_FAN_LEVEL_MSG );
-uint8_t  imsg2[imsg2Size];
-size_t   messageSize;
-uint8_t  cmd   = IPMI_MSG_CMD_GET_FAN_LEVEL;
-uint8_t  netfn = IPMI_MSG_NETFN_PICMG;
+int ipmiMsgGetFanLevel(void* device, IpmiSess sess, uint8_t* data, int bridged, uint8_t rsAddr, uint8_t rqAddr,
+                       size_t* responseSize, int roffs, uint8_t fruId) {
+    uint8_t message[MSG_MAX_LENGTH] = {0};
+    uint8_t imsg2Size               = sizeof(GET_FAN_LEVEL_MSG);
+    uint8_t imsg2[imsg2Size];
+    size_t  messageSize;
+    uint8_t cmd   = IPMI_MSG_CMD_GET_FAN_LEVEL;
+    uint8_t netfn = IPMI_MSG_NETFN_PICMG;
 
-	memcpy( imsg2, GET_FAN_LEVEL_MSG, imsg2Size );
-	imsg2[IPMI_MSG2_RQADDR_OFFSET] = IPMI_MSG_ADDR_SW;
-	imsg2[IPMI_MSG2_CMD_OFFSET]    = cmd;
-	imsg2[IPMI_MSG2_SET_FRU_ACT_FRU_OFFSET] = fruId;
+    memcpy(imsg2, GET_FAN_LEVEL_MSG, imsg2Size);
+    imsg2[IPMI_MSG2_RQADDR_OFFSET]          = IPMI_MSG_ADDR_SW;
+    imsg2[IPMI_MSG2_CMD_OFFSET]             = cmd;
+    imsg2[IPMI_MSG2_SET_FRU_ACT_FRU_OFFSET] = fruId;
 
-	if ( bridged ) // may need to distinguish between once and twice-bridged messages
-		ipmiBuildSendMsg( sess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0 );
-	else
-		messageSize = ipmiMsgBuild( sess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0 );
+    if (bridged) { // may need to distinguish between once and twice-bridged messages
+        ipmiBuildSendMsg(sess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0);
+    } else {
+        messageSize = ipmiMsgBuild(sess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0);
+    }
 
-	return sess->wrf( device, sess, message, messageSize, data, responseSize, cmd, netfn, roffs, 0 );
+    return sess->wrf(device, sess, message, messageSize, data, responseSize, cmd, netfn, roffs, 0);
 }
 
 /* Set fan level - PICMG command
@@ -1374,28 +1361,28 @@ uint8_t  netfn = IPMI_MSG_NETFN_PICMG;
  *            non-zero for error
  */
 
-int
-ipmiMsgSetFanLevel(void *device, IpmiSess sess, uint8_t *data, int bridged, uint8_t rsAddr, uint8_t rqAddr, size_t *responseSize, int roffs, uint8_t fruId, uint8_t level)
-{
-uint8_t  message[MSG_MAX_LENGTH] = { 0 };
-uint8_t  imsg2Size = sizeof( GET_FAN_LEVEL_MSG );
-uint8_t  imsg2[imsg2Size];
-size_t   messageSize;
-uint8_t  cmd   = IPMI_MSG_CMD_GET_FAN_LEVEL;
-uint8_t  netfn = IPMI_MSG_NETFN_PICMG;
+int ipmiMsgSetFanLevel(void* device, IpmiSess sess, uint8_t* data, int bridged, uint8_t rsAddr, uint8_t rqAddr,
+                       size_t* responseSize, int roffs, uint8_t fruId, uint8_t level) {
+    uint8_t message[MSG_MAX_LENGTH] = {0};
+    uint8_t imsg2Size               = sizeof(GET_FAN_LEVEL_MSG);
+    uint8_t imsg2[imsg2Size];
+    size_t  messageSize;
+    uint8_t cmd   = IPMI_MSG_CMD_GET_FAN_LEVEL;
+    uint8_t netfn = IPMI_MSG_NETFN_PICMG;
 
-	memcpy( imsg2, GET_FAN_LEVEL_MSG, imsg2Size );
-	imsg2[IPMI_MSG2_RQADDR_OFFSET] = IPMI_MSG_ADDR_SW;
-	imsg2[IPMI_MSG2_CMD_OFFSET]    = cmd;
-	imsg2[IPMI_MSG2_SET_FRU_ACT_FRU_OFFSET] = fruId;
-	imsg2[IPMI_MSG2_SET_FAN_LEVEL_OFFSET] = level;
+    memcpy(imsg2, GET_FAN_LEVEL_MSG, imsg2Size);
+    imsg2[IPMI_MSG2_RQADDR_OFFSET]          = IPMI_MSG_ADDR_SW;
+    imsg2[IPMI_MSG2_CMD_OFFSET]             = cmd;
+    imsg2[IPMI_MSG2_SET_FRU_ACT_FRU_OFFSET] = fruId;
+    imsg2[IPMI_MSG2_SET_FAN_LEVEL_OFFSET]   = level;
 
-	if ( bridged ) // may need to distinguish between once and twice-bridged messages
-		ipmiBuildSendMsg( sess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0 );
-	else
-		messageSize = ipmiMsgBuild( sess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0 );
+    if (bridged) { // may need to distinguish between once and twice-bridged messages
+        ipmiBuildSendMsg(sess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0);
+    } else {
+        messageSize = ipmiMsgBuild(sess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0);
+    }
 
-	return sess->wrf( device, sess, message, messageSize, data, responseSize, cmd, netfn, roffs, 0 );
+    return sess->wrf(device, sess, message, messageSize, data, responseSize, cmd, netfn, roffs, 0);
 }
 
 /* Set FRU Activation - PICMG command
@@ -1405,29 +1392,29 @@ uint8_t  netfn = IPMI_MSG_NETFN_PICMG;
  *            non-zero for error
  */
 
-int
-ipmiMsgSetFruAct(void *device, IpmiSess sess, uint8_t *data, int bridged, uint8_t rsAddr, uint8_t rqAddr, size_t *responseSize, int roffs, uint8_t fruId, int parm)
-{
-uint8_t  message[MSG_MAX_LENGTH] = { 0 };
-uint8_t  imsg2Size = sizeof( SET_FRU_ACT_MSG );
-uint8_t  imsg2[imsg2Size];
-size_t   messageSize;
-uint8_t  cmd   = IPMI_MSG_CMD_SET_FRU_ACT;
-uint8_t  netfn = IPMI_MSG_NETFN_PICMG;
+int ipmiMsgSetFruAct(void* device, IpmiSess sess, uint8_t* data, int bridged, uint8_t rsAddr, uint8_t rqAddr,
+                     size_t* responseSize, int roffs, uint8_t fruId, int parm) {
+    uint8_t message[MSG_MAX_LENGTH] = {0};
+    uint8_t imsg2Size               = sizeof(SET_FRU_ACT_MSG);
+    uint8_t imsg2[imsg2Size];
+    size_t  messageSize;
+    uint8_t cmd   = IPMI_MSG_CMD_SET_FRU_ACT;
+    uint8_t netfn = IPMI_MSG_NETFN_PICMG;
 
-	memcpy( imsg2, GET_FAN_LEVEL_MSG, imsg2Size );
-	imsg2[IPMI_MSG2_RQADDR_OFFSET] = IPMI_MSG_ADDR_SW;
-	imsg2[IPMI_MSG2_CMD_OFFSET]    = cmd;
-	imsg2[IPMI_MSG2_SET_FRU_ACT_FRU_OFFSET] = fruId;
-	imsg2[IPMI_MSG2_SET_FRU_ACT_CMD_OFFSET] = parm;
+    memcpy(imsg2, GET_FAN_LEVEL_MSG, imsg2Size);
+    imsg2[IPMI_MSG2_RQADDR_OFFSET]          = IPMI_MSG_ADDR_SW;
+    imsg2[IPMI_MSG2_CMD_OFFSET]             = cmd;
+    imsg2[IPMI_MSG2_SET_FRU_ACT_FRU_OFFSET] = fruId;
+    imsg2[IPMI_MSG2_SET_FRU_ACT_CMD_OFFSET] = parm;
 
-printf("*************ipmi set fru act parm %i\n", parm);
-	if ( bridged ) // may need to distinguish between once and twice-bridged messages
-		ipmiBuildSendMsg( sess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0 );
-	else
-		messageSize = ipmiMsgBuild( sess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0 );
+    printf("*************ipmi set fru act parm %i\n", parm);
+    if (bridged) { // may need to distinguish between once and twice-bridged messages
+        ipmiBuildSendMsg(sess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0);
+    } else {
+        messageSize = ipmiMsgBuild(sess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0);
+    }
 
-	return sess->wrf( device, sess, message, messageSize, data, responseSize, cmd, netfn, roffs, 0 );
+    return sess->wrf(device, sess, message, messageSize, data, responseSize, cmd, netfn, roffs, 0);
 }
 
 /* Get PICMG properties
@@ -1436,47 +1423,46 @@ printf("*************ipmi set fru act parm %i\n", parm);
  *            0 on success
  *            non-zero for error
  */
-int
-ipmiMsgGetFanProp(void *device, IpmiSess sess, uint8_t *data, int bridged, uint8_t rsAddr, uint8_t rqAddr, size_t *responseSize, int roffs, uint8_t fruId)
-{
-uint8_t  message[MSG_MAX_LENGTH] = { 0 };
-uint8_t  imsg2Size = sizeof( GET_FAN_PROP_MSG );
-uint8_t  imsg2[imsg2Size];
-size_t   messageSize;
-uint8_t  cmd   = IPMI_MSG_CMD_GET_FAN_PROP;
-uint8_t  netfn = IPMI_MSG_NETFN_PICMG;
+int ipmiMsgGetFanProp(void* device, IpmiSess sess, uint8_t* data, int bridged, uint8_t rsAddr, uint8_t rqAddr,
+                      size_t* responseSize, int roffs, uint8_t fruId) {
+    uint8_t message[MSG_MAX_LENGTH] = {0};
+    uint8_t imsg2Size               = sizeof(GET_FAN_PROP_MSG);
+    uint8_t imsg2[imsg2Size];
+    size_t  messageSize;
+    uint8_t cmd   = IPMI_MSG_CMD_GET_FAN_PROP;
+    uint8_t netfn = IPMI_MSG_NETFN_PICMG;
 
-	memcpy( imsg2, GET_FAN_PROP_MSG, imsg2Size );
-	imsg2[IPMI_MSG2_RQADDR_OFFSET] = IPMI_MSG_ADDR_SW;
-	imsg2[IPMI_MSG2_CMD_OFFSET]    = cmd;
-	imsg2[IPMI_MSG2_SET_FRU_ACT_FRU_OFFSET] = fruId;
+    memcpy(imsg2, GET_FAN_PROP_MSG, imsg2Size);
+    imsg2[IPMI_MSG2_RQADDR_OFFSET]          = IPMI_MSG_ADDR_SW;
+    imsg2[IPMI_MSG2_CMD_OFFSET]             = cmd;
+    imsg2[IPMI_MSG2_SET_FRU_ACT_FRU_OFFSET] = fruId;
 
-	if ( bridged ) // may need to distinguish between once and twice-bridged messages
-		ipmiBuildSendMsg( sess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0 );
-	else
-		messageSize = ipmiMsgBuild( sess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0 );
+    if (bridged) { // may need to distinguish between once and twice-bridged messages
+        ipmiBuildSendMsg(sess, message, &messageSize, cmd, netfn, rsAddr, rqAddr, imsg2, imsg2Size, 0);
+    } else {
+        messageSize = ipmiMsgBuild(sess, message, cmd, netfn, imsg2, imsg2Size, 0, 0, 0, 0, 0, 0);
+    }
 
-	return sess->wrf( device, sess, message, messageSize, data, responseSize, cmd, netfn, roffs, 0 );
+    return sess->wrf(device, sess, message, messageSize, data, responseSize, cmd, netfn, roffs, 0);
 }
-	
 
-void
-ipmiBuildSendMsg(IpmiSess sess, uint8_t *message, size_t *messageSize, uint8_t cmd, uint8_t netfn, uint8_t rsAddr, uint8_t rqAddr, uint8_t *msg2, size_t msg2Size, uint8_t lun)
-{
-size_t   imsg2Size   = sizeof( SEND_MSG_MSG );
-size_t   b1msg1Size   = sizeof( IPMI_MSG1 );
-uint8_t  imsg2[imsg2Size];
-uint8_t  b1msg1[b1msg1Size];
+void ipmiBuildSendMsg(IpmiSess sess, uint8_t* message, size_t* messageSize, uint8_t cmd, uint8_t netfn, uint8_t rsAddr,
+                      uint8_t rqAddr, uint8_t* msg2, size_t msg2Size, uint8_t lun) {
+    size_t  imsg2Size  = sizeof(SEND_MSG_MSG);
+    size_t  b1msg1Size = sizeof(IPMI_MSG1);
+    uint8_t imsg2[imsg2Size];
+    uint8_t b1msg1[b1msg1Size];
 
-	memcpy( imsg2, SEND_MSG_MSG,  imsg2Size  );
-	memcpy( b1msg1, IPMI_MSG1,    b1msg1Size );
+    memcpy(imsg2, SEND_MSG_MSG, imsg2Size);
+    memcpy(b1msg1, IPMI_MSG1, b1msg1Size);
 
-	imsg2[IPMI_MSG2_CHAN_OFFSET] = IPMI_MSG_CHAN_IPMB0 + IPMI_MSG_TRACKING;
+    imsg2[IPMI_MSG2_CHAN_OFFSET] = IPMI_MSG_CHAN_IPMB0 + IPMI_MSG_TRACKING;
 
-	b1msg1[IPMI_MSG1_RSADDR_OFFSET]   = rsAddr;
-	b1msg1[IPMI_MSG1_NETFNLUN_OFFSET] = lun | (netfn << 2);
+    b1msg1[IPMI_MSG1_RSADDR_OFFSET]   = rsAddr;
+    b1msg1[IPMI_MSG1_NETFNLUN_OFFSET] = lun | (netfn << 2);
 
-	msg2[IPMI_MSG2_RQADDR_OFFSET] = rqAddr;
-                                                                 
-	*messageSize = ipmiMsgBuild( sess, message, cmd, IPMI_MSG_NETFN_APP_REQUEST, imsg2, imsg2Size, b1msg1, msg2, msg2Size, 0, 0, 0 );
+    msg2[IPMI_MSG2_RQADDR_OFFSET] = rqAddr;
+
+    *messageSize =
+        ipmiMsgBuild(sess, message, cmd, IPMI_MSG_NETFN_APP_REQUEST, imsg2, imsg2Size, b1msg1, msg2, msg2Size, 0, 0, 0);
 }

--- a/src/ipmiMsg.h
+++ b/src/ipmiMsg.h
@@ -1,160 +1,189 @@
 //////////////////////////////////////////////////////////////////////////////
 // This file is part of 'ipmiComm'.
-// It is subject to the license terms in the LICENSE.txt file found in the 
-// top-level directory of this distribution and at: 
-//    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
-// No part of 'ipmiComm', including this file, 
-// may be copied, modified, propagated, or distributed except according to 
+// It is subject to the license terms in the LICENSE.txt file found in the
+// top-level directory of this distribution and at:
+//    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+// No part of 'ipmiComm', including this file,
+// may be copied, modified, propagated, or distributed except according to
 // the terms contained in the LICENSE.txt file.
 //////////////////////////////////////////////////////////////////////////////
 #ifndef DRV_IPMI_MSG_H
 #define DRV_IPMI_MSG_H
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 #include <drvMch.h>
 
-/* Convert 2-element array (which stores LS byte first) to integer */
-uint16_t arrayToUint16(uint8_t *data );
+    /* Convert 2-element array (which stores LS byte first) to integer */
+    uint16_t arrayToUint16(uint8_t* data);
 
-/* Convert 4-element array (which stores LS byte first) to integer */
-uint32_t arrayToUint32(uint8_t *data);
+    /* Convert 4-element array (which stores LS byte first) to integer */
+    uint32_t arrayToUint32(uint8_t* data);
 
-/* Increment value of 2-element uint8_t array (which stores LS byte first)
- * Roll over to 0 when max possible value is reached.
- */
-void incr2Uint8Array(uint8_t *data, int incr); 
+    /* Increment value of 2-element uint8_t array (which stores LS byte first)
+     * Roll over to 0 when max possible value is reached.
+     */
+    void incr2Uint8Array(uint8_t* data, int incr);
 
-/* Increment value of 4-element uint8_t array (which stores LS byte first)
- * Roll over to 0 when max possible value is reached.
- */
+    /* Increment value of 4-element uint8_t array (which stores LS byte first)
+     * Roll over to 0 when max possible value is reached.
+     */
 
-void  incr4Uint8Array(uint8_t *data, int incr); 
+    void incr4Uint8Array(uint8_t* data, int incr);
 
-/*
- * To-MCH IPMI message structure:
- *
- * {RMCP header}{IPMI header}{IPMI msg 1(cs)}{IPMI msg 2 [Bridged msg part1(cs)][Bridged msg part2 [Bridged msg part1(cs)][Bridged msg part2(cs)](checksum)] (checksum)}      		 
- *                                                        |_______________________________________||____________________________________________|      |	 |		  	 
- *                                                                            |                                          |                             |	 |		  	 
- *                                                            First optional bridged message              Second optional bridged message            cs for	 cs for IPMI msg part2	  	 
- *                                                                                                                                                   optional	     (does not include 	 
- *                                                                                                                                                   first bridged   bridged msgs)
- *                                                                                                                                                   msg part2
- *                                                                                                                                                  (does not         
- *                                                                                                                                                   include second 
- *                                                                                                                                                   bridged msg)
- * RMCP uses MSB first
- * IPMI uses LSB first - (this does not match the standard 'network order') 
- * so all multi-byte values below store LSB first
- *
- * 
- *   RMCP header - fixed for all IPMI messages (RMCP_HEADER below)
- *
- *   IPMI Message Session Header  - fixed length (IPMI_WRAPPER below)
- *
- *   IPMI Message Part 1 - fixed length (IMSG1 below)
- *       rsAddr    (1 byte) - Responder's address (BMC address)
- *       netFn/LUN (1 byte) - Function code 
- *
- *   IPMI Message Part 1 Checksum - 2's complement checksum (1 byte)
- *
- *   IPMI Message Part 2 - variable length depending on msg type (variations below)
- *       rqAddr (1 byte) - Requester's address
- *       rqSeq           - Message sequence number
- *       cmd             - Command code
- *       data (variable) - Depends on message type
- *
- * --- begin first optional "bridged" message - embedded IPMI message to be sent to other channel. Used with IPMI Message cmd = MSG_IPMI_MCD_SEND_MSG
- *
- *        IPMI Bridged Message Part 1 - rsAddr = Bridged channel address
- *   
- *        IPMI Bridged Message Part 1 Checksum - 2's complement checksum (1 byte)
- *  
- *        IPMI Bridged Message Part 2 
- *
- * --- begin second optional "bridged" message - embedded IPMI message to be sent to other channel. Used with IPMI Message cmd = MSG_IPMI_MCD_SEND_MSG
- *
- *        IPMI 2nd Bridged Message Part 1 - rsAddr = Bridged channel address
- *   
- *        IPMI 2nd Bridged Message Part 1 Checksum - 2's complement checksum (1 byte)
- *  
- *        IPMI 2nd Bridged Message Part 2 
- *
- *        IPMI 2nd Bridged Message Part 2 Checksum - 2's complement checksum (1 byte)
- *
- * --- end second optional "bridged" message
- *
- *        IPMI Bridged Message Part 2 Checksum - 2's complement checksum (1 byte)
- *
- * --- end first optional "bridged" message
- *   
- *   IPMI Message Part 2 Checksum - 2's complement checksum (1 byte)
- */
+    // clang-format off
+    /*
+     * To-MCH IPMI message structure:
+     *
+     * {RMCP header}{IPMI header}{IPMI msg 1(cs)}{IPMI msg 2 [Bridged msg part1(cs)][Bridged msg part2 [Bridged msg part1(cs)][Bridged msg part2(cs)](checksum)] (checksum)}
+     *                                                        |_______________________________________||____________________________________________|      |     |
+     *                                                                            |                                          |                             |     |
+     *                                                            First optional bridged message              Second optional bridged message            cs for  cs for IPMI msg part2
+     *                                                                                                                                                   optional            (does not include
+     *                                                                                                                                                   first bridged   bridged msgs)
+     *                                                                                                                                                   msg part2
+     *                                                                                                                                                  (does not
+     *                                                                                                                                                   include second
+     *                                                                                                                                                   bridged msg)
+     * RMCP uses MSB first
+     * IPMI uses LSB first - (this does not match the standard 'network order')
+     * so all multi-byte values below store LSB first
+     *
+     *
+     *   RMCP header - fixed for all IPMI messages (RMCP_HEADER below)
+     *
+     *   IPMI Message Session Header  - fixed length (IPMI_WRAPPER below)
+     *
+     *   IPMI Message Part 1 - fixed length (IMSG1 below)
+     *       rsAddr    (1 byte) - Responder's address (BMC address)
+     *       netFn/LUN (1 byte) - Function code
+     *
+     *   IPMI Message Part 1 Checksum - 2's complement checksum (1 byte)
+     *
+     *   IPMI Message Part 2 - variable length depending on msg type (variations below)
+     *       rqAddr (1 byte) - Requester's address
+     *       rqSeq           - Message sequence number
+     *       cmd             - Command code
+     *       data (variable) - Depends on message type
+     *
+     * --- begin first optional "bridged" message - embedded IPMI message to be sent to other channel. Used with IPMI Message cmd = MSG_IPMI_MCD_SEND_MSG
+     *
+     *        IPMI Bridged Message Part 1 - rsAddr = Bridged channel address
+     *
+     *        IPMI Bridged Message Part 1 Checksum - 2's complement checksum (1 byte)
+     *
+     *        IPMI Bridged Message Part 2
+     *
+     * --- begin second optional "bridged" message - embedded IPMI message to be sent to other channel. Used with IPMI Message cmd = MSG_IPMI_MCD_SEND_MSG
+     *
+     *        IPMI 2nd Bridged Message Part 1 - rsAddr = Bridged channel address
+     *
+     *        IPMI 2nd Bridged Message Part 1 Checksum - 2's complement checksum (1 byte)
+     *
+     *        IPMI 2nd Bridged Message Part 2
+     *
+     *        IPMI 2nd Bridged Message Part 2 Checksum - 2's complement checksum (1 byte)
+     *
+     * --- end second optional "bridged" message
+     *
+     *        IPMI Bridged Message Part 2 Checksum - 2's complement checksum (1 byte)
+     *
+     * --- end first optional "bridged" message
+     *
+     *   IPMI Message Part 2 Checksum - 2's complement checksum (1 byte)
+     */
+    // clang-format on
 
-/* IMPORTANT: For all routines below, caller must perform locking */
+    /* IMPORTANT: For all routines below, caller must perform locking */
 
-void ipmiBuildSendMsg(IpmiSess sess, uint8_t *message, size_t *messageSize, uint8_t cmd, uint8_t netfn, uint8_t rsAddr, uint8_t rqAddr, uint8_t *msg2, size_t msg2Size, uint8_t lun);
+    void ipmiBuildSendMsg(IpmiSess sess, uint8_t* message, size_t* messageSize, uint8_t cmd, uint8_t netfn,
+                          uint8_t rsAddr, uint8_t rqAddr, uint8_t* msg2, size_t msg2Size, uint8_t lun);
 
-void ipmiCompletionCode(const char *name, uint8_t code, uint8_t cmd, uint8_t netfn);
+    void ipmiCompletionCode(const char* name, uint8_t code, uint8_t cmd, uint8_t netfn);
 
-int ipmiMsgBuild(IpmiSess sess, uint8_t *message, uint8_t cmd, uint8_t imsg1netfn, uint8_t *imsg2, size_t imsg2Size, uint8_t *b1msg1, uint8_t *b1msg2, size_t b1msg2Size, uint8_t *b2msg1, uint8_t *b2msg2, size_t b2msg2Size);
+    int ipmiMsgBuild(IpmiSess sess, uint8_t* message, uint8_t cmd, uint8_t imsg1netfn, uint8_t* imsg2, size_t imsg2Size,
+                     uint8_t* b1msg1, uint8_t* b1msg2, size_t b1msg2Size, uint8_t* b2msg1, uint8_t* b2msg2,
+                     size_t b2msg2Size);
 
-int ipmiMsgWriteRead(const char *name, uint8_t *message, size_t messageSize, uint8_t *response, size_t *responseSize, double timeout, size_t *responseLen);
+    int ipmiMsgWriteRead(const char* name, uint8_t* message, size_t messageSize, uint8_t* response,
+                         size_t* responseSize, double timeout, size_t* responseLen);
 
-int ipmiMsgBroadcastGetDeviceId(void *device, IpmiSess sess, uint8_t *data, int bridged, uint8_t rsAddr, uint8_t rqAddr, size_t *responseSize, int offs);
+    int ipmiMsgBroadcastGetDeviceId(void* device, IpmiSess sess, uint8_t* data, int bridged, uint8_t rsAddr,
+                                    uint8_t rqAddr, size_t* responseSize, int offs);
 
-int ipmiMsgGetDeviceId(void *device, IpmiSess sess, uint8_t *data, int bridged, uint8_t rsAddr, uint8_t rqAddr, size_t *responseSize, int offs);
+    int ipmiMsgGetDeviceId(void* device, IpmiSess sess, uint8_t* data, int bridged, uint8_t rsAddr, uint8_t rqAddr,
+                           size_t* responseSize, int offs);
 
-int ipmiMsgGetChanAuth(void *device, IpmiSess sess, uint8_t *data, size_t *responseSize, size_t roffs);
+    int ipmiMsgGetChanAuth(void* device, IpmiSess sess, uint8_t* data, size_t* responseSize, size_t roffs);
 
-int ipmiMsgGetSess(void *device, IpmiSess sess, uint8_t *data, size_t *responseSize, uint8_t *msg, size_t roffs);
+    int ipmiMsgGetSess(void* device, IpmiSess sess, uint8_t* data, size_t* responseSize, uint8_t* msg, size_t roffs);
 
-int ipmiMsgActSess(void *device, IpmiSess sess, uint8_t *data, size_t *responseSize, size_t roffs);
+    int ipmiMsgActSess(void* device, IpmiSess sess, uint8_t* data, size_t* responseSize, size_t roffs);
 
-int ipmiMsgSetPriv(void *device, IpmiSess sess, uint8_t *data, size_t *responseSize, uint8_t level, size_t roffs);
+    int ipmiMsgSetPriv(void* device, IpmiSess sess, uint8_t* data, size_t* responseSize, uint8_t level, size_t roffs);
 
-int ipmiMsgCloseSess(void *device, IpmiSess sess, uint8_t *data, size_t *responseSize);
+    int ipmiMsgCloseSess(void* device, IpmiSess sess, uint8_t* data, size_t* responseSize);
 
-int ipmiMsgColdReset(void *device, IpmiSess sess, uint8_t *data);
+    int ipmiMsgColdReset(void* device, IpmiSess sess, uint8_t* data);
 
-int ipmiMsgChassisControl(void *device, IpmiSess sess,  uint8_t *data, int bridged, uint8_t rsAddr, uint8_t rqAddr, uint8_t parm, size_t *responseSize, int offs);
+    int ipmiMsgChassisControl(void* device, IpmiSess sess, uint8_t* data, int bridged, uint8_t rsAddr, uint8_t rqAddr,
+                              uint8_t parm, size_t* responseSize, int offs);
 
-int ipmiMsgGetChassisStatus(void *device, IpmiSess sess,  uint8_t *data, int bridged, uint8_t rsAddr, uint8_t rqAddr, size_t *responseSize, int roffs);
+    int ipmiMsgGetChassisStatus(void* device, IpmiSess sess, uint8_t* data, int bridged, uint8_t rsAddr, uint8_t rqAddr,
+                                size_t* responseSize, int roffs);
 
-int ipmiMsgGetFruInvInfo(void *device, IpmiSess sess, uint8_t *data, int bridged, uint8_t rsAddr, uint8_t rqAddr, uint8_t id, size_t *responseSize, int offs);
+    int ipmiMsgGetFruInvInfo(void* device, IpmiSess sess, uint8_t* data, int bridged, uint8_t rsAddr, uint8_t rqAddr,
+                             uint8_t id, size_t* responseSize, int offs);
 
-int ipmiMsgReadFru(void *device, IpmiSess sess, uint8_t *data, int bridged, uint8_t rsAddr, uint8_t rqAddr, uint8_t id, uint8_t *readOffset, uint8_t readSize, size_t *responseSize, int offs);
+    int ipmiMsgReadFru(void* device, IpmiSess sess, uint8_t* data, int bridged, uint8_t rsAddr, uint8_t rqAddr,
+                       uint8_t id, uint8_t* readOffset, uint8_t readSize, size_t* responseSize, int offs);
 
-int ipmiMsgGetSdrRepInfo(void *device, IpmiSess sess, uint8_t *data, int bridged, uint8_t rsAddr, uint8_t rqAddr, size_t *responseSize, int offs, uint8_t parm);
+    int ipmiMsgGetSdrRepInfo(void* device, IpmiSess sess, uint8_t* data, int bridged, uint8_t rsAddr, uint8_t rqAddr,
+                             size_t* responseSize, int offs, uint8_t parm);
 
-int ipmiMsgReserveSdrRep(void *device, IpmiSess sess, uint8_t *data, int bridged, uint8_t rsAddr, uint8_t rqAddr, size_t *responseSize, int offs, uint8_t parm);
+    int ipmiMsgReserveSdrRep(void* device, IpmiSess sess, uint8_t* data, int bridged, uint8_t rsAddr, uint8_t rqAddr,
+                             size_t* responseSize, int offs, uint8_t parm);
 
-int ipmiMsgGetSdr(void *device, IpmiSess sess, uint8_t *data, int bridged, uint8_t rsAddr, uint8_t rqAddr,  uint8_t *id, uint8_t *res, uint8_t offset, uint8_t readSize, size_t *responseSize, int offs, uint8_t parm);
-				
-int ipmiMsgReadSensor(void *device, IpmiSess sess, uint8_t *data, uint8_t bridged, uint8_t rsAddr, uint8_t rqAddr, uint8_t sens, uint8_t lun, size_t *responseSize, int offs);
+    int ipmiMsgGetSdr(void* device, IpmiSess sess, uint8_t* data, int bridged, uint8_t rsAddr, uint8_t rqAddr,
+                      uint8_t* id, uint8_t* res, uint8_t offset, uint8_t readSize, size_t* responseSize, int offs,
+                      uint8_t parm);
 
-int ipmiMsgGetSensorThresholds(void *device, IpmiSess sess, uint8_t *data, uint8_t bridged, uint8_t rsAddr, uint8_t rqAddr, uint8_t sens, uint8_t lun, size_t *responseSize, int offs);
+    int ipmiMsgReadSensor(void* device, IpmiSess sess, uint8_t* data, uint8_t bridged, uint8_t rsAddr, uint8_t rqAddr,
+                          uint8_t sens, uint8_t lun, size_t* responseSize, int offs);
 
-int ipmiMsgGetAddressInfoHwAddr(void *device, IpmiSess sess, uint8_t *data, int bridged, uint8_t rsAddr, uint8_t rqAddr, size_t *responseSize, int roffs, uint8_t fru, uint8_t keytpe, uint8_t key, uint8_t sitetype);
+    int ipmiMsgGetSensorThresholds(void* device, IpmiSess sess, uint8_t* data, uint8_t bridged, uint8_t rsAddr,
+                                   uint8_t rqAddr, uint8_t sens, uint8_t lun, size_t* responseSize, int offs);
 
-int ipmiMsgGetAddressInfoIpmb0(void *device, IpmiSess sess, uint8_t *data, int bridged, uint8_t rsAddr, uint8_t rqAddr, size_t *responseSize, int roffs, uint8_t fru, uint8_t key);
+    int ipmiMsgGetAddressInfoHwAddr(void* device, IpmiSess sess, uint8_t* data, int bridged, uint8_t rsAddr,
+                                    uint8_t rqAddr, size_t* responseSize, int roffs, uint8_t fru, uint8_t keytpe,
+                                    uint8_t key, uint8_t sitetype);
 
-int ipmiMsgGetAddressInfoIpmc(void *device, IpmiSess sess, uint8_t *data, int bridged, uint8_t rsAddr, uint8_t rqAddr, size_t *responseSize, int roffs);
+    int ipmiMsgGetAddressInfoIpmb0(void* device, IpmiSess sess, uint8_t* data, int bridged, uint8_t rsAddr,
+                                   uint8_t rqAddr, size_t* responseSize, int roffs, uint8_t fru, uint8_t key);
 
-int ipmiMsgGetFanProp(void *device, IpmiSess sess, uint8_t *data, int bridged, uint8_t rsAddr, uint8_t rqAddr, size_t *responseSize, int roffs, uint8_t fruId);
+    int ipmiMsgGetAddressInfoIpmc(void* device, IpmiSess sess, uint8_t* data, int bridged, uint8_t rsAddr,
+                                  uint8_t rqAddr, size_t* responseSize, int roffs);
 
-int ipmiMsgGetPicmgProp(void *device, IpmiSess sess, uint8_t *data, int bridged, uint8_t rsAddr, uint8_t rqAddr, size_t *responseSize, int roffs);
+    int ipmiMsgGetFanProp(void* device, IpmiSess sess, uint8_t* data, int bridged, uint8_t rsAddr, uint8_t rqAddr,
+                          size_t* responseSize, int roffs, uint8_t fruId);
 
-int ipmiMsgGetPowerLevel(void *device, IpmiSess sess, uint8_t *data, int bridged, uint8_t rsAddr, uint8_t rqAddr, size_t *responseSize, int roffs, uint8_t fruId, uint8_t parm);
+    int ipmiMsgGetPicmgProp(void* device, IpmiSess sess, uint8_t* data, int bridged, uint8_t rsAddr, uint8_t rqAddr,
+                            size_t* responseSize, int roffs);
 
-int ipmiMsgGetFanLevel(void *device, IpmiSess sess, uint8_t *data, int bridged, uint8_t rsAddr, uint8_t rqAddr, size_t *responseSize, int roffs, uint8_t fruId);
+    int ipmiMsgGetPowerLevel(void* device, IpmiSess sess, uint8_t* data, int bridged, uint8_t rsAddr, uint8_t rqAddr,
+                             size_t* responseSize, int roffs, uint8_t fruId, uint8_t parm);
 
-int ipmiMsgSetFanLevel(void *device, IpmiSess sess, uint8_t *data, int bridged, uint8_t rsAddr, uint8_t rqAddr, size_t *responseSize, int roffs, uint8_t fruId, uint8_t level);
+    int ipmiMsgGetFanLevel(void* device, IpmiSess sess, uint8_t* data, int bridged, uint8_t rsAddr, uint8_t rqAddr,
+                           size_t* responseSize, int roffs, uint8_t fruId);
 
-int ipmiMsgSetFruAct(void *device, IpmiSess sess, uint8_t *data, int bridged, uint8_t rsAddr, uint8_t rqAddr, size_t *responseSize, int roffs, uint8_t fruId, int parm);
+    int ipmiMsgSetFanLevel(void* device, IpmiSess sess, uint8_t* data, int bridged, uint8_t rsAddr, uint8_t rqAddr,
+                           size_t* responseSize, int roffs, uint8_t fruId, uint8_t level);
+
+    int ipmiMsgSetFruAct(void* device, IpmiSess sess, uint8_t* data, int bridged, uint8_t rsAddr, uint8_t rqAddr,
+                         size_t* responseSize, int roffs, uint8_t fruId, int parm);
 
 #ifdef __cplusplus
 };

--- a/src/picmgDef.c
+++ b/src/picmgDef.c
@@ -1,10 +1,10 @@
 //////////////////////////////////////////////////////////////////////////////
 // This file is part of 'ipmiComm'.
-// It is subject to the license terms in the LICENSE.txt file found in the 
-// top-level directory of this distribution and at: 
-//    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
-// No part of 'ipmiComm', including this file, 
-// may be copied, modified, propagated, or distributed except according to 
+// It is subject to the license terms in the LICENSE.txt file found in the
+// top-level directory of this distribution and at:
+//    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+// No part of 'ipmiComm', including this file,
+// may be copied, modified, propagated, or distributed except according to
 // the terms contained in the LICENSE.txt file.
 //////////////////////////////////////////////////////////////////////////////
 #include <inttypes.h>
@@ -12,107 +12,106 @@
 #include <picmgDef.h>
 
 /* Get PICMG Properties */
-uint8_t GET_PICMG_PROP_MSG[] = { IPMI_MSG_ADDR_BMC,          /* Requester's address */
-                                 0,                           /* Message sequence number */
-                                 IPMI_MSG_CMD_GET_PICMG_PROP,  /* Command code */
-                                 0,                           /* PICMG Identifier, 0x00 is used */
-                                 0 };                         /* For checksum */
-
+uint8_t GET_PICMG_PROP_MSG[] = {IPMI_MSG_ADDR_BMC,           /* Requester's address */
+                                0,                           /* Message sequence number */
+                                IPMI_MSG_CMD_GET_PICMG_PROP, /* Command code */
+                                0,                           /* PICMG Identifier, 0x00 is used */
+                                0};                          /* For checksum */
 
 /* Set FRU Activation */
-uint8_t SET_FRU_ACT_MSG[] = { IPMI_MSG_ADDR_BMC,           /* Requester's address */            
-                              0,                           /* Message sequence number */         
-                              IPMI_MSG_CMD_SET_FRU_ACT,    /* Command code */         
-			      0,                           /* PICMG Identifier, 0x00 is used */
-                              0,                           /* FRU device ID */	
-                              0,                           /* Command value, 0x00 deactivate, 0x01 activate */         
-                              0 };                         /* For checksum */
+uint8_t SET_FRU_ACT_MSG[] = {IPMI_MSG_ADDR_BMC,        /* Requester's address */
+                             0,                        /* Message sequence number */
+                             IPMI_MSG_CMD_SET_FRU_ACT, /* Command code */
+                             0,                        /* PICMG Identifier, 0x00 is used */
+                             0,                        /* FRU device ID */
+                             0,                        /* Command value, 0x00 deactivate, 0x01 activate */
+                             0};                       /* For checksum */
 
 /* Set FRU Activation Policy */
-uint8_t SET_FRU_POLICY_MSG[] = { IPMI_MSG_ADDR_BMC,           /* Requester's address */            
-                                 0,                           /* Message sequence number */         
-                                 IPMI_MSG_CMD_SET_FRU_POLICY, /* Command code */         
-			         0,                           /* PICMG Identifier, 0x00 is used */
-                                 0,                           /* FRU device ID */	
-                                 0,                           /* FRU activation policy mask bits */
-                                 0,                           /* FRU activation policy set bits */         
-                                 0 };                         /* For checksum */
+uint8_t SET_FRU_POLICY_MSG[] = {IPMI_MSG_ADDR_BMC,           /* Requester's address */
+                                0,                           /* Message sequence number */
+                                IPMI_MSG_CMD_SET_FRU_POLICY, /* Command code */
+                                0,                           /* PICMG Identifier, 0x00 is used */
+                                0,                           /* FRU device ID */
+                                0,                           /* FRU activation policy mask bits */
+                                0,                           /* FRU activation policy set bits */
+                                0};                          /* For checksum */
 
 /* Get FRU Activation Policy */
-uint8_t GET_FRU_POLICY_MSG[] = { IPMI_MSG_ADDR_BMC,           /* Requester's address */            
-                                 0,                           /* Message sequence number */         
-                                 IPMI_MSG_CMD_GET_FRU_POLICY, /* Command code */         
-			         0,                           /* PICMG Identifier, 0x00 is used */
-                                 0,                           /* FRU device ID */	
-                                 0 };                         /* For checksum */
+uint8_t GET_FRU_POLICY_MSG[] = {IPMI_MSG_ADDR_BMC,           /* Requester's address */
+                                0,                           /* Message sequence number */
+                                IPMI_MSG_CMD_GET_FRU_POLICY, /* Command code */
+                                0,                           /* PICMG Identifier, 0x00 is used */
+                                0,                           /* FRU device ID */
+                                0};                          /* For checksum */
 
 /* Get Fan Speed Properties */
-uint8_t GET_FAN_PROP_MSG[] = {   IPMI_MSG_ADDR_BMC,           /* Requester's address */            
-                                 0,                           /* Message sequence number */         
-                                 IPMI_MSG_CMD_GET_FAN_PROP,   /* Command code */         
-			         0,                           /* PICMG Identifier, 0x00 is used */
-                                 0,                           /* FRU ID */	
-                                 0 };                         /* For checksum */
+uint8_t GET_FAN_PROP_MSG[] = {IPMI_MSG_ADDR_BMC,         /* Requester's address */
+                              0,                         /* Message sequence number */
+                              IPMI_MSG_CMD_GET_FAN_PROP, /* Command code */
+                              0,                         /* PICMG Identifier, 0x00 is used */
+                              0,                         /* FRU ID */
+                              0};                        /* For checksum */
 
 /* Get Fan Level */
-uint8_t GET_FAN_LEVEL_MSG[] = {  IPMI_MSG_ADDR_BMC,           /* Requester's address */            
-                                 0,                           /* Message sequence number */         
-                                 IPMI_MSG_CMD_GET_FAN_LEVEL,  /* Command code */         
-			         0,                           /* PICMG Identifier, 0x00 is used */
-                                 0,                           /* FRU ID */	
-                                 0 };                         /* For checksum */
+uint8_t GET_FAN_LEVEL_MSG[] = {IPMI_MSG_ADDR_BMC,          /* Requester's address */
+                               0,                          /* Message sequence number */
+                               IPMI_MSG_CMD_GET_FAN_LEVEL, /* Command code */
+                               0,                          /* PICMG Identifier, 0x00 is used */
+                               0,                          /* FRU ID */
+                               0};                         /* For checksum */
 
 /* Set Fan Level */
-uint8_t SET_FAN_LEVEL_MSG[] = {  IPMI_MSG_ADDR_BMC,           /* Requester's address */            
-                                 0,                           /* Message sequence number */         
-                                 IPMI_MSG_CMD_SET_FAN_LEVEL,  /* Command code */         
-			         0,                           /* PICMG Identifier, 0x00 is used */
-                                 0,                           /* FRU ID */	
-                                 0,                           /* Fan level */	
-                                 0,                           /* OPTIONAL local control enable state, 0 to disable, 1 to enable */	
-                                 0 };                         /* For checksum */
+uint8_t SET_FAN_LEVEL_MSG[] = {IPMI_MSG_ADDR_BMC,          /* Requester's address */
+                               0,                          /* Message sequence number */
+                               IPMI_MSG_CMD_SET_FAN_LEVEL, /* Command code */
+                               0,                          /* PICMG Identifier, 0x00 is used */
+                               0,                          /* FRU ID */
+                               0,                          /* Fan level */
+                               0,  /* OPTIONAL local control enable state, 0 to disable, 1 to enable */
+                               0}; /* For checksum */
 
 /* Set Power Level */
-uint8_t GET_POWER_LEVEL_MSG[] = {  IPMI_MSG_ADDR_BMC,         /* Requester's address */            
-                                 0,                           /* Message sequence number */         
-                                 IPMI_MSG_CMD_GET_POWER_LEVEL,/* Command code */         
-			         0,                           /* PICMG Identifier, 0x00 is used */
-                                 0,                           /* FRU ID */	
-                                 0,                           /* Power type: steady state, desired, early, desired early */	
-                                 0 };                         /* For checksum */
+uint8_t GET_POWER_LEVEL_MSG[] = {IPMI_MSG_ADDR_BMC,            /* Requester's address */
+                                 0,                            /* Message sequence number */
+                                 IPMI_MSG_CMD_GET_POWER_LEVEL, /* Command code */
+                                 0,                            /* PICMG Identifier, 0x00 is used */
+                                 0,                            /* FRU ID */
+                                 0,  /* Power type: steady state, desired, early, desired early */
+                                 0}; /* For checksum */
 
 /* Get address info - implementing all optional fields */
-uint8_t GET_ADDR_INFO_MSG[] = {  IPMI_MSG_ADDR_BMC,           /* Requester's address */            
-                                 0,                           /* Message sequence number */         
-                                 IPMI_MSG_CMD_GET_ADDR_INFO,  /* Command code */         
-			         0,                           /* PICMG Identifier, 0x00 is used */
-                                 0,                           /* FRU ID */	
-                                 0,                           /* Address key type */	
-                                 0,                           /* Address key */	
-                                 0,                           /* Site type */	
-                                 0 };                         /* For checksum */
+uint8_t GET_ADDR_INFO_MSG[] = {IPMI_MSG_ADDR_BMC,          /* Requester's address */
+                               0,                          /* Message sequence number */
+                               IPMI_MSG_CMD_GET_ADDR_INFO, /* Command code */
+                               0,                          /* PICMG Identifier, 0x00 is used */
+                               0,                          /* FRU ID */
+                               0,                          /* Address key type */
+                               0,                          /* Address key */
+                               0,                          /* Site type */
+                               0};                         /* For checksum */
 
 /* Get address info using HW address; does not implement optional last field */
-uint8_t GET_ADDR_INFO_HWADDR_MSG[] = {  IPMI_MSG_ADDR_BMC,           /* Requester's address */            
-                                 0,                           /* Message sequence number */         
-                                 IPMI_MSG_CMD_GET_ADDR_INFO,  /* Command code */         
-			         0,                           /* PICMG Identifier, 0x00 is used */
-                                 0,                           /* FRU ID */	
-                                 0,                           /* Address key type */	
-                                 0,                           /* Address key */	
-                                 0 };                         /* For checksum */
+uint8_t GET_ADDR_INFO_HWADDR_MSG[] = {IPMI_MSG_ADDR_BMC,          /* Requester's address */
+                                      0,                          /* Message sequence number */
+                                      IPMI_MSG_CMD_GET_ADDR_INFO, /* Command code */
+                                      0,                          /* PICMG Identifier, 0x00 is used */
+                                      0,                          /* FRU ID */
+                                      0,                          /* Address key type */
+                                      0,                          /* Address key */
+                                      0};                         /* For checksum */
 
 /* Get address info using HW address; does not implement optional last field */
-uint8_t GET_ADDR_INFO_IPMB0_MSG[] = {  IPMI_MSG_ADDR_BMC,           /* Requester's address */            
-                                 0,                           /* Message sequence number */         
-                                 IPMI_MSG_CMD_GET_ADDR_INFO,  /* Command code */         
-			         0,                           /* PICMG Identifier, 0x00 is used */
-                                 0,                           /* FRU ID */	
-                                 PICMG_ADDR_KEY_TYPE_IPMB0,   /* Address key type */	
-                                 0,                           /* Address key */	
-                                 0 };                         /* For checksum */
+uint8_t GET_ADDR_INFO_IPMB0_MSG[] = {IPMI_MSG_ADDR_BMC,          /* Requester's address */
+                                     0,                          /* Message sequence number */
+                                     IPMI_MSG_CMD_GET_ADDR_INFO, /* Command code */
+                                     0,                          /* PICMG Identifier, 0x00 is used */
+                                     0,                          /* FRU ID */
+                                     PICMG_ADDR_KEY_TYPE_IPMB0,  /* Address key type */
+                                     0,                          /* Address key */
+                                     0};                         /* For checksum */
 
-/* I2C addresses, compiled by NAT 
+/* I2C addresses, compiled by NAT
  * Indexed by FRU ID
  * (last 150-ish addresses are unused,
  *  so left these out of the array)
@@ -120,61 +119,61 @@ uint8_t GET_ADDR_INFO_IPMB0_MSG[] = {  IPMI_MSG_ADDR_BMC,           /* Requester
 
 uint8_t FRU_I2C_ADDR[102] = {
 
-       0,	/* carrier manager */
-       0,	/* physical Shelf FRU Info 1 */
-       0,	/* physical Shelf FRU Info 2 */
-    0x10,	/* MCMC1 */
-    0x12,	/* MCMC2 */
-    0x72,	/* AMC1  */
-    0x74,	/* AMC2  */
-    0x76,	/* AMC3  */
-    0x78,	/* AMC4	 */
-    0x7A,	/* AMC5	 */
-    0x7C,	/* AMC6	 */
-    0x7E,	/* AMC7  */
-    0x80,	/* AMC8	 */
-    0x82,	/* AMC9	 */
-    0x84,	/* AMC10 */
-    0x86,	/* AMC11 */
-    0x88,	/* AMC12 */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,	 /* 17-28 reserved for AMC */
-    0xA2,	/* AMC13 */
-    0xA4,	/* AMC13 */
-    0, 0, 0, 0, 0, 0, 0, 0, 0,           /* 31-39 reserved for AMC */
-    0xA8,	/* CU1   */
-    0xAA,	/* CU2   */
-    0, 0, 0, 0, 0, 0, 0, 0,              /* 42-49 reserved for CU  */
-    0xC2,	/* PM1   */
-    0xC4,	/* PM2   */
-    0xC6,	/* PM3   */
-    0xC8,	/* PM4   */
-    0, 0, 0, 0, 0, 0,                    /* 54-59 reserved for PM  */
-    0x14,	/* ClkMod1 */
-    0x16,	/* HubMod1 */
-    0x14,	/* ClkMod2 */
-    0x16,	/* HubMod2 */
-    0x1C,	/* MCH RTM 1 */
-    0x1E,	/* MCH RTM 2 */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 66-78 reserved for OEM modules */
-    0,          /* Telco Alarm Function */
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,          /* 80-89 implementation defined */
-    0x72,	/* RTM1  */
-    0x74,	/* RTM2  */
-    0x76,	/* RTM3  */
-    0x78,	/* RTM4  */
-    0x7A,	/* RTM5  */
-    0x7C,	/* RTM6  */
-    0x7E,	/* RTM7  */
-    0x80,	/* RTM8  */
-    0x82,	/* RTM9  */
-    0x84,	/* RTM10 */
-    0x86,	/* RTM11 */
-    0x88	/* RTM12 */
-		/* 102-124 reserved for RTM 
-		 * 125-127 reserved
-		 * 128 local ShM (blank)
-		 * 129-252 reserved (blank)
-		 * 253 logical CM (backplane FRU-Info) (blank)
-		 * 254 logical ShM (backplane FRU-Info) (blank)
-		 */
+    0,                                        /* carrier manager */
+    0,                                        /* physical Shelf FRU Info 1 */
+    0,                                        /* physical Shelf FRU Info 2 */
+    0x10,                                     /* MCMC1 */
+    0x12,                                     /* MCMC2 */
+    0x72,                                     /* AMC1  */
+    0x74,                                     /* AMC2  */
+    0x76,                                     /* AMC3  */
+    0x78,                                     /* AMC4	 */
+    0x7A,                                     /* AMC5	 */
+    0x7C,                                     /* AMC6	 */
+    0x7E,                                     /* AMC7  */
+    0x80,                                     /* AMC8	 */
+    0x82,                                     /* AMC9	 */
+    0x84,                                     /* AMC10 */
+    0x86,                                     /* AMC11 */
+    0x88,                                     /* AMC12 */
+    0,    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,    /* 17-28 reserved for AMC */
+    0xA2,                                     /* AMC13 */
+    0xA4,                                     /* AMC13 */
+    0,    0, 0, 0, 0, 0, 0, 0, 0,             /* 31-39 reserved for AMC */
+    0xA8,                                     /* CU1   */
+    0xAA,                                     /* CU2   */
+    0,    0, 0, 0, 0, 0, 0, 0,                /* 42-49 reserved for CU  */
+    0xC2,                                     /* PM1   */
+    0xC4,                                     /* PM2   */
+    0xC6,                                     /* PM3   */
+    0xC8,                                     /* PM4   */
+    0,    0, 0, 0, 0, 0,                      /* 54-59 reserved for PM  */
+    0x14,                                     /* ClkMod1 */
+    0x16,                                     /* HubMod1 */
+    0x14,                                     /* ClkMod2 */
+    0x16,                                     /* HubMod2 */
+    0x1C,                                     /* MCH RTM 1 */
+    0x1E,                                     /* MCH RTM 2 */
+    0,    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 66-78 reserved for OEM modules */
+    0,                                        /* Telco Alarm Function */
+    0,    0, 0, 0, 0, 0, 0, 0, 0, 0,          /* 80-89 implementation defined */
+    0x72,                                     /* RTM1  */
+    0x74,                                     /* RTM2  */
+    0x76,                                     /* RTM3  */
+    0x78,                                     /* RTM4  */
+    0x7A,                                     /* RTM5  */
+    0x7C,                                     /* RTM6  */
+    0x7E,                                     /* RTM7  */
+    0x80,                                     /* RTM8  */
+    0x82,                                     /* RTM9  */
+    0x84,                                     /* RTM10 */
+    0x86,                                     /* RTM11 */
+    0x88                                      /* RTM12 */
+                                              /* 102-124 reserved for RTM
+                                               * 125-127 reserved
+                                               * 128 local ShM (blank)
+                                               * 129-252 reserved (blank)
+                                               * 253 logical CM (backplane FRU-Info) (blank)
+                                               * 254 logical ShM (backplane FRU-Info) (blank)
+                                               */
 };

--- a/src/picmgDef.h
+++ b/src/picmgDef.h
@@ -1,10 +1,10 @@
 //////////////////////////////////////////////////////////////////////////////
 // This file is part of 'ipmiComm'.
-// It is subject to the license terms in the LICENSE.txt file found in the 
-// top-level directory of this distribution and at: 
-//    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
-// No part of 'ipmiComm', including this file, 
-// may be copied, modified, propagated, or distributed except according to 
+// It is subject to the license terms in the LICENSE.txt file found in the
+// top-level directory of this distribution and at:
+//    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+// No part of 'ipmiComm', including this file,
+// may be copied, modified, propagated, or distributed except according to
 // the terms contained in the LICENSE.txt file.
 //////////////////////////////////////////////////////////////////////////////
 #ifndef DRV_PICMG_H
@@ -30,209 +30,214 @@ extern uint8_t FRU_I2C_ADDR[102];
  */
 
 /* PICMG */
-#define PICMG_RPLY_IMSG2_GET_POWER_LEVEL_PROP_OFFSET   2    /* FRU power properties */
-#define PICMG_RPLY_IMSG2_GET_POWER_LEVEL_DELAY_OFFSET  3    /* Delay to stable power */
-#define PICMG_RPLY_IMSG2_GET_POWER_LEVEL_MULT_OFFSET   4    /* Power multiplier */
-#define PICMG_RPLY_IMSG2_GET_POWER_LEVEL_DRAW_OFFSET   5    /* Draw of first level (optional: next levels follow this, up to 25 total) */
-#define IPMI_RPLY_IMSG2_GET_FAN_PROP_MIN_OFFSET    2     /* Fan tray minimum fan level */
-#define IPMI_RPLY_IMSG2_GET_FAN_PROP_MAX_OFFSET    3     /* Fan tray maximum fan level */
-#define IPMI_RPLY_IMSG2_GET_FAN_PROP_NOM_OFFSET    4     /* Fan tray nominal fan level */
-#define IPMI_RPLY_IMSG2_GET_FAN_PROP_PROP_OFFSET   5     /* Fan tray properties */
+#define PICMG_RPLY_IMSG2_GET_POWER_LEVEL_PROP_OFFSET  2 /* FRU power properties */
+#define PICMG_RPLY_IMSG2_GET_POWER_LEVEL_DELAY_OFFSET 3 /* Delay to stable power */
+#define PICMG_RPLY_IMSG2_GET_POWER_LEVEL_MULT_OFFSET  4 /* Power multiplier */
+#define PICMG_RPLY_IMSG2_GET_POWER_LEVEL_DRAW_OFFSET  5 /* Draw of first level */
+                                                        /* (optional: next levels follow this, up to 25 total) */
+
+#define IPMI_RPLY_IMSG2_GET_FAN_PROP_MIN_OFFSET  2 /* Fan tray minimum fan level */
+#define IPMI_RPLY_IMSG2_GET_FAN_PROP_MAX_OFFSET  3 /* Fan tray maximum fan level */
+#define IPMI_RPLY_IMSG2_GET_FAN_PROP_NOM_OFFSET  4 /* Fan tray nominal fan level */
+#define IPMI_RPLY_IMSG2_GET_FAN_PROP_PROP_OFFSET 5 /* Fan tray properties */
 
 /* PICMG */
 /* consider changing these names to include picmg  ? */
-#define IPMI_MSG2_SET_FRU_ACT_DEACTIVATE      0    /* Command value in Set FRU Activate command */
-#define IPMI_MSG2_SET_FRU_ACT_ACTIVATE        1
-#define IPMI_MSG2_SET_FRU_ACT_FRU_OFFSET      4    /* FRU ID, used in many commands */
-#define IPMI_MSG2_SET_FRU_ACT_CMD_OFFSET      5
-#define IPMI_MSG2_SET_FRU_POLICY_MASK_OFFSET  5
-#define IPMI_MSG2_SET_FRU_POLICY_BITS_OFFSET  6
-#define IPMI_MSG2_SET_FAN_LEVEL_OFFSET        5    /* New fan level to set */
-#define PICMG_RPLY_IMSG2_GET_POWER_LEVEL_TYPE_OFFSET    5
-#define PICMG_RPLY_IMSG2_GET_FAN_OVERRIDE_LEVEL_OFFSET  2    /* Fan level set by shelf manager */
-#define PICMG_RPLY_IMSG2_GET_FAN_LOCAL_LEVEL_OFFSET     3    /* Fan level set locally */
-#define PICMG_RPLY_IMSG2_GET_FAN_LOCAL_ENABLED_OFFSET   4    /* 1 if fan is in local control, else 0 */
-#define PICMG_RPLY_IMSG2_PICMG_ID_OFFSET                1    /* Indicates PICMG-defined group extension; value of 0x00 is used */
-#define PICMG_RPLY_IMSG2_GET_PICMG_PROP_PICMG_VERS_OFFSET 2  /* Version of PICMG extensions implemented by IPM controller */
-#define PICMG_RPLY_IMSG2_GET_PICMG_PROP_MAX_FRU_ID_OFFSET 3  /* Maximum FRU device ID on system (excluding reserved 254, 255) */
+#define IPMI_MSG2_SET_FRU_ACT_DEACTIVATE               0 /* Command value in Set FRU Activate command */
+#define IPMI_MSG2_SET_FRU_ACT_ACTIVATE                 1
+#define IPMI_MSG2_SET_FRU_ACT_FRU_OFFSET               4 /* FRU ID, used in many commands */
+#define IPMI_MSG2_SET_FRU_ACT_CMD_OFFSET               5
+#define IPMI_MSG2_SET_FRU_POLICY_MASK_OFFSET           5
+#define IPMI_MSG2_SET_FRU_POLICY_BITS_OFFSET           6
+#define IPMI_MSG2_SET_FAN_LEVEL_OFFSET                 5 /* New fan level to set */
+#define PICMG_RPLY_IMSG2_GET_POWER_LEVEL_TYPE_OFFSET   5
+#define PICMG_RPLY_IMSG2_GET_FAN_OVERRIDE_LEVEL_OFFSET 2 /* Fan level set by shelf manager */
+#define PICMG_RPLY_IMSG2_GET_FAN_LOCAL_LEVEL_OFFSET    3 /* Fan level set locally */
+#define PICMG_RPLY_IMSG2_GET_FAN_LOCAL_ENABLED_OFFSET  4 /* 1 if fan is in local control, else 0 */
+#define PICMG_RPLY_IMSG2_PICMG_ID_OFFSET 1 /* Indicates PICMG-defined group extension; value of 0x00 is used */
+#define PICMG_RPLY_IMSG2_GET_PICMG_PROP_PICMG_VERS_OFFSET                                                              \
+    2 /* Version of PICMG extensions implemented by IPM controller */
+#define PICMG_RPLY_IMSG2_GET_PICMG_PROP_MAX_FRU_ID_OFFSET                                                              \
+    3 /* Maximum FRU device ID on system (excluding reserved 254, 255) */
 #define PICMG_RPLY_IMSG2_GET_PICMG_PROP_IPMC_FRU_ID_OFFSET 4 /* FRU ID of IPM comtroller */
 
 /* Get address info command */
-#define PICMG_IMSG2_GET_ADDR_INFO_FRUID_OFFSET      4
-#define PICMG_IMSG2_GET_ADDR_INFO_KEY_TYPE_OFFSET   5
-#define PICMG_IMSG2_GET_ADDR_INFO_KEY_OFFSET        6
-#define PICMG_IMSG2_GET_ADDR_INFO_SITE_TYPE_OFFSET  7
-#define PICMG_RPLY_IMSG2_GET_ADDR_INFO_HWADDR_OFFSET      2  /* Hardware address */
-#define PICMG_RPLY_IMSG2_GET_ADDR_INFO_IPMB0_ADDR_OFFSET  3  /* IPMB-0 address if implemented; for PICMG 2.9 value of 0xFF indicates IPMB-0 not implemented */
-#define PICMG_RPLY_IMSG2_GET_ADDR_INFO_FRU_ID_OFFSET      5  /* FRU device ID or 0xFF if Address Key Type = Physical Address and Site Type = RTM */
-#define PICMG_RPLY_IMSG2_GET_ADDR_INFO_SITE_NUMBER_OFFSET 6  /* Site number */
-#define PICMG_RPLY_IMSG2_GET_ADDR_INFO_SITE_TYPE_OFFSET   7  /* Site type */
-#define PICMG_ADDR_KEY_TYPE_HWADDR   0x00
-#define PICMG_ADDR_KEY_TYPE_IPMB0    0x01
-#define PICMG_ADDR_KEY_TYPE_PICMG29  0x02 /* Reserved for PICMG 2.9 */
-#define PICMG_ADDR_KEY_TYPE_PHYSADDR 0x03
+#define PICMG_IMSG2_GET_ADDR_INFO_FRUID_OFFSET       4
+#define PICMG_IMSG2_GET_ADDR_INFO_KEY_TYPE_OFFSET    5
+#define PICMG_IMSG2_GET_ADDR_INFO_KEY_OFFSET         6
+#define PICMG_IMSG2_GET_ADDR_INFO_SITE_TYPE_OFFSET   7
+#define PICMG_RPLY_IMSG2_GET_ADDR_INFO_HWADDR_OFFSET 2 /* Hardware address */
+#define PICMG_RPLY_IMSG2_GET_ADDR_INFO_IPMB0_ADDR_OFFSET                                                               \
+    3 /* IPMB-0 address if implemented; for PICMG 2.9 value of 0xFF indicates IPMB-0 not implemented */
+#define PICMG_RPLY_IMSG2_GET_ADDR_INFO_FRU_ID_OFFSET                                                                   \
+    5 /* FRU device ID or 0xFF if Address Key Type = Physical Address and Site Type = RTM */
+#define PICMG_RPLY_IMSG2_GET_ADDR_INFO_SITE_NUMBER_OFFSET 6 /* Site number */
+#define PICMG_RPLY_IMSG2_GET_ADDR_INFO_SITE_TYPE_OFFSET   7 /* Site type */
+#define PICMG_ADDR_KEY_TYPE_HWADDR                        0x00
+#define PICMG_ADDR_KEY_TYPE_IPMB0                         0x01
+#define PICMG_ADDR_KEY_TYPE_PICMG29                       0x02 /* Reserved for PICMG 2.9 */
+#define PICMG_ADDR_KEY_TYPE_PHYSADDR                      0x03
 
-#define IPMI_MSG_CMD_GET_PICMG_PROP          0x00
-#define IPMI_MSG_CMD_GET_ADDR_INFO           0x01
-#define IPMI_MSG_CMD_GET_POWER_LEVEL         0x12
-#define IPMI_MSG_CMD_GET_FAN_PROP            0x14
-#define IPMI_MSG_CMD_GET_FAN_LEVEL           0x16
-#define IPMI_MSG_CMD_SET_FAN_LEVEL           0x15
+#define IPMI_MSG_CMD_GET_PICMG_PROP  0x00
+#define IPMI_MSG_CMD_GET_ADDR_INFO   0x01
+#define IPMI_MSG_CMD_GET_POWER_LEVEL 0x12
+#define IPMI_MSG_CMD_GET_FAN_PROP    0x14
+#define IPMI_MSG_CMD_GET_FAN_LEVEL   0x16
+#define IPMI_MSG_CMD_SET_FAN_LEVEL   0x15
 
-#define IPMI_RPLY_GET_FRU_POLICY_LENGTH   3
-#define IPMI_RPLY_GET_FAN_PROP_LENGTH     6
-#define IPMI_RPLY_GET_FAN_LEVEL_LENGTH    5  /* max length due to optional bytes */
-#define IPMI_RPLY_GET_POWER_LEVEL_LENGTH  6  /* min length--currently only read lowest power level values, which is all SLAC ATCA systems provide */
-#define IPMI_RPLY_SET_FAN_LEVEL_LENGTH    3  /* ignore optional byte for now */
+#define IPMI_RPLY_GET_FRU_POLICY_LENGTH 3
+#define IPMI_RPLY_GET_FAN_PROP_LENGTH   6
+#define IPMI_RPLY_GET_FAN_LEVEL_LENGTH  5 /* max length due to optional bytes */
+#define IPMI_RPLY_GET_POWER_LEVEL_LENGTH                                                                               \
+    6 /* min length--currently only read lowest power level values, which is all SLAC ATCA systems provide */
+#define IPMI_RPLY_SET_FAN_LEVEL_LENGTH        3 /* ignore optional byte for now */
 #define IPMI_RPLY_IMSG2_GET_PICMG_PROP_LENGTH 4
-#define PICMG_RPLY_GET_ADDR_INFO_LENGTH   8 
-#define PICMG_RPLY_SET_FRU_ACT_LENGTH     2
+#define PICMG_RPLY_GET_ADDR_INFO_LENGTH       8
+#define PICMG_RPLY_SET_FRU_ACT_LENGTH         2
 
 /* need to update this */
-#define IPMI_RPLY_GET_FRU_POLICY_PROP_OFFSET    44    /* FRU activation policy properties */
+#define IPMI_RPLY_GET_FRU_POLICY_PROP_OFFSET 44 /* FRU activation policy properties */
 
-#define PICMG_FAN_LOCAL_CONTROL_SUPPORTED(x) (x&0x80)
+#define PICMG_FAN_LOCAL_CONTROL_SUPPORTED(x) (x & 0x80)
 
 /* PICMG */
-#define FRU_PWR_DYNAMIC(x) x & (1 << 7)
-#define FRU_PWR_LEVEL(x)   x & 0xF
+#define FRU_PWR_DYNAMIC(x)       x & (1 << 7)
+#define FRU_PWR_LEVEL(x)         x & 0xF
 #define FRU_PWR_STEADY_STATE     0
 #define FRU_PWR_STEADY_STATE_DES 1
 #define FRU_PWR_EARLY            2
 #define FRU_PWR_EARLY_DES        3
-#define FRU_PWR_MSG_CMPTBL(x) ((x>=3 && x<=16) || (x>=40 && x<=41) || (x>=50 && x<=53)) /* See Vadatech CLI Manual (5.7.9) */
+#define FRU_PWR_MSG_CMPTBL(x)                                                                                          \
+    ((x >= 3 && x <= 16) || (x >= 40 && x <= 41) || (x >= 50 && x <= 53)) /* See Vadatech CLI Manual (5.7.9) */
 
 /* Site type values */
-#define PICMG_SITE_TYPE_FRONT_BOARD          0x00
-#define PICMG_SITE_TYPE_POWER_ENTRY          0x01
-#define PICMG_SITE_TYPE_SHELF_FRU_INFO       0x02
-#define PICMG_SITE_TYPE_SHMC                 0x03
-#define PICMG_SITE_TYPE_FAN_TRAY             0x04
-#define PICMG_SITE_TYPE_FAN_FILTER_TRAY      0x05
-#define PICMG_SITE_TYPE_ALARM                0x06
-#define PICMG_SITE_TYPE_AMC                  0x07
-#define PICMG_SITE_TYPE_PMC                  0x08
-#define PICMG_SITE_TYPE_RTM                  0x09
-#define PICMG_SITE_TYPE_OEM_MIN              0xC0
-#define PICMG_SITE_TYPE_OEM_MAX              0xCF
+#define PICMG_SITE_TYPE_FRONT_BOARD     0x00
+#define PICMG_SITE_TYPE_POWER_ENTRY     0x01
+#define PICMG_SITE_TYPE_SHELF_FRU_INFO  0x02
+#define PICMG_SITE_TYPE_SHMC            0x03
+#define PICMG_SITE_TYPE_FAN_TRAY        0x04
+#define PICMG_SITE_TYPE_FAN_FILTER_TRAY 0x05
+#define PICMG_SITE_TYPE_ALARM           0x06
+#define PICMG_SITE_TYPE_AMC             0x07
+#define PICMG_SITE_TYPE_PMC             0x08
+#define PICMG_SITE_TYPE_RTM             0x09
+#define PICMG_SITE_TYPE_OEM_MIN         0xC0
+#define PICMG_SITE_TYPE_OEM_MAX         0xCF
 /* Reserved site type ranges: 0x0A-0xBF and 0xD0-0xFE
  * Unknown site type 0xFF
  */
 
 /* MicroTCA */
-#define UTCA_FRU_TYPE_CARRIER                0
-#define UTCA_FRU_TYPE_SHELF_MIN              1
-#define UTCA_FRU_TYPE_SHELF_MAX              2
-#define UTCA_FRU_TYPE_MCH_MIN                3
-#define UTCA_FRU_TYPE_MCH_MAX                4
-#define UTCA_FRU_TYPE_AMC_MIN                5
-#define UTCA_FRU_TYPE_AMC_MAX                39
-#define UTCA_FRU_TYPE_CU_MIN                 40
-#define UTCA_FRU_TYPE_CU_MAX                 49
-#define UTCA_FRU_TYPE_PM_MIN                 50
-#define UTCA_FRU_TYPE_PM_MAX                 59
-#define UTCA_FRU_TYPE_RTM_MIN                90
-#define UTCA_FRU_TYPE_RTM_MAX                124
-#define UTCA_FRU_TYPE_LOG_CARRIER            253
+#define UTCA_FRU_TYPE_CARRIER     0
+#define UTCA_FRU_TYPE_SHELF_MIN   1
+#define UTCA_FRU_TYPE_SHELF_MAX   2
+#define UTCA_FRU_TYPE_MCH_MIN     3
+#define UTCA_FRU_TYPE_MCH_MAX     4
+#define UTCA_FRU_TYPE_AMC_MIN     5
+#define UTCA_FRU_TYPE_AMC_MAX     39
+#define UTCA_FRU_TYPE_CU_MIN      40
+#define UTCA_FRU_TYPE_CU_MAX      49
+#define UTCA_FRU_TYPE_PM_MIN      50
+#define UTCA_FRU_TYPE_PM_MAX      59
+#define UTCA_FRU_TYPE_RTM_MIN     90
+#define UTCA_FRU_TYPE_RTM_MAX     124
+#define UTCA_FRU_TYPE_LOG_CARRIER 253
 
-#define PICMG_FRU_TYPE_SHMC_MAX               254
-#define PICMG_FRU_TYPE_SHMC_MIN               252
+#define PICMG_FRU_TYPE_SHMC_MAX 254
+#define PICMG_FRU_TYPE_SHMC_MIN 252
 
 /* FRU index values for ATCA systems;
  * Values arbitrarily chosen by system software (us)
- * in order to have uniform FRU indices assigned to 
+ * in order to have uniform FRU indices assigned to
  * hardware across systems. For example, slot 1 AMC will
- * use the same index across all systems. This is done to 
+ * use the same index across all systems. This is done to
  * be able to configure PVs & EDM screens in advance.
  */
-#define ATCA_FRU_TYPE_CARRIER                0
-#define ATCA_FRU_TYPE_SHELF_MIN              1
-#define ATCA_FRU_TYPE_SHELF_MAX              2
-#define ATCA_FRU_TYPE_MCH_MIN                3
-#define ATCA_FRU_TYPE_MCH_MAX                4
-#define ATCA_FRU_TYPE_AMC_MIN                5
-#define ATCA_FRU_TYPE_AMC_MAX                39
-#define ATCA_FRU_TYPE_CU_MIN                 40
-#define ATCA_FRU_TYPE_CU_MAX                 49
-#define ATCA_FRU_TYPE_PM_MIN                 50
-#define ATCA_FRU_TYPE_PM_MAX                 59
-#define ATCA_FRU_TYPE_RTM_MIN                90
-#define ATCA_FRU_TYPE_RTM_MAX                124
-#define ATCA_FRU_TYPE_LOG_CARRIER            253
+#define ATCA_FRU_TYPE_CARRIER     0
+#define ATCA_FRU_TYPE_SHELF_MIN   1
+#define ATCA_FRU_TYPE_SHELF_MAX   2
+#define ATCA_FRU_TYPE_MCH_MIN     3
+#define ATCA_FRU_TYPE_MCH_MAX     4
+#define ATCA_FRU_TYPE_AMC_MIN     5
+#define ATCA_FRU_TYPE_AMC_MAX     39
+#define ATCA_FRU_TYPE_CU_MIN      40
+#define ATCA_FRU_TYPE_CU_MAX      49
+#define ATCA_FRU_TYPE_PM_MIN      50
+#define ATCA_FRU_TYPE_PM_MAX      59
+#define ATCA_FRU_TYPE_RTM_MIN     90
+#define ATCA_FRU_TYPE_RTM_MAX     124
+#define ATCA_FRU_TYPE_LOG_CARRIER 253
 
-/* Response message lengths using Vadatech MCH (0s for those that can vary) */ 
-#define IPMI_RPLY_CLOSE_SESSION_LENGTH_VT           22
-#define IPMI_RPLY_SENSOR_READ_MAX_LENGTH_VT         48 /* length varies */
-#define IPMI_RPLY_GET_SENSOR_THRESH_LENGTH_VT       51 /* need to determine this; using NAT length for now*/
-#define IPMI_RPLY_GET_CHAS_STATUS_LENGTH_VT         47 /* does NOT include optional byte */
-#define IPMI_RPLY_CHAS_CTRL_LENGTH_VT               44
-#define IPMI_RPLY_GET_FRU_INFO_LENGTH_VT            47
-#define IPMI_RPLY_READ_FRU_DATA_BASE_LENGTH_VT      45
-#define IPMI_RPLY_WRITE_FRU_DATA_LENGTH_VT          45
-#define IPMI_RPLY_GET_SDRREP_INFO_LENGTH_VT         58
-#define IPMI_RPLY_RESERVE_SDRREP_LENGTH_VT          46
-#define IPMI_RPLY_GET_SDR_BASE_LENGTH_VT            50 /* get sdr message length is this + remaining data bytes */
-#define IPMI_RPLY_GET_SDR_LENGTH_VT                 0  /* varies */
-#define IPMI_RPLY_GET_DEV_SDR_INFO_LENGTH_VT        50
-#define IPMI_RPLY_GET_DEV_SDR_LENGTH_VT             0  /* varies */
-#define IPMI_RPLY_COLD_RESET_LENGTH_VT              44
-#define IPMI_RPLY_SET_FRU_POLICY_LENGTH_VT          44
-#define IPMI_RPLY_GET_FRU_POLICY_LENGTH_VT          45
-#define IPMI_RPLY_SET_FRU_ACT_LENGTH_VT             45
-#define IPMI_RPLY_GET_DEVICE_ID_LENGTH_VT           59 /* includes optional bytes */
-#define IPMI_RPLY_GET_FAN_PROP_LENGTH_VT            49
-#define IPMI_RPLY_GET_FAN_LEVEL_LENGTH_VT           48
-#define IPMI_RPLY_SET_FAN_LEVEL_LENGTH_VT           45
+/* Response message lengths using Vadatech MCH (0s for those that can vary) */
+#define IPMI_RPLY_CLOSE_SESSION_LENGTH_VT      22
+#define IPMI_RPLY_SENSOR_READ_MAX_LENGTH_VT    48 /* length varies */
+#define IPMI_RPLY_GET_SENSOR_THRESH_LENGTH_VT  51 /* need to determine this; using NAT length for now*/
+#define IPMI_RPLY_GET_CHAS_STATUS_LENGTH_VT    47 /* does NOT include optional byte */
+#define IPMI_RPLY_CHAS_CTRL_LENGTH_VT          44
+#define IPMI_RPLY_GET_FRU_INFO_LENGTH_VT       47
+#define IPMI_RPLY_READ_FRU_DATA_BASE_LENGTH_VT 45
+#define IPMI_RPLY_WRITE_FRU_DATA_LENGTH_VT     45
+#define IPMI_RPLY_GET_SDRREP_INFO_LENGTH_VT    58
+#define IPMI_RPLY_RESERVE_SDRREP_LENGTH_VT     46
+#define IPMI_RPLY_GET_SDR_BASE_LENGTH_VT       50 /* get sdr message length is this + remaining data bytes */
+#define IPMI_RPLY_GET_SDR_LENGTH_VT            0  /* varies */
+#define IPMI_RPLY_GET_DEV_SDR_INFO_LENGTH_VT   50
+#define IPMI_RPLY_GET_DEV_SDR_LENGTH_VT        0 /* varies */
+#define IPMI_RPLY_COLD_RESET_LENGTH_VT         44
+#define IPMI_RPLY_SET_FRU_POLICY_LENGTH_VT     44
+#define IPMI_RPLY_GET_FRU_POLICY_LENGTH_VT     45
+#define IPMI_RPLY_SET_FRU_ACT_LENGTH_VT        45
+#define IPMI_RPLY_GET_DEVICE_ID_LENGTH_VT      59 /* includes optional bytes */
+#define IPMI_RPLY_GET_FAN_PROP_LENGTH_VT       49
+#define IPMI_RPLY_GET_FAN_LEVEL_LENGTH_VT      48
+#define IPMI_RPLY_SET_FAN_LEVEL_LENGTH_VT      45
 
 /* Response message lengths using NAT MCH (0s for those we haven't figured out yet) */
-#define IPMI_RPLY_CLOSE_SESSION_LENGTH_NAT           22 /* UPDATE THIS */
-#define IPMI_RPLY_SENSOR_READ_MAX_LENGTH_NAT         34 /* length varies */
-#define IPMI_RPLY_GET_SENSOR_THRESH_LENGTH_NAT       51
-#define IPMI_RPLY_GET_CHAS_STATUS_LENGTH_NAT         47 /* does NOT include optional byte */
-#define IPMI_RPLY_CHAS_CTRL_LENGTH_NAT               44
-#define IPMI_RPLY_GET_FRU_INFO_LENGTH_NAT            32
-#define IPMI_RPLY_READ_FRU_DATA_BASE_LENGTH_NAT      30
-#define IPMI_RPLY_WRITE_FRU_DATA_LENGTH_NAT          45
-#define IPMI_RPLY_GET_SDRREP_INFO_LENGTH_NAT         43
-#define IPMI_RPLY_RESERVE_SDRREP_LENGTH_NAT          31
-#define IPMI_RPLY_GET_SDR_BASE_LENGTH_NAT            35 /* get sdr message length is this + remaining data bytes */
-#define IPMI_RPLY_GET_SDR_LENGTH_NAT                 0  /* varies */
-#define IPMI_RPLY_GET_DEV_SDR_INFO_LENGTH_NAT        50
-#define IPMI_RPLY_GET_DEV_SDR_LENGTH_NAT             0  /* varies */
-#define IPMI_RPLY_COLD_RESET_LENGTH_NAT              44
-#define IPMI_RPLY_SET_FRU_POLICY_LENGTH_NAT          29
-#define IPMI_RPLY_GET_FRU_POLICY_LENGTH_NAT          39
-#define IPMI_RPLY_SET_FRU_ACT_LENGTH_NAT             45
-#define IPMI_RPLY_GET_DEVICE_ID_LENGTH_NAT           44 /* includes optional bytes */
-#define IPMI_RPLY_GET_FAN_PROP_LENGTH_NAT            43
-#define IPMI_RPLY_GET_FAN_LEVEL_LENGTH_NAT           42
-#define IPMI_RPLY_SET_FAN_LEVEL_LENGTH_NAT           41
-#define IPMI_RPLY_OFFSET_NAT              -15
-#define IPMI_RPLY_2ND_BRIDGED_OFFSET_NAT   14
+#define IPMI_RPLY_CLOSE_SESSION_LENGTH_NAT      22 /* UPDATE THIS */
+#define IPMI_RPLY_SENSOR_READ_MAX_LENGTH_NAT    34 /* length varies */
+#define IPMI_RPLY_GET_SENSOR_THRESH_LENGTH_NAT  51
+#define IPMI_RPLY_GET_CHAS_STATUS_LENGTH_NAT    47 /* does NOT include optional byte */
+#define IPMI_RPLY_CHAS_CTRL_LENGTH_NAT          44
+#define IPMI_RPLY_GET_FRU_INFO_LENGTH_NAT       32
+#define IPMI_RPLY_READ_FRU_DATA_BASE_LENGTH_NAT 30
+#define IPMI_RPLY_WRITE_FRU_DATA_LENGTH_NAT     45
+#define IPMI_RPLY_GET_SDRREP_INFO_LENGTH_NAT    43
+#define IPMI_RPLY_RESERVE_SDRREP_LENGTH_NAT     31
+#define IPMI_RPLY_GET_SDR_BASE_LENGTH_NAT       35 /* get sdr message length is this + remaining data bytes */
+#define IPMI_RPLY_GET_SDR_LENGTH_NAT            0  /* varies */
+#define IPMI_RPLY_GET_DEV_SDR_INFO_LENGTH_NAT   50
+#define IPMI_RPLY_GET_DEV_SDR_LENGTH_NAT        0 /* varies */
+#define IPMI_RPLY_COLD_RESET_LENGTH_NAT         44
+#define IPMI_RPLY_SET_FRU_POLICY_LENGTH_NAT     29
+#define IPMI_RPLY_GET_FRU_POLICY_LENGTH_NAT     39
+#define IPMI_RPLY_SET_FRU_ACT_LENGTH_NAT        45
+#define IPMI_RPLY_GET_DEVICE_ID_LENGTH_NAT      44 /* includes optional bytes */
+#define IPMI_RPLY_GET_FAN_PROP_LENGTH_NAT       43
+#define IPMI_RPLY_GET_FAN_LEVEL_LENGTH_NAT      42
+#define IPMI_RPLY_SET_FAN_LEVEL_LENGTH_NAT      41
+#define IPMI_RPLY_OFFSET_NAT                    -15
+#define IPMI_RPLY_2ND_BRIDGED_OFFSET_NAT        14
 
 /* PICMG-specific Entity IDs */
 #define ENTITY_ID_PICMG_FRONT_BOARD    0xA0
 #define ENTITY_ID_PICMG_RTM            0xC0
-#define ENTITY_ID_PICMG_AMC            0xC1 
+#define ENTITY_ID_PICMG_AMC            0xC1
 #define ENTITY_ID_PICMG_SHMC           0xF0
 #define ENTITY_ID_PICMG_FILT_UNIT      0xF1
 #define ENTITY_ID_PICMG_SHELF_FRU_INFO 0xF2
 #define ENTITY_ID_PICMG_ALARM_PANEL    0xF3
 #define PICMG_ENTITY_ID_POWER_FILT     0x15
 
-
-
 /*
 #define PICMG_ENTITY_ID_FRONT_BOARD          0xA0
 #define PICMG_ENTITY_ID_RTM                  0xC0
 #define PICMG_ENTITY_ID_AMC                  0xC1
-#define PICMG_ENTITY_ID_SHM                  0xF0 Shelf management controller 
+#define PICMG_ENTITY_ID_SHM                  0xF0 Shelf management controller
 #define PICMG_ENTITY_ID_FILTRATION_UNIT      0xF1
 #define PICMG_ENTITY_ID_SHELF_FRU_INFO       0xF2
 #define PICMG_ENTITY_ID_ALARM_PANEL          0xF3
 #define PICMG_ENTITY_ID_POWER_FILTERING      0x15
 */
-
 
 /* PICMG hardware addresses */
 #define PICMG_HWADDR_SHMC       0x10 /* Active shelf manager */
@@ -275,13 +280,14 @@ extern uint8_t FRU_I2C_ADDR[102];
 #define PICMG_IPMB_LOG_SLOT16 0xA0 /* Logical slot 16 */
 
 /* PICMG sensor type codes */
-#define SENSOR_TYPE_HOTSWAP        0xF0  /* Contains M-state */
-#define SENSOR_TYPE_HOTSWAP_NAT    0xF2
-#define SENSOR_TYPE_IPMB0          0xF1  /* IPMB-0 Physical Link */
-#define SENSOR_TYPE_TELCO          0xF4  /* Telco Alarm Input */
+#define SENSOR_TYPE_HOTSWAP     0xF0 /* Contains M-state */
+#define SENSOR_TYPE_HOTSWAP_NAT 0xF2
+#define SENSOR_TYPE_IPMB0       0xF1 /* IPMB-0 Physical Link */
+#define SENSOR_TYPE_TELCO       0xF4 /* Telco Alarm Input */
 
 #ifdef __cplusplus
-};
+}
+;
 #endif
 
 #endif

--- a/src/subIpmiComm.c
+++ b/src/subIpmiComm.c
@@ -1,10 +1,10 @@
 //////////////////////////////////////////////////////////////////////////////
 // This file is part of 'ipmiComm'.
-// It is subject to the license terms in the LICENSE.txt file found in the 
-// top-level directory of this distribution and at: 
-//    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
-// No part of 'ipmiComm', including this file, 
-// may be copied, modified, propagated, or distributed except according to 
+// It is subject to the license terms in the LICENSE.txt file found in the
+// top-level directory of this distribution and at:
+//    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+// No part of 'ipmiComm', including this file,
+// may be copied, modified, propagated, or distributed except according to
 // the terms contained in the LICENSE.txt file.
 //////////////////////////////////////////////////////////////////////////////
 #include <stdio.h>
@@ -23,10 +23,10 @@
 
 #include <drvMch.h>
 
-/* 
+/*
  *
- *  Inputs    
- *                                                          
+ *  Inputs
+ *
  *	a   Raw 'type' value as defined in drvMchDef.h
  *
  * b-h are the converted 'type' values used by other facility software
@@ -38,7 +38,7 @@
  *      f   'Type' value for Pentair shelf manager
  *      g   'Type' value for Artesyn shelf manager
  *      h   'Type' value for Advantech server
- *      
+ *
  *  Outputs
  *
  *      a   0 if FAULT, 1 if OK
@@ -48,46 +48,52 @@
  *      MPS requirements can be found...
  */
 
-long
-subMchTypeFacility(struct aSubRecord *psub)
-{
-epicsFloat64   unknown    = *(epicsFloat64 *)psub->b;    
-epicsFloat64   vt         = *(epicsFloat64 *)psub->c;    
-epicsFloat64   nat        = *(epicsFloat64 *)psub->d;    
-epicsFloat64   supermicro = *(epicsFloat64 *)psub->e;    
-epicsFloat64   pentair    = *(epicsFloat64 *)psub->f;    
-epicsFloat64   artesyn    = *(epicsFloat64 *)psub->g;    
-epicsFloat64   advantech  = *(epicsFloat64 *)psub->h;    
+long subMchTypeFacility(struct aSubRecord* psub) {
+    epicsFloat64 unknown    = *(epicsFloat64*)psub->b;
+    epicsFloat64 vt         = *(epicsFloat64*)psub->c;
+    epicsFloat64 nat        = *(epicsFloat64*)psub->d;
+    epicsFloat64 supermicro = *(epicsFloat64*)psub->e;
+    epicsFloat64 pentair    = *(epicsFloat64*)psub->f;
+    epicsFloat64 artesyn    = *(epicsFloat64*)psub->g;
+    epicsFloat64 advantech  = *(epicsFloat64*)psub->h;
 
-epicsFloat64   raw;
+    epicsFloat64 raw;
 
-	if( psub == NULL)
-		return 0;
+    if (psub == NULL) {
+        return 0;
+    }
 
-	raw = *(epicsFloat64 *)psub->a;
+    raw = *(epicsFloat64*)psub->a;
 
-	if ( raw == MCH_TYPE_VT )
-		*((epicsFloat64 *)psub->vala) = vt;
+    if (raw == MCH_TYPE_VT) {
+        *((epicsFloat64*)psub->vala) = vt;
+    }
 
-	else if ( raw == MCH_TYPE_NAT )
-		*((epicsFloat64 *)psub->vala) = nat;
+    else if (raw == MCH_TYPE_NAT) {
+        *((epicsFloat64*)psub->vala) = nat;
+    }
 
-	else if ( raw == MCH_TYPE_SUPERMICRO )
-		*((epicsFloat64 *)psub->vala) = supermicro;
+    else if (raw == MCH_TYPE_SUPERMICRO) {
+        *((epicsFloat64*)psub->vala) = supermicro;
+    }
 
-	else if ( raw == MCH_TYPE_PENTAIR )
-		*((epicsFloat64 *)psub->vala) = pentair;
+    else if (raw == MCH_TYPE_PENTAIR) {
+        *((epicsFloat64*)psub->vala) = pentair;
+    }
 
-	else if ( raw == MCH_TYPE_ARTESYN )
-		*((epicsFloat64 *)psub->vala) = artesyn;
+    else if (raw == MCH_TYPE_ARTESYN) {
+        *((epicsFloat64*)psub->vala) = artesyn;
+    }
 
-	else if ( raw == MCH_TYPE_ADVANTECH )
-		*((epicsFloat64 *)psub->vala) = advantech;
+    else if (raw == MCH_TYPE_ADVANTECH) {
+        *((epicsFloat64*)psub->vala) = advantech;
+    }
 
-	else if ( raw == MCH_TYPE_UNKNOWN )
-		*((epicsFloat64 *)psub->vala) = unknown;
+    else if (raw == MCH_TYPE_UNKNOWN) {
+        *((epicsFloat64*)psub->vala) = unknown;
+    }
 
-	return 0;
+    return 0;
 }
 
 epicsRegisterFunction(subMchTypeFacility);


### PR DESCRIPTION
In the current code style, there are some misleading indentation, which makes the code a little hard to understand, so I fixed some of this mistakes. 
Changed the function headers to have the return type in the same line as the function name, and add a tab before the local variable declarations . Change the indentation style to use four spaces, and change the space usages in function calls, if-else statements, switch cases, and other specific situations.
I guess some of this code styles was a project choice, so it can be removed from this commit if you think it should be the way that it is! 
