### PR TITLE
Small fixes

### DIFF
--- a/Db/Makefile
+++ b/Db/Makefile
@@ -43,12 +43,12 @@ DB += shelf_atca_7slot.db
 DB += server_pc.db
 
 # Templates specific to LCLS
+DB += system_common_lcls.db
 DB += shelf_microtca_12slot_lcls.db
 DB += server_pc_lcls.db
 DB += fru_atca_fb_lcls.db
 DB += fru_atca_rtm_lcls.db
 DB += shelf_atca_7slot_lcls.db
-DB += system_common_lcls.db
 
 #----------------------------------------------------
 # Create and install (or just install) into <top>/db

--- a/iocs/ipmicomm-test-IOC/iocBoot/iocipmicomm-test-IOC/st.cmd
+++ b/iocs/ipmicomm-test-IOC/iocBoot/iocipmicomm-test-IOC/st.cmd
@@ -1,4 +1,4 @@
-#!../../bin/rhel6-x86_64/ipmicomm-test-IOC
+#!../../bin/rhel7-x86_64/ipmicomm-test-IOC
 #==============================================================
 #
 #  Abs:  Startup script for Network IOC


### PR DESCRIPTION
system_common_lcls.db must come first in the LCLS block in Makefile.

Changed default binary architecture for test IOC to rhel7.