### PR TITLE
Fix exp2, exp10, cube and cube_neg1 sensor conversions

### DIFF
--- a/src/devMch.c
+++ b/src/devMch.c
@@ -399,11 +399,11 @@ epicsFloat64 value;
 	else if ( l == SENSOR_CONV_SQR )
 		value = pow( value, 2);
 	else if ( l == SENSOR_CONV_CUBE )
-		value = pow( value, 1/3 );
+		value = pow( value, 3.0 );
 	else if ( l == SENSOR_CONV_SQRT )
 		value = sqrt( value );
 	else if ( l == SENSOR_CONV_CUBE_NEG1 )
-		value = pow( value, -1/3 );
+		value = cbrt( value );
 	else
 		printf("sensorConversion %s: unknown sensor conversion algorithm\n", name);
 

--- a/src/devMch.c
+++ b/src/devMch.c
@@ -391,9 +391,9 @@ epicsFloat64 value;
 	else if ( l == SENSOR_CONV_E )
 		value = exp( value );
 	else if ( l == SENSOR_CONV_EXP10 )
-		value = pow( value, 10 );
+		value = exp10( value );
 	else if ( l == SENSOR_CONV_EXP2 )
-		value = pow( value, 2 );
+		value = exp2( value );
 	else if ( l == SENSOR_CONV_1_X )
 		value = 1/value;
 	else if ( l == SENSOR_CONV_SQR )


### PR DESCRIPTION

Fixed exp2 and exp10 conversions. The `value` and constant parameters were swapped.

`SENSOR_CONV_CUBE` should be cube, not cube root. 



`SENSOR_CONV_CUBE_NEG1` should be cube root. The IPMI spec is not very clear on this, but it defines this conversion as $cube^{-1}(x)$ 

I've also substituted the `pow` for `cbrt` here because it is faster than `pow(x, 1.0/3.0)` (not that it matters :))


This fixes the issues seen with the Vadatech ATC807 switches and their `vOut` readout.