### PR TITLE
Handles `IPMI_COMP_CODE_DESTINATION_UNAVAIL` completion code.

### DIFF
--- a/src/drvMch.c
+++ b/src/drvMch.c
@@ -1343,7 +1343,7 @@ size_t  tmp = sens->readMsgLength; /* Initially set to requested msg length,
 
 	/* If error code ... */
 	if ( rval ) {
-		if ( rval == IPMI_COMP_CODE_REQUESTED_DATA )	
+		if ( rval == IPMI_COMP_CODE_REQUESTED_DATA || rval == IPMI_COMP_CODE_DESTINATION_UNAVAIL )
 			sens->unavail = 1;
 		return -1;
 	}


### PR DESCRIPTION
This message is sent by MCH when the destination is not available. So, in order to handle this, the sens->unavail flag must be set to 1.